### PR TITLE
release: chdb 3.1.0 + relocatable @chdb/lib-* 26.5.2 (ships #50 fix to users)

### DIFF
--- a/.github/workflows/chdb-node-test.yml
+++ b/.github/workflows/chdb-node-test.yml
@@ -93,8 +93,7 @@ jobs:
           # subpackage from the registry — the cleanroom then tests the released
           # binary instead of the one just built, which is how a non-relocatable
           # binary (chdb-io/chdb-node#50) shipped past a green cleanroom.
-          REL=$(grep -E '^LATEST_RELEASE=' update_libchdb.sh | cut -d= -f2)
-          export CHDB_LIB_VERSION="${REL#v}"
+          export CHDB_LIB_VERSION="$(grep -E '^LIBCHDB_NPM_VERSION=' update_libchdb.sh | cut -d= -f2)"
           npm run build:platform
           MAIN_TGZ="$PWD/$(npm pack --silent)"
           SUB_DIR="$PWD/npm/@chdb/lib-linux-x64-gnu"

--- a/.github/workflows/prebuild-publish.yml
+++ b/.github/workflows/prebuild-publish.yml
@@ -39,10 +39,11 @@ jobs:
       - run: npm run libchdb
       - run: npm run build
       - run: npm run test:all
-      - name: Derive libchdb version from update_libchdb.sh
+      - name: Derive subpackage version from update_libchdb.sh
         run: |
-          REL=$(grep -E '^LATEST_RELEASE=' update_libchdb.sh | cut -d= -f2)
-          echo "CHDB_LIB_VERSION=${REL#v}" >> "$GITHUB_ENV"
+          # The published @chdb/lib-* version is decoupled from the libchdb
+          # download (LATEST_RELEASE); see LIBCHDB_NPM_VERSION in update_libchdb.sh.
+          echo "CHDB_LIB_VERSION=$(grep -E '^LIBCHDB_NPM_VERSION=' update_libchdb.sh | cut -d= -f2)" >> "$GITHUB_ENV"
       - name: Build subpackage
         run: npm run build:platform
       - name: Publish subpackage (idempotent — skip or tolerate already-published)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chdb",
-  "version": "3.1.0-rc.1",
+  "version": "3.1.0",
   "description": "chDB bindings for nodejs",
   "main": "index.js",
   "types": "index.d.ts",
@@ -65,10 +65,10 @@
     "node-gyp-build": "^4.6.0"
   },
   "optionalDependencies": {
-    "@chdb/lib-darwin-arm64": "26.5.1-rc.1",
-    "@chdb/lib-darwin-x64": "26.5.1-rc.1",
-    "@chdb/lib-linux-arm64-gnu": "26.5.1-rc.1",
-    "@chdb/lib-linux-x64-gnu": "26.5.1-rc.1"
+    "@chdb/lib-darwin-arm64": "26.5.2",
+    "@chdb/lib-darwin-x64": "26.5.2",
+    "@chdb/lib-linux-arm64-gnu": "26.5.2",
+    "@chdb/lib-linux-x64-gnu": "26.5.2"
   },
   "peerDependencies": {
     "apache-arrow": ">=14"

--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -15,6 +15,17 @@ set -e
 # accessors the raw/streaming insert needs; absent in the v26.5.0 stable line).
 LATEST_RELEASE=v26.5.1-rc.1
 
+# Version published for the @chdb/lib-<platform> native subpackages on npm.
+# DECOUPLED from LATEST_RELEASE on purpose: chdb-core has no 26.5.2 release, but
+# the previously published subpackage versions (26.5.0, 26.5.1-rc.1) shipped a
+# non-relocatable Linux binary (chdb-io/chdb-node#50). npm forbids republishing
+# over an existing version, so the relocatability fix needs a NEW version — a
+# formal packaging revision — while the bundled libchdb stays LATEST_RELEASE
+# above (the only build carrying the #73/#15 C-ABI the binding requires). The
+# publish + cleanroom workflows read CHDB_LIB_VERSION from here, and the main
+# package's optionalDependencies pin this exact value.
+LIBCHDB_NPM_VERSION=26.5.2
+
 # Download the correct version based on the platform
 case "$(uname -s)" in
     Linux)


### PR DESCRIPTION
## Summary

Ships the relocatability fix from #57 to users by cutting **`chdb@3.1.0`** (formal, `latest`) backed by new **`@chdb/lib-*@26.5.2`** subpackages.

A plain re-release could not deliver the fix: the published Linux subpackages are broken at **both** versions on the registry, and npm forbids republishing over an existing version (the 72h self-serve unpublish window closed on 2026-06-18).

Verified by inspecting the actual published binaries (`strings` for the baked path, `otool`/load-command for darwin):

| `@chdb/lib-*` | linux-x64 | linux-arm64 | darwin-arm64 | darwin-x64 |
|---|:--:|:--:|:--:|:--:|
| `26.5.0` | ❌ | ❌ | ✅ | ✅ |
| `26.5.1-rc.1` | ❌ | ❌ | ✅ | ✅ |

Each broken binary carries a baked `/home/runner/work/chdb-node/chdb-node/libchdb.so` `DT_NEEDED`. So **`chdb@3.0.1` (latest, pins `26.5.0`) and `chdb@3.1.0-rc.2` (next, pins `26.5.1-rc.1`) are both unusable on Linux.**

## Changes

- **`update_libchdb.sh`**: add `LIBCHDB_NPM_VERSION=26.5.2` — the npm subpackage version, **decoupled** from the libchdb download. `LATEST_RELEASE` stays `v26.5.1-rc.1` (the only chdb-core build carrying the `#73`/`#15` C-ABI the binding needs; formal `v26.5.0` lacks it and chdb-core has no `26.5.2`). `26.5.2` is a formal packaging revision, not a prerelease.
- **`prebuild-publish.yml` + `chdb-node-test.yml`**: derive `CHDB_LIB_VERSION` from `LIBCHDB_NPM_VERSION` so the published/tested subpackage is `26.5.2` and the cleanroom keeps testing the locally-built binary.
- **`package.json`**: `chdb` → `3.1.0` (the publish workflow tags it `latest`), all four `optionalDependencies` pinned to `26.5.2`.

`package-lock.json` is intentionally untouched: not shipped, no workflow uses `npm ci`, and `26.5.2` isn't on the registry yet — it regenerates cleanly post-publish.

## Verification

- Local (macOS arm64): version derives to `26.5.2`; `build:platform` stamps it and passes `assert-relocatable`; a clean-room install of the packed `chdb@3.1.0` + `@chdb/lib-darwin-arm64@26.5.2` runs real sync/async/session queries **with the build-tree `libchdb.so` moved away** (proves `@loader_path` relocation).
- Linux x64 + arm64: the `cleanroom` job on this PR builds the `26.5.2` subpackage, installs it, deletes the build `libchdb.so`, and loads via `$ORIGIN` — the relocation-faithful test added in #57.

## Release steps after merge (separate, require maintainer auth)

1. push tag **`v3.1.0`** → `prebuild-publish` builds all 4 platforms at `26.5.2` (relocatable; `build:platform` asserts it) and publishes `chdb@3.1.0` as `latest`;
2. `npm deprecate @chdb/lib-linux-x64-gnu@26.5.0`, `@26.5.1-rc.1`, and the same two for `lib-linux-arm64-gnu`, pointing users at `>=26.5.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
