### PR TITLE
fix(pkg): make Linux prebuilt addon relocatable + guard against build-machine-only binaries (#50)

### DIFF
--- a/.github/workflows/chdb-node-test.yml
+++ b/.github/workflows/chdb-node-test.yml
@@ -82,10 +82,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-      - run: sudo apt-get update && sudo apt-get install -y patchelf
+      - run: sudo apt-get update && sudo apt-get install -y patchelf binutils
       - run: npm install --ignore-scripts && npm run libchdb && npm run build
       - name: Pack main + platform subpackage
         run: |
+          # Stamp the subpackage with the SAME version main pins in
+          # optionalDependencies (derived from update_libchdb.sh, as the publish
+          # workflow does). Without this the local build is 0.0.0-dev, which does
+          # NOT satisfy main's pin, so `npm install` silently pulls the PUBLISHED
+          # subpackage from the registry — the cleanroom then tests the released
+          # binary instead of the one just built, which is how a non-relocatable
+          # binary (chdb-io/chdb-node#50) shipped past a green cleanroom.
+          REL=$(grep -E '^LATEST_RELEASE=' update_libchdb.sh | cut -d= -f2)
+          export CHDB_LIB_VERSION="${REL#v}"
           npm run build:platform
           MAIN_TGZ="$PWD/$(npm pack --silent)"
           SUB_DIR="$PWD/npm/@chdb/lib-linux-x64-gnu"
@@ -97,5 +106,18 @@ jobs:
           mkdir -p /tmp/cleanroom && cd /tmp/cleanroom
           npm init -y >/dev/null
           npm install --no-save "$SUB_TGZ" "$MAIN_TGZ"
+          # The exact binary that will be dlopen'd must be relocatable. Assert it
+          # directly on the INSTALLED file — this also fails loudly (instead of a
+          # cryptic dlopen error) if npm resolved the subpackage from the registry
+          # rather than the local tgz.
+          INSTALLED_NODE="node_modules/@chdb/lib-linux-x64-gnu/chdb_node.node"
+          bash "$GITHUB_WORKSPACE/scripts/assert-relocatable.sh" "$INSTALLED_NODE"
           cp "$GITHUB_WORKSPACE/scripts/smoke-e2e.mjs" ./smoke-e2e.mjs
+          # Relocation-faithful e2e: delete the build-machine libchdb.so so a
+          # baked absolute/build-dir library reference (chdb-io/chdb-node#50)
+          # can no longer be satisfied from the build tree. The installed package
+          # must resolve libchdb.so from the subpackage via $ORIGIN alone —
+          # exactly what a real user's machine offers. Without this the test
+          # passes on the build runner even when the binary is unshippable.
+          rm -f "$GITHUB_WORKSPACE/libchdb.so"
           node smoke-e2e.mjs

--- a/.github/workflows/prebuild-publish.yml
+++ b/.github/workflows/prebuild-publish.yml
@@ -32,9 +32,9 @@ jobs:
         with:
           node-version: 22.x
           registry-url: "https://registry.npmjs.org"
-      - name: Install patchelf (linux rpath)
+      - name: Install patchelf + binutils (linux rpath fixup + relocatability assert)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y patchelf
+        run: sudo apt-get update && sudo apt-get install -y patchelf binutils
       - run: npm install --ignore-scripts
       - run: npm run libchdb
       - run: npm run build

--- a/scripts/assert-relocatable.sh
+++ b/scripts/assert-relocatable.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Assert a packaged native addon carries NO build-machine-absolute library
+# reference — the environment-independent guard against "works on the build
+# machine" packaging bugs.
+#
+# The failure it catches (chdb-io/chdb-node#50): a prebuilt chdb_node.node
+# whose libchdb.so dependency is baked as the CI checkout path
+# (/home/runner/work/chdb-node/chdb-node/libchdb.so) loads fine on the build
+# runner — where that path still exists — but nowhere else, so every Linux
+# user hits "cannot open shared object file". A `patchelf --set-rpath '$ORIGIN'`
+# does NOT fix an absolute DT_NEEDED: the loader opens an absolute NEEDED
+# verbatim, ignoring RUNPATH. This check fails the build when that (or any
+# other absolute dylib reference) is present, regardless of whether the build
+# machine happens to satisfy the stale path.
+#
+# Usage: assert-relocatable.sh <path-to-chdb_node.node>
+set -euo pipefail
+
+NODE_FILE="${1:?usage: assert-relocatable.sh <chdb_node.node>}"
+[ -f "$NODE_FILE" ] || { echo "assert-relocatable: no such file: $NODE_FILE" >&2; exit 1; }
+
+fail() { echo "assert-relocatable: FAIL — $1" >&2; exit 1; }
+
+case "$(uname -s)" in
+  Linux)
+    command -v readelf >/dev/null || fail "readelf not found (install binutils)"
+    dyn=$(readelf -d "$NODE_FILE")
+    needed=$(printf '%s\n' "$dyn" | sed -nE 's/.*\(NEEDED\).*\[(.*)\]/\1/p')
+    # Every NEEDED must be a bare soname (no slash); a slash means an absolute
+    # or relative path was baked in at link time and won't relocate.
+    if printf '%s\n' "$needed" | grep -q '/'; then
+      fail $'path-bearing NEEDED entry (must be a bare soname resolved via RUNPATH):\n'"$needed"
+    fi
+    # libchdb.so must be referenced by its bare name so $ORIGIN finds the
+    # sibling copy shipped in the subpackage.
+    if ! printf '%s\n' "$needed" | grep -qx 'libchdb.so'; then
+      fail $'expected a bare "libchdb.so" NEEDED entry; got:\n'"$needed"
+    fi
+    # RUNPATH (or legacy RPATH) must point at $ORIGIN — the addon's own dir.
+    if ! printf '%s\n' "$dyn" | grep -E '\((RUNPATH|RPATH)\)' | grep -q '\$ORIGIN'; then
+      rp=$(printf '%s\n' "$dyn" | grep -E '\((RUNPATH|RPATH)\)' || echo '(none)')
+      fail $'RUNPATH/RPATH must contain $ORIGIN; got:\n'"$rp"
+    fi
+    ;;
+  Darwin)
+    command -v otool >/dev/null || fail "otool not found"
+    # Collect every LC_LOAD_DYLIB target. None may be an absolute filesystem
+    # path except the OS libraries under /usr/lib or /System; everything else
+    # must be @loader_path/@rpath/@executable_path-relative.
+    loads=$(otool -l "$NODE_FILE" | awk '/LC_LOAD_DYLIB/{f=1;next} f&&/^[[:space:]]*name /{print $2;f=0}')
+    while IFS= read -r p; do
+      [ -z "$p" ] && continue
+      case "$p" in
+        @*|/usr/lib/*|/System/*) ;;                       # relocatable or OS lib — ok
+        *) fail "non-relocatable dylib reference: $p" ;;
+      esac
+    done <<< "$loads"
+    if ! printf '%s\n' "$loads" | grep -q '@loader_path/libchdb.so'; then
+      fail $'expected "@loader_path/libchdb.so" load command; got:\n'"$loads"
+    fi
+    ;;
+  *)
+    fail "unsupported OS $(uname -s)"
+    ;;
+esac
+
+echo "assert-relocatable: OK — $(basename "$NODE_FILE") has no build-machine-absolute library refs"

--- a/scripts/build-platform-pkg.sh
+++ b/scripts/build-platform-pkg.sh
@@ -32,9 +32,26 @@ cp libchdb.so "$PKG/"
 if [[ "$OS" == "darwin" ]]; then
   install_name_tool -change @loader_path/../../libchdb.so @loader_path/libchdb.so "$PKG/chdb_node.node"
 else
-  # $ORIGIN so the addon resolves libchdb.so from its own dir at runtime.
+  # node-gyp links the addon against the absolute build path
+  # (<module_root_dir>/libchdb.so) and libchdb.so carries no DT_SONAME, so ld
+  # bakes that absolute path as the DT_NEEDED. `--set-rpath '$ORIGIN'` alone
+  # does NOT fix it: the dynamic loader opens an absolute NEEDED verbatim and
+  # ignores RUNPATH, so the addon only loads on a machine that happens to have
+  # the build path (chdb-io/chdb-node#50). Rewrite the path-bearing NEEDED back
+  # to a bare soname FIRST, then point RUNPATH at the addon's own dir so it
+  # resolves the sibling libchdb.so shipped in the subpackage.
+  abs_needed=$(patchelf --print-needed "$PKG/chdb_node.node" | grep -E '/libchdb\.so$' || true)
+  if [ -n "$abs_needed" ]; then
+    patchelf --replace-needed "$abs_needed" libchdb.so "$PKG/chdb_node.node"
+  fi
   patchelf --set-rpath '$ORIGIN' "$PKG/chdb_node.node"
 fi
+
+# Guard against shipping a binary that only loads on the build machine: assert
+# the packaged addon has no build-absolute library references. Environment-
+# independent (it inspects the binary, not its runtime), so it catches the bug
+# even on the build runner where a stale absolute path still resolves.
+bash scripts/assert-relocatable.sh "$PKG/chdb_node.node"
 
 echo "module.exports = require('./chdb_node.node');" > "$PKG/index.js"
 


### PR DESCRIPTION
## Summary

The published Linux native subpackages (`@chdb/lib-linux-x64-gnu`, `@chdb/lib-linux-arm64-gnu`) shipped a `chdb_node.node` that **only loaded on the build runner**. On any other machine it failed with:

```
ChdbBinaryVersionMismatchError: failed to load native binding from @chdb/lib-linux-x64-gnu:
/home/runner/work/chdb-node/chdb-node/libchdb.so: cannot open shared object file: No such file or directory
```

Closes #50.

## Root cause

`binding.gyp` links the addon against the **absolute** build path (`<module_root_dir>/libchdb.so`), and `libchdb.so` carries no `DT_SONAME`, so `ld` bakes that absolute path (`/home/runner/work/chdb-node/chdb-node/libchdb.so` — the publish runner's checkout) as the `DT_NEEDED`. The existing `patchelf --set-rpath '$ORIGIN'` **does not fix an absolute `NEEDED`**: the dynamic loader opens an absolute `NEEDED` verbatim and ignores `RUNPATH`. So the binary resolves only on a machine that happens to have that exact path — i.e. the build runner.

- **Introduced by** `47d2399` (Phase-5 per-platform subpackage builder). The latent absolute link in `binding.gyp` predates it (`b76b911`, 2024) but was harmless until prebuilt binaries were distributed to other machines.
- **macOS unaffected** — its branch rewrites the load command to `@loader_path/libchdb.so` (verified locally: `otool -l` shows only `@loader_path` / OS-lib refs).
- **Both Linux arches affected** — `linux-x64-gnu` and `linux-arm64-gnu` share the identical `else` branch; only x64 was reported.

## Why CI was green while users broke

The `cleanroom` job **builds and runs the e2e on the same runner**, where `/home/runner/work/chdb-node/chdb-node/libchdb.so` still exists — so `dlopen` of the stale absolute `NEEDED` accidentally succeeds. It never tested true relocation to a machine without that path.

## Fix

`scripts/build-platform-pkg.sh` (Linux branch): rewrite the path-bearing `NEEDED` back to a bare `libchdb.so` with `patchelf --replace-needed` **before** `--set-rpath '$ORIGIN'`, so the addon resolves the sibling `libchdb.so` shipped in the subpackage.

## Defense (so this class of bug can't recur)

1. **`scripts/assert-relocatable.sh`** — environment-independent binary check, wired into `build:platform` so it runs on every subpackage build (both `cleanroom` and publish):
   - Linux (`readelf -d`): no path-bearing `NEEDED`, a bare `libchdb.so` entry, and `RUNPATH` contains `$ORIGIN`.
   - macOS (`otool -l`): no absolute non-system dylib refs; `@loader_path/libchdb.so` present.
   It inspects the binary, not its runtime, so it fails **even on the build runner** where a stale path still resolves.
2. **Relocation-faithful `cleanroom`** — deletes the build-machine `libchdb.so` before loading the installed package, forcing resolution via `$ORIGIN` alone (what a real user's machine offers).
3. Install `binutils` alongside `patchelf` where `build:platform` runs.

## Verification

- Locally on macOS arm64: `npm run build:platform` now runs the assertion inline → `assert-relocatable: OK`. Negative cases (absolute path / wrong-relative load command) correctly fail the assertion. macOS package confirmed fully `@loader_path`-relative.
- The Linux `--replace-needed` + the `readelf` assertion + the relocation-faithful cleanroom are validated by this PR's CI (`test`/`cleanroom` legs on both Linux arches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
