### PR TITLE
Bump default chdb latest release version to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chdb",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "chDB bindings for nodejs",
   "main": "index.js",
   "repository": {

--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")"
 
 # Get the newest release version
 # LATEST_RELEASE=$(curl --silent "https://api.github.com/repos/chdb-io/chdb/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-LATEST_RELEASE=v1.1.0
+LATEST_RELEASE=v1.4.1
 
 # Download the correct version based on the platform
 case "$(uname -s)" in


### PR DESCRIPTION
When installing `chdb-node` the default `chdb` version the `update_libchdb.sh` script installs is 1.1.0.

This PR bumps that default version to the current latest release of `chdb`: 1.4.1.

You could comment/un-comment the `LATEST_RELEASE` variable in the script but I believe most people want to be in control of the `chdb` version they use.

Also I bumped the `chdb-node` version to 1.1.4 as I don't think there are any breaking changes between `chdb` 1.1.0 and 1.4.1 but happy to change it to 1.2.0 if you think it's more appropriate.