### PR TITLE
bump libchdb LATEST_RELEASE to v3.7.2

### DIFF
--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")"
 
 # Get the newest release version
 # LATEST_RELEASE=$(curl --silent "https://api.github.com/repos/chdb-io/chdb/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-LATEST_RELEASE=v3.6.0
+LATEST_RELEASE=v3.7.2
 
 # Download the correct version based on the platform
 case "$(uname -s)" in


### PR DESCRIPTION
3.7.2 contains fixes for a stdin bug which causes our test suite to freeze, it'd be great to get this in.

Please let me know if anything else needs changing.

Thanks for maintaining chdb-node!