### PR TITLE
release: chdb 3.0.0 on chdb-core v26.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chdb",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "chDB bindings for nodejs",
   "main": "index.js",
   "types": "index.d.ts",
@@ -58,10 +58,10 @@
     "node-gyp-build": "^4.6.0"
   },
   "optionalDependencies": {
-    "@chdb/lib-linux-x64-gnu": ">=26.5.0",
-    "@chdb/lib-linux-arm64-gnu": ">=26.5.0",
-    "@chdb/lib-darwin-x64": ">=26.5.0",
-    "@chdb/lib-darwin-arm64": ">=26.5.0"
+    "@chdb/lib-linux-x64-gnu": "26.5.0",
+    "@chdb/lib-linux-arm64-gnu": "26.5.0",
+    "@chdb/lib-darwin-x64": "26.5.0",
+    "@chdb/lib-darwin-arm64": "26.5.0"
   },
   "peerDependencies": {
     "apache-arrow": ">=14"


### PR DESCRIPTION
## What

Cuts the **stable `chdb@3.0.0`** release on the **chdb-core v26.5.0** engine line. Single-file change to `package.json`:

- `version` 2.0.0 → **3.0.0**
- `optionalDependencies` for the four `@chdb/lib-*` native subpackages: `>=26.5.0` → **exact `26.5.0`**.

`update_libchdb.sh` already points at `v26.5.0` on `main`; no change needed.

## Why pin the subpackages exactly

The `>=26.5.0` range would let a `chdb@3.0.0` install float onto a newer engine subpackage (e.g. a future `26.5.1`) — a stable release should resolve a fixed, tested engine. Exact `26.5.0` guarantees reproducible installs.

## Test

`npm run test:v3` green against v26.5.0: **118 passed**. (The legacy mocha `test`/`test:all` runs on CI's Node 22.x; it trips a yargs/ESM error only on very new local Node, unrelated to this change.)

## Release (separate, gated step)

Publishing happens on a pushed `v3.0.0` tag (→ npm dist-tag `latest`), not on merge. To be done after this merges.