### PR TITLE
Shrink published tarball and modernize CI

### DIFF
--- a/.github/workflows/chdb-node-test.yml
+++ b/.github/workflows/chdb-node-test.yml
@@ -22,12 +22,12 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
     steps:
     - name: Use Python 3.11
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         registry-url: 'https://registry.npmjs.org'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 libchdb.so
 chdb.h
 chdb.hpp
+
+*-tmp/

--- a/package.json
+++ b/package.json
@@ -22,6 +22,16 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "binding.gyp",
+    "lib/chdb_node.cpp",
+    "lib/chdb_node.h",
+    "update_libchdb.sh",
+    "fix_loader_path.sh",
+    "example.js"
+  ],
   "devDependencies": {
     "chai": "^4.5.0",
     "mocha": "^10.7.3",


### PR DESCRIPTION
## Summary

The recently published \`chdb@2.0.0\` tarball includes 41 files, of which **30 are noise**:

- \`chdb-node-tmp/\` and \`test-connection-tmp/\` — ClickHouse MergeTree data directories created by \`example.js\` and \`test_connection.js\` when run locally before publishing
- \`test_basic.js\`, \`test_connection.js\` — test scripts
- \`.github/workflows/\` — CI config

These end up in every user's \`node_modules/chdb/\` after \`npm install chdb\`, polluting IDE search indexes (binary \`data.bin\`, \`primary.cidx\`, etc.) and tripping some security scanners.

This PR fixes the published shape and cleans up two adjacent issues.

## Changes

### 1. \`files\` whitelist in \`package.json\`

Replace the \"publish everything not in .npmignore\" default with an explicit allowlist of what's actually needed to install and run the package:

\`\`\`json
\"files\": [
  \"index.js\",
  \"index.d.ts\",
  \"binding.gyp\",
  \"lib/chdb_node.cpp\",
  \"lib/chdb_node.h\",
  \"update_libchdb.sh\",
  \"fix_loader_path.sh\",
  \"example.js\"
]
\`\`\`

\`README.md\`, \`LICENSE\`, and \`package.json\` are always included by npm regardless. \`build/\` and \`libchdb.so\` are install-time artifacts produced by the package's own \`install\` script.

**Effect**:

|                        | before | after |
| ---------------------- | -----: | ----: |
| files in tarball       |     41 |    11 |
| compressed             | 14.9 KB | 10.2 KB |
| unpacked               | 47.6 KB | 32.7 KB |

### 2. \`*-tmp/\` added to \`.gitignore\`

These directories appear in \`git status\` after every local test run. Ignoring them avoids accidental commits and keeps the working tree clean.

### 3. Bump deprecated GitHub Actions

CI has been printing a deprecation warning on every run:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: \`actions/checkout@v3\`, \`actions/setup-node@v3\`, \`actions/setup-python@v2\`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

Bumped to current majors:

- \`actions/checkout\` v3 → v4
- \`actions/setup-node\` v3 → v4
- \`actions/setup-python\` v2 → v5

## Local verification

Done end-to-end against this branch before opening the PR:

1. **Tarball inspection** — \`npm pack --dry-run\` shows exactly 11 files, no \`*-tmp/\`, no test scripts, no \`.github/\`.
2. **Fresh install** — \`npm install /tmp/chdb-local.tgz\` in a brand-new project. Native binding compiled in 18 s on macOS.
3. **API smoke test** — both APIs exercised:
   - Standalone: \`query(\"SELECT version(), 'hello chdb', 1+1\")\` → \`\"26.3.9.1\",\"hello chdb\",2\`
   - Session: CREATE DATABASE → CREATE TABLE → INSERT 3 rows → \`SELECT count(), sum(id)\` → \`3,6\`, \`SELECT *\` returns all rows correctly
   - Error path: \`SELECT * FROM nonexistent_table\` throws \`Code: 60. UNKNOWN_TABLE\` as expected
4. **Installed layout check** — \`node_modules/chdb/\` contains only the whitelisted files plus install-time artifacts (\`build/\`, \`libchdb.so\`, \`chdb.h\`, \`chdb.hpp\`); zero \`*-tmp/\` directories.

## Rollout

The fix lands as a normal patch release. Once merged:

\`\`\`bash
git tag v2.0.1
git push origin v2.0.1
\`\`\`

The tag-driven workflow from #37 will publish a clean \`2.0.1\` automatically. The polluted \`2.0.0\` stays on the registry (per npm's [unpublish policy](https://docs.npmjs.com/policies/unpublish)) but \`latest\` will move to \`2.0.1\`, so new \`npm install chdb\` users get the clean version.