### PR TITLE
Publish to npm on tag push and derive version from tag

### DIFF
--- a/.github/workflows/chdb-node-test.yml
+++ b/.github/workflows/chdb-node-test.yml
@@ -9,6 +9,8 @@ on:
     branches: [ "main" ]
     paths-ignore:
       - '**/.md'
+    tags:
+      - 'v*'
 
 
 jobs:
@@ -33,8 +35,19 @@ jobs:
       run: npm install
     - name: Run tests
       run: npm run test
+    - name: Set version from tag
+      if: startsWith(github.ref, 'refs/tags/v') && matrix.node-version == '18.x' && matrix.os == 'ubuntu-latest'
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        echo "Publishing version: $VERSION"
+        npm pkg set version="$VERSION"
+        if [[ "$VERSION" == *-* ]]; then
+          echo "NPM_DIST_TAG=next" >> "$GITHUB_ENV"
+        else
+          echo "NPM_DIST_TAG=latest" >> "$GITHUB_ENV"
+        fi
     - name: Publish to npm
-      if: github.ref == 'refs/heads/main' && matrix.node-version == '18.x' && matrix.os == 'ubuntu-latest'
-      run: npm publish
+      if: startsWith(github.ref, 'refs/tags/v') && matrix.node-version == '18.x' && matrix.os == 'ubuntu-latest'
+      run: npm publish --tag "$NPM_DIST_TAG"
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace the manual main-branch publish flow with **tag-driven releases**. Pushing a tag like `v2.0.0` now triggers the workflow and publishes to npm; merges to `main` no longer publish.
- **Version is derived from the tag** at runtime via `npm pkg set version=...`, so `package.json` no longer needs a manual bump before each release.
- **Prerelease tags** (containing a hyphen, e.g. `v2.0.0-beta.1`) are published under the `next` dist-tag, leaving `latest` pointing at the current stable.

## Why

Today the workflow publishes on every push to `main`, which:

- Requires a manual `package.json` version bump in a separate commit before the release commit, easy to forget or get wrong.
- Couples publishing to merging, making rollbacks awkward.
- Cannot distinguish a prerelease from a stable release, so any beta would clobber the `latest` dist-tag for all `npm install chdb` users.

Driving releases from semver tags is the standard npm/Node ecosystem flow and resolves all three.

## How to release after this PR

```bash
# stable release
git tag v2.0.0
git push origin v2.0.0

# prerelease (auto-published under dist-tag "next")
git tag v2.0.0-beta.1
git push origin v2.0.0-beta.1
```

Or use GitHub's **Releases → Draft a new release** UI with the same tag name.

## Test plan

- [ ] Open a PR or push to `main` → CI runs build/tests on the matrix, **no publish step executes** (verify in Actions logs).
- [ ] Push a tag `v0.0.0-test.1` to a fork or scratch tag → workflow runs, the `Set version from tag` step prints `Publishing version: 0.0.0-test.1`, and the `Publish to npm` step uses `--tag next`. (Drop the tag without actually publishing if testing pre-merge.)
- [ ] After merge, do a real release tag (e.g. `v2.0.0`) once the `NPM_TOKEN` secret is verified valid.

## Notes / follow-ups

- This change does **not** address the recent npm `404` publish failure on the `2.0.0` push to `main`; that appears to be the `NPM_TOKEN` secret being expired or no longer scoped to the `chdb` package, and needs to be rotated separately on npmjs.com → GitHub repo secrets.
- `package.json`'s `version` field will drift from the published version after this change. That is expected and harmless; the git tag is the source of truth. If you prefer to keep them in sync, use `npm version <x.y.z>` locally (which commits + tags in one shot) before pushing.

Made with [Cursor](https://cursor.com)