### PR TITLE
Add a .stream() terminal with server-side parameter binding to Layer 3

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -329,6 +329,14 @@ export class Session {
   queryStream(query: string, opts?: StreamOptions): ChdbQueryStream;
 
   /**
+   * Like {@link queryStream}, but binds `{name:Type}` placeholders server-side
+   * from `params` (values never enter the SQL text, so a streamed read is as
+   * injection-safe as {@link queryBindAsync}). Throws a typed `ChdbBindError`
+   * synchronously on a bad param value.
+   */
+  queryStreamBind(query: string, params: object, opts?: StreamOptions): ChdbQueryStream;
+
+  /**
    * Closes the session: releases the native connection and, for a temporary
    * session, removes the temporary directory. Idempotent and never throws.
    */

--- a/index.js
+++ b/index.js
@@ -609,6 +609,21 @@ class Session {
   // at a time (one streaming cursor per connection); other sessions stream in
   // parallel on their own connections.
   queryStream(sql, opts = {}) {
+    return this.#startStream(sql, opts, undefined);
+  }
+
+  // v3 streaming with server-side parameter binding. Same contract as
+  // queryStream, but {name:Type} placeholders are bound from `params` by the
+  // engine (chdb_stream_query_with_params_n) — values never enter the SQL text,
+  // so a streamed read is as injection-safe as queryBindAsync. Throws a typed
+  // ChdbBindError synchronously on a bad param value.
+  queryStreamBind(sql, params = {}, opts = {}) {
+    return this.#startStream(sql, opts, formatParams(params));
+  }
+
+  // Shared stream starter. `bound` is undefined for the param-less path or a
+  // pre-formatted { name: literal } map for the bound path.
+  #startStream(sql, opts, bound) {
     if (!this.connection) throw new ChdbClosedError("No active connection available");
     if (!sql) throw new ChdbStreamError("queryStream requires a non-empty query");
     if (this._activeStream && !this._activeStream.closed) {
@@ -617,7 +632,9 @@ class Session {
     const prep = prepArrow(sql, opts, "JSONEachRow");
     let handle;
     try {
-      handle = chdbNode.StreamQuery(this.connection, prep.sql, prep.format);
+      handle = bound === undefined
+        ? chdbNode.StreamQuery(this.connection, prep.sql, prep.format)
+        : chdbNode.StreamQuery(this.connection, prep.sql, prep.format, bound);
     } catch (e) {
       throw asQueryError(e);
     }

--- a/lib/chdb_node.cpp
+++ b/lib/chdb_node.cpp
@@ -719,11 +719,15 @@ static void stream_close(StreamState *st) {
   }
 }
 
-// Args: (connection, sql, format) -> External<StreamState>
+// Args: (connection, sql, format[, paramsObj]) -> External<StreamState>
+// When paramsObj is present, the stream is opened with server-side parameter
+// binding (chdb_stream_query_with_params_n) — values are pre-formatted to param
+// strings by the JS layer and never spliced into the SQL, exactly like the
+// one-shot QueryWithParams path. Otherwise the plain (param-less) stream opens.
 Napi::Value StreamQueryWrapper(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   if (info.Length() < 3 || !info[0].IsExternal() || !info[1].IsString() || !info[2].IsString()) {
-    Napi::TypeError::New(env, "Usage: connection, sql, format").ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, "Usage: connection, sql, format[, params]").ThrowAsJavaScriptException();
     return env.Undefined();
   }
   chdb_connection *connPtr = static_cast<chdb_connection *>(info[0].As<Napi::External<void>>().Data());
@@ -735,7 +739,29 @@ Napi::Value StreamQueryWrapper(const Napi::CallbackInfo &info) {
   std::string sql = info[1].As<Napi::String>();
   std::string format = info[2].As<Napi::String>();
 
-  chdb_result *handle = chdb_stream_query_n(conn, sql.data(), sql.size(), format.data(), format.size());
+  const bool hasParams = info.Length() >= 4 && info[3].IsObject();
+  chdb_result *handle;
+  if (hasParams) {
+    std::vector<std::string> names, values;
+    if (!collectParams(info[3].As<Napi::Object>(), names, values)) {
+      Napi::TypeError::New(env, "param values must be pre-formatted strings").ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+    size_t n = names.size();
+    std::vector<const char *> cnames(n), cvalues(n);
+    std::vector<size_t> vlens(n);
+    for (size_t i = 0; i < n; i++) {
+      cnames[i] = names[i].c_str();
+      cvalues[i] = values[i].data();
+      vlens[i] = values[i].size();
+    }
+    handle = chdb_stream_query_with_params_n(
+        conn, sql.data(), sql.size(), format.data(), format.size(),
+        n ? cnames.data() : nullptr, nullptr /* name lens => strlen */,
+        n ? cvalues.data() : nullptr, n ? vlens.data() : nullptr, n);
+  } else {
+    handle = chdb_stream_query_n(conn, sql.data(), sql.size(), format.data(), format.size());
+  }
   if (!handle) {
     Napi::Error::New(env, "chdb stream query returned a null handle").ThrowAsJavaScriptException();
     return env.Undefined();

--- a/src/layer3/builder/select.ts
+++ b/src/layer3/builder/select.ts
@@ -20,6 +20,7 @@ import type {
 import { ChExpression, toExpr, toValue, type ExprInput } from './expression'
 import {
   executeSelect,
+  executeSelectStream,
   type ExecContext,
   type ExecuteOptions,
 } from '../execute/terminal'
@@ -281,5 +282,21 @@ export class SelectQueryBuilder<O = Record<string, unknown>> {
       throw new ChdbCompileError('executeTakeFirstOrThrow: the query returned no rows')
     }
     return first
+  }
+
+  /**
+   * Stream rows lazily instead of buffering the whole result — the large-result
+   * path. Values are still bound server-side, so this is as injection-safe as
+   * {@link execute}. Requires a bound session (`chdb.session()`); the default
+   * connection has no streaming cursor. Only one stream may be active per session
+   * at a time. An `AbortSignal` in `opts` cancels the stream. `timeout` is not
+   * accepted — Layer 1 streaming has no deadline knob, only `signal`.
+   *
+   * ```ts
+   * for await (const row of db.selectFrom('events').selectAll().stream()) { … }
+   * ```
+   */
+  stream(opts?: Omit<ExecuteOptions, 'format' | 'timeout'>): AsyncIterableIterator<O> {
+    return executeSelectStream<O>(this.ctx, this.node, opts)
   }
 }

--- a/src/layer3/execute/terminal.ts
+++ b/src/layer3/execute/terminal.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ChdbResult } from '../../result'
+import { ChdbStreamError } from '../../errors'
 import { runtime, type RuntimeSession } from '../runtime'
 import { compileQuery, type CompiledQuery } from '../compiler/compile'
 import type { QueryNode, SelectQueryNode } from '../compiler/nodes'
@@ -62,6 +63,57 @@ export async function executeSelect<O>(
   if (plan.view === 'rows') return parseRows<O>(result.text())
   if (plan.view === 'arrow') return result.toArrow()
   return result
+}
+
+/**
+ * Compile a SELECT and stream its rows lazily, one at a time, instead of
+ * buffering the whole result (the large-result path: a forgotten `.limit()` on a
+ * big scan stays O(chunk) in memory rather than materializing 3–4×N).
+ *
+ * Fixed to the JSONEachRow row view so streamed rows equal executed rows. Caller
+ * settings ride in the statement's SETTINGS clause; the 64-bit-int precision
+ * setting instead rides on a session-level SET before the stream opens (see
+ * {@link streamSelectRows} for why). Values are still bound server-side (via
+ * queryStreamBind), so streaming is as injection-safe as `.execute()`. Requires a
+ * bound session: the default connection has no streaming cursor.
+ *
+ * `timeout` is intentionally absent from the options: Layer 1 streaming has no
+ * deadline knob (only `signal`), so accepting it would imply unsupported behavior.
+ */
+export function executeSelectStream<O>(
+  ctx: ExecContext,
+  node: SelectQueryNode,
+  opts: Omit<ExecuteOptions, 'format' | 'timeout'> = {},
+): AsyncIterableIterator<O> {
+  if (ctx.session === undefined) {
+    throw new ChdbStreamError(
+      'stream() requires a bound session; use chdb.session().selectFrom(...).stream() ' +
+        '(pass chdb.session(path) for a persistent database)',
+    )
+  }
+  const compiled = compileQuery(mergeSettings(node, opts.settings))
+  // The generator takes `session` as a non-optional parameter (rather than closing
+  // over the narrowed ctx.session) so the non-undefined type holds inside the
+  // closure across TypeScript versions.
+  return streamSelectRows<O>(ctx.session, compiled, opts.signal)
+}
+
+async function* streamSelectRows<O>(
+  session: RuntimeSession,
+  compiled: CompiledQuery,
+  signal: AbortSignal | undefined,
+): AsyncIterableIterator<O> {
+  // chDB builds the streaming output format from the connection's session settings
+  // at OPEN time, not from a query's trailing SETTINGS clause (which executeSelect
+  // rides in SQL). So the row view's 64-bit-int precision setting must be SET on the
+  // session first, otherwise UInt64/Int64 come back as lossy JS numbers and streamed
+  // rows would differ from executed rows. The setting persists on the session by design.
+  await session.queryAsync('SET output_format_json_quote_64bit_integers = 1', { format: 'CSV' })
+  const stream = session.queryStreamBind(compiled.sql, compiled.parameters, {
+    format: 'JSONEachRow',
+    signal,
+  })
+  yield* stream.rows() as AsyncIterableIterator<O>
 }
 
 /** Compile and run any query node that returns no row view (UPDATE/DELETE/INSERT…SELECT). */

--- a/src/layer3/runtime.ts
+++ b/src/layer3/runtime.ts
@@ -31,6 +31,17 @@ export interface RuntimeStreamOptions {
   signal?: AbortSignal
 }
 
+/**
+ * The subset of Layer 1's ChdbQueryStream the fluent `.stream()` terminal uses:
+ * a row-level async iterator plus explicit cancellation.
+ */
+export interface RuntimeRowStream<O = unknown> {
+  /** Lazily yields one parsed row at a time across all chunks. */
+  rows(): AsyncIterableIterator<O>
+  /** Cancel the stream and release the native cursor (best effort). */
+  cancel(): void
+}
+
 export interface RuntimeInsertParams {
   table: string
   values: ReadonlyArray<Record<string, unknown> | ReadonlyArray<unknown>>
@@ -52,6 +63,7 @@ export interface RuntimeSession {
   queryBindAsync(query: string, params: object, opts?: RuntimeQueryOptions): Promise<ChdbResult>
   insert(params: RuntimeInsertParams): Promise<RuntimeInsertSummary>
   queryStream(query: string, opts?: RuntimeStreamOptions): unknown
+  queryStreamBind(query: string, params: object, opts?: RuntimeStreamOptions): RuntimeRowStream
   close(): void
 }
 

--- a/test/v3/layer3/stream.test.ts
+++ b/test/v3/layer3/stream.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { session, selectFrom } from '../../../index.js'
+
+// .stream() — the large-result path: rows arrive lazily through Layer 1's
+// streaming cursor (chdb_stream_query_with_params_n) instead of buffering the
+// whole result. Values are still bound server-side, so a streamed read is as
+// injection-safe as .execute(). The global afterEach (setup.ts) force-closes
+// every session, so the fixture is rebuilt per test.
+
+let db: ReturnType<typeof session>
+
+beforeEach(async () => {
+  db = session()
+  await db.session!.queryAsync(
+    `CREATE TABLE t (id UInt64, name String) ENGINE = MergeTree ORDER BY id`,
+    { format: 'CSV' },
+  )
+  await db
+    .insertInto('t')
+    .values([
+      { id: 1, name: "O'Brien" },
+      { id: 2, name: 'Bob' },
+      { id: 18446744073709551615n as unknown as number, name: 'Max' },
+    ])
+    .execute()
+})
+
+async function collect<T>(it: AsyncIterableIterator<T>): Promise<T[]> {
+  const out: T[] = []
+  for await (const row of it) out.push(row)
+  return out
+}
+
+describe('.stream()', () => {
+  it('streams the same rows .execute() returns, in order', async () => {
+    const q = () => db.selectFrom('t').select(['id', 'name']).orderBy('id')
+    const streamed = await collect(q().stream())
+    const executed = await q().execute()
+    expect(streamed).toEqual(executed)
+  })
+
+  it('binds a value server-side (no interpolation) and filters', async () => {
+    const rows = await collect(
+      db.selectFrom('t').select(['id', 'name']).where('name', '=', "O'Brien").stream(),
+    )
+    expect(rows).toEqual([{ id: '1', name: "O'Brien" }])
+  })
+
+  it('keeps 64-bit ids as strings (row precision setting injected)', async () => {
+    const rows = (await collect(
+      db.selectFrom('t').select('id').orderBy('id').stream(),
+    )) as { id: string }[]
+    expect(rows.map((r) => r.id)).toEqual(['1', '2', '18446744073709551615'])
+  })
+
+  it('throws synchronously without a bound session', () => {
+    expect(() => selectFrom('t').selectAll().stream()).toThrow(/bound session/)
+  })
+
+  it('aborts an in-flight stream via AbortSignal', async () => {
+    const ac = new AbortController()
+    ac.abort()
+    await expect(
+      collect(db.selectFrom('t').selectAll().stream({ signal: ac.signal })),
+    ).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## What

Adds a `.stream()` terminal to the Layer 3 fluent SELECT builder so large result
sets arrive lazily, one row at a time, through Layer 1's streaming cursor instead
of buffering the whole result.

```ts
for await (const row of db.selectFrom('events').selectAll().where('ts', '>', cutoff).stream()) {
  // O(chunk) memory, not O(result)
}
```

## Why

The fluent read path buffered the entire result (`parseRows` over the full text),
so a forgotten `.limit()` on a big OLAP scan peaked at ~3–4× the result size and
risked OOM. Layer 1 already had a streaming cursor, but the fluent builder never
used it, and its param-less streaming C entry could not carry the compiler's bound
values.

`libchdb` already ships `chdb_stream_query_with_params_n` (streaming + server-side
binding), so **no upstream change is needed**.

## How

- **Native** (`lib/chdb_node.cpp`): `StreamQuery` now takes an optional
  pre-formatted params object and routes to `chdb_stream_query_with_params_n`,
  mirroring the one-shot `QueryWithParams` path; the param-less path is unchanged.
- **Layer 1** (`index.js` / `index.d.ts`): new `Session.queryStreamBind`;
  `queryStream` refactored to share a single `#startStream`. Values are bound
  exactly like `queryBindAsync`.
- **Layer 3** (`builder/select.ts`, `execute/terminal.ts`, `runtime.ts`):
  `SelectQueryBuilder.stream()` returns an `AsyncIterableIterator<O>` via
  `executeSelectStream`. Values stay bound server-side, so a streamed read is as
  injection-safe as `.execute()`. It requires a bound session (the default
  connection has no streaming cursor) and honors an `AbortSignal`.

### Note on 64-bit precision

chDB builds a streaming query's output format from the connection's **session
settings at open time**, not from a query's trailing `SETTINGS` clause (which
`executeSelect` rides in SQL). So the row view `SET`s
`output_format_json_quote_64bit_integers = 1` before opening the stream —
without it, 64-bit ints would stream as lossy JS numbers and streamed rows would
differ from executed rows.

## Tests

- 5 new `.stream()` cases: parity with `.execute()`, bound filter, 64-bit
  precision, no-session throw, abort.
- Full v3 suite green (373 passed / 11 skipped), including the existing Layer 1
  streaming tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)