### PR TITLE
fix(pkg): no-op install script so npm doesn't inject node-gyp rebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "bench": "node bench/bench.js",
     "build": "node-gyp configure build --verbose && npm run fixloaderpath && npm run build:ts",
     "build:ts": "tsc -p tsconfig.build.json",
-    "prepack": "npm run build:ts"
+    "prepack": "npm run build:ts",
+    "install": "node -e \"\""
   },
   "author": {
     "name": "chdb",
@@ -58,10 +59,10 @@
     "node-gyp-build": "^4.6.0"
   },
   "optionalDependencies": {
-    "@chdb/lib-linux-x64-gnu": "26.5.1-rc.1",
-    "@chdb/lib-linux-arm64-gnu": "26.5.1-rc.1",
+    "@chdb/lib-darwin-arm64": "26.5.1-rc.1",
     "@chdb/lib-darwin-x64": "26.5.1-rc.1",
-    "@chdb/lib-darwin-arm64": "26.5.1-rc.1"
+    "@chdb/lib-linux-arm64-gnu": "26.5.1-rc.1",
+    "@chdb/lib-linux-x64-gnu": "26.5.1-rc.1"
   },
   "peerDependencies": {
     "apache-arrow": ">=14"


### PR DESCRIPTION
`npm install chdb` fails for **both published versions (3.0.0 and 3.1.0-rc.1)**:

```
node-gyp rebuild  →  no binding.gyp / no C++ sources in the tarball  →  install aborts
```

## Cause

The native addon ships as prebuilt per-platform subpackages (`@chdb/lib-<platform>`, pulled via `optionalDependencies`, resolved at runtime by `dist/loader.js`) — nothing is built on the user's machine. But the repo keeps a `binding.gyp` for dev builds, and **npm auto-injects `"install": "node-gyp rebuild"` into a published package when it sees a `binding.gyp` and no explicit install script** (the string is never in our source — `git log -S` finds it nowhere). The `files` whitelist ships no `binding.gyp` or sources, so that injected rebuild has nothing to build and the install fails.

## Fix

Add an explicit no-op `install` (`node -e ""`) so npm stops injecting the default. Users get the addon from the subpackage; dev still builds via `npm run build`.

Verified with `npm pack`: the tarball's `install` is now the no-op and `binding.gyp` is absent.

## Follow-ups (not in this PR)
- The already-published 3.0.0 / 3.1.0-rc.1 are immutable; they need patch republishes (**3.0.1** / **3.1.0-rc.2**) carrying this fix to become installable.
- The publish CI never installs the published package from the registry — adding a clean-room "`npm install` the packed tarball" check would have caught this.