### PR TITLE
fix: resolve Deno task interception by avoiding nested npm run

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "url": "https://github.com/chdb-io/chdb-node.git"
   },
   "scripts": {
-    "install": "npm run libchdb && npm run build",
+    "install": "bash ./update_libchdb.sh && node-gyp configure build --verbose && bash ./fix_loader_path.sh",
     "test": "mocha test_basic.js test_connection.js --timeout 15000",
     "libchdb": "bash ./update_libchdb.sh",
     "fixloaderpath": "bash ./fix_loader_path.sh",
-    "build": "node-gyp configure build --verbose && npm run fixloaderpath"
+    "build": "node-gyp configure build --verbose && bash ./fix_loader_path.sh"
   },
   "author": {
     "name": "chdb",


### PR DESCRIPTION
### Description

This PR implements the changes proposed in #41 to avoid nested `npm run` calls inside package lifecycles. 

By executing `bash` and `node-gyp` directly, we bypass Deno's task interception, making `chdb-node` fully compatible with Deno's native `allowScripts` / `deno compile` out-of-the-box.

### Verification
- Fully backward-compatible with Node.js and npm.
- Eliminates `task libchdb not found` / `task build not found` errors when installing via Deno.

Closes #41