### PR TITLE
ci(publish): macos-15-intel for darwin-x64 + idempotent publish

### DIFF
--- a/.github/workflows/prebuild-publish.yml
+++ b/.github/workflows/prebuild-publish.yml
@@ -45,9 +45,16 @@ jobs:
           echo "CHDB_LIB_VERSION=${REL#v}" >> "$GITHUB_ENV"
       - name: Build subpackage
         run: npm run build:platform
-      - name: Publish subpackage
-        run: npm publish --access public
+      - name: Publish subpackage (skip if this version already exists)
         working-directory: npm/@chdb/lib-${{ matrix.plat }}
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VER=$(node -p "require('./package.json').version")
+          if npm view "$NAME@$VER" version >/dev/null 2>&1; then
+            echo "$NAME@$VER already published; skipping (lets a re-run finish a partially-published release)."
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -70,7 +77,13 @@ jobs:
           else
             echo "NPM_DIST_TAG=latest" >> "$GITHUB_ENV"
           fi
-      - name: Publish main (prepack builds dist)
-        run: npm publish --provenance --access public --tag "$NPM_DIST_TAG"
+      - name: Publish main (prepack builds dist; skip if this version already exists)
+        run: |
+          VER=$(node -p "require('./package.json').version")
+          if npm view "chdb@$VER" version >/dev/null 2>&1; then
+            echo "chdb@$VER already published; skipping."
+          else
+            npm publish --provenance --access public --tag "$NPM_DIST_TAG"
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/prebuild-publish.yml
+++ b/.github/workflows/prebuild-publish.yml
@@ -22,7 +22,7 @@ jobs:
           - { os: ubuntu-latest, plat: linux-x64-gnu }
           - { os: ubuntu-24.04-arm, plat: linux-arm64-gnu }
           - { os: macos-14, plat: darwin-arm64 }
-          - { os: macos-13, plat: darwin-x64 }
+          - { os: macos-15-intel, plat: darwin-x64 }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Fixes two issues that surfaced while publishing v3.0.0 (the darwin-x64 subpackage job stalled queuing on a macos-13 runner, leaving the release partially published).

1. **darwin-x64 builds on `macos-15-intel`** (was `macos-13`). The test workflow already moved to `macos-15-intel`; the publish workflow was never aligned. `macos-13` queues for a long time and is near retirement — that stall is exactly what stranded the v3.0.0 publish with 3 of 4 subpackages out.

2. **Publish steps are now idempotent** — each subpackage and the main package check the registry first and publish only if that exact version is missing. A partially-published release can now be completed by re-running, instead of failing with npm 403 (version exists) on the subpackages that already went out.

Context: `@chdb/lib-{linux-x64,linux-arm64,darwin-arm64}@26.5.0` are already on npm from the stalled v3.0.0 run; `@chdb/lib-darwin-x64@26.5.0` and `chdb@3.0.0` are not. After this merges, re-pointing the `v3.0.0` tag at the fixed commit re-runs the publish: the three existing subpackages skip, darwin-x64 builds on macos-15-intel and publishes, and the main job publishes `chdb@3.0.0`.