### PR TITLE
Add Vercel AI SDK and Mastra tool adapters (chdb/ai-sdk, chdb/mastra)

### DIFF
--- a/integrations/ai-sdk.d.mts
+++ b/integrations/ai-sdk.d.mts
@@ -9,8 +9,34 @@ export interface ChdbToolOptions {
   maxRows?: number
 }
 
-/** A schema-aware chDB toolset: { chdbQuery, chdbListTables, chdbDescribeSource }. */
-export function chdbTools(opts?: ChdbToolOptions): Record<string, unknown>
+export interface ChdbQueryResult {
+  rows: Array<Record<string, unknown>>
+  rowCount: number
+  truncated: boolean
+  error?: string
+}
+export interface ChdbListTablesResult {
+  tables: string[]
+  error?: string
+}
+export interface ChdbDescribeResult {
+  columns: Array<{ name: string; type: string }>
+  error?: string
+}
+
+/** A tool whose `execute` resolves to a typed result `T` (the framework adds its own fields). */
+export interface ChdbTool<T> {
+  description: string
+  execute(args: Record<string, unknown>, options?: unknown): Promise<T>
+  [key: string]: unknown
+}
+
+/** A schema-aware chDB toolset for the Vercel AI SDK. */
+export function chdbTools(opts?: ChdbToolOptions): {
+  chdbQuery: ChdbTool<ChdbQueryResult>
+  chdbListTables: ChdbTool<ChdbListTablesResult>
+  chdbDescribeSource: ChdbTool<ChdbDescribeResult>
+}
 /** Just the read-only query tool. */
-export function chdbQueryTool(opts?: ChdbToolOptions): unknown
+export function chdbQueryTool(opts?: ChdbToolOptions): ChdbTool<ChdbQueryResult>
 export default chdbTools

--- a/integrations/ai-sdk.d.mts
+++ b/integrations/ai-sdk.d.mts
@@ -1,0 +1,16 @@
+import type { Session } from '../index.js'
+
+export interface ChdbToolOptions {
+  /** A chdb Session whose data to query. Defaults to the in-process default connection. */
+  session?: Session
+  /** Allow writes/DDL. Default false: reads run on an engine-level read-only session. */
+  allowWrite?: boolean
+  /** Cap on rows returned to the model (default 1000); `truncated` flags when hit. */
+  maxRows?: number
+}
+
+/** A schema-aware chDB toolset: { chdbQuery, chdbListTables, chdbDescribeSource }. */
+export function chdbTools(opts?: ChdbToolOptions): Record<string, unknown>
+/** Just the read-only query tool. */
+export function chdbQueryTool(opts?: ChdbToolOptions): unknown
+export default chdbTools

--- a/integrations/ai-sdk.mjs
+++ b/integrations/ai-sdk.mjs
@@ -1,0 +1,55 @@
+// Vercel AI SDK tools for chDB. Import from 'chdb/ai-sdk'.
+//
+//   import { chdbTools } from 'chdb/ai-sdk'
+//   import { Session } from 'chdb'
+//   const db = new Session('./db')
+//   const result = await generateText({
+//     model, prompt,
+//     tools: chdbTools({ session: db }),   // chdbQuery + chdbListTables + chdbDescribeSource
+//   })
+//
+// `ai` and `zod` are optional peer dependencies — install them in your app.
+
+import { tool } from 'ai'
+import { z } from 'zod'
+import {
+  createChdbExecutor,
+  CHDB_QUERY_DESCRIPTION,
+  CHDB_LIST_TABLES_DESCRIPTION,
+  CHDB_DESCRIBE_DESCRIPTION,
+  CHDB_SQL_FIELD_DESCRIPTION,
+  CHDB_SOURCE_FIELD_DESCRIPTION,
+} from './chdb-tool-core.mjs'
+
+/**
+ * A schema-aware chDB toolset: discover tables, inspect a source's columns, then run a
+ * read-only query. Pass the whole object as `tools` to generateText/streamText.
+ * @param {{ session?: object, allowWrite?: boolean, maxRows?: number }} [opts]
+ */
+export function chdbTools(opts = {}) {
+  const ex = createChdbExecutor(opts)
+  return {
+    chdbQuery: tool({
+      description: CHDB_QUERY_DESCRIPTION,
+      inputSchema: z.object({ sql: z.string().describe(CHDB_SQL_FIELD_DESCRIPTION) }),
+      execute: async ({ sql }) => ex.query(sql),
+    }),
+    chdbListTables: tool({
+      description: CHDB_LIST_TABLES_DESCRIPTION,
+      inputSchema: z.object({}),
+      execute: async () => ex.listTables(),
+    }),
+    chdbDescribeSource: tool({
+      description: CHDB_DESCRIBE_DESCRIPTION,
+      inputSchema: z.object({ source: z.string().describe(CHDB_SOURCE_FIELD_DESCRIPTION) }),
+      execute: async ({ source }) => ex.describeSource(source),
+    }),
+  }
+}
+
+/** Just the query tool, for when you only want one. */
+export function chdbQueryTool(opts = {}) {
+  return chdbTools(opts).chdbQuery
+}
+
+export default chdbTools

--- a/integrations/chdb-store.mjs
+++ b/integrations/chdb-store.mjs
@@ -24,7 +24,9 @@ import { Session } from '../index.mjs'
 
 const now = () => Date.now()
 const ms = (d) => (d instanceof Date ? d.getTime() : d ? new Date(d).getTime() : 0)
-const esc = (s) => `'${String(s).replace(/'/g, "''")}'`
+// ClickHouse string literals interpret backslash escapes, so neutralize both
+// backslashes and quotes; null/undefined → empty string (not the text 'undefined').
+const esc = (s) => `'${String(s ?? '').replace(/\\/g, '\\\\').replace(/'/g, "''")}'`
 
 function reviveDates(obj, fields) {
   if (!obj) return obj
@@ -208,8 +210,10 @@ class ChDBObservabilityStore extends ObservabilityStorage {
   }
 
   async updateSpan(args) {
+    // UpdateSpanArgs = { traceId, spanId, updates }; merge only `updates` so
+    // extraneous top-level keys never leak into the persisted span record.
     const { traceId, spanId } = args
-    const patch = args.updates ?? args.span ?? args
+    const patch = args.updates ?? {}
     const rows = await this.#rows(
       `SELECT record FROM mastra_ai_spans FINAL WHERE traceId = ${esc(traceId)} AND spanId = ${esc(spanId)} LIMIT 1`,
     )

--- a/integrations/chdb-store.mjs
+++ b/integrations/chdb-store.mjs
@@ -1,0 +1,284 @@
+// ChDBStore — a Mastra storage adapter backed by chDB, scoped to the two domains
+// where ClickHouse's columnar engine is the right tool:
+//   • memory       — agent threads + messages
+//   • observability — AI tracing spans (the analytical sweet spot: aggregate over
+//                     traces/spans/latencies/errors with SQL)
+//
+// Storage model: each record is kept as a full JSON blob alongside indexed key
+// columns, in a ReplacingMergeTree keyed by the record id (threads/messages) or
+// (traceId, spanId) for spans, versioned by an `_updated` epoch-ms column. This
+// gives upsert-by-id semantics (point updates that ClickHouse otherwise handles
+// awkwardly) and exact round-tripping of Mastra's nested record shapes, while the
+// indexed columns (resourceId, threadId, spanType, startedAt, …) stay queryable.
+// Reads use FINAL so a re-saved id returns its latest version without waiting for
+// a background merge.
+//
+// Other Mastra domains (workflows, scores, …) are intentionally not implemented
+// here — they are point-update/OLTP-shaped; compose another backend for them via
+// Mastra's per-domain composite storage.
+//
+// `@mastra/core` is an optional peer dependency of chdb.
+
+import { MastraStorage, MemoryStorage, ObservabilityStorage } from '@mastra/core/storage'
+import { Session } from '../index.mjs'
+
+const now = () => Date.now()
+const ms = (d) => (d instanceof Date ? d.getTime() : d ? new Date(d).getTime() : 0)
+const esc = (s) => `'${String(s).replace(/'/g, "''")}'`
+
+function reviveDates(obj, fields) {
+  if (!obj) return obj
+  for (const f of fields) if (obj[f] != null && typeof obj[f] === 'string') obj[f] = new Date(obj[f])
+  return obj
+}
+
+// --- memory domain -----------------------------------------------------------
+
+class ChDBMemoryStore extends MemoryStorage {
+  #s
+  constructor(session) {
+    super()
+    this.#s = session
+    this.#s.query(
+      `CREATE TABLE IF NOT EXISTS mastra_threads (id String, resourceId String, _created Int64, _updated Int64, record String)` +
+        ` ENGINE = ReplacingMergeTree(_updated) ORDER BY id`,
+      'CSV',
+    )
+    this.#s.query(
+      `CREATE TABLE IF NOT EXISTS mastra_messages (id String, threadId String, resourceId String, _created Int64, _updated Int64, record String)` +
+        ` ENGINE = ReplacingMergeTree(_updated) ORDER BY id`,
+      'CSV',
+    )
+  }
+
+  async #rows(sql) {
+    const r = await this.#s.queryAsync(sql, { format: 'JSON' })
+    return r.json()?.data ?? []
+  }
+
+  async saveThread({ thread }) {
+    await this.#s.insert({
+      table: 'mastra_threads',
+      values: [
+        {
+          id: thread.id,
+          resourceId: thread.resourceId ?? '',
+          _created: ms(thread.createdAt) || now(),
+          _updated: ms(thread.updatedAt) || now(),
+          record: JSON.stringify(thread),
+        },
+      ],
+    })
+    return thread
+  }
+
+  async getThreadById({ threadId }) {
+    const rows = await this.#rows(`SELECT record FROM mastra_threads FINAL WHERE id = ${esc(threadId)} LIMIT 1`)
+    return rows[0] ? reviveDates(JSON.parse(rows[0].record), ['createdAt', 'updatedAt']) : null
+  }
+
+  async updateThread({ id, title, metadata }) {
+    const existing = await this.getThreadById({ threadId: id })
+    if (!existing) throw new Error(`ChDBStore: thread '${id}' not found`)
+    const updated = {
+      ...existing,
+      title: title ?? existing.title,
+      metadata: { ...(existing.metadata ?? {}), ...(metadata ?? {}) },
+      updatedAt: new Date(),
+    }
+    return this.saveThread({ thread: updated })
+  }
+
+  async deleteThread({ threadId }) {
+    this.#s.query(`DELETE FROM mastra_threads WHERE id = ${esc(threadId)}`, 'CSV')
+    this.#s.query(`DELETE FROM mastra_messages WHERE threadId = ${esc(threadId)}`, 'CSV')
+  }
+
+  async listThreads(args = {}) {
+    const { perPage = 100, page = 0, filter } = args
+    const where = ['1']
+    if (filter?.resourceId) where.push(`resourceId = ${esc(filter.resourceId)}`)
+    for (const [k, v] of Object.entries(filter?.metadata ?? {})) {
+      where.push(`JSONExtractString(record, 'metadata', ${esc(k)}) = ${esc(v)}`)
+    }
+    const w = where.join(' AND ')
+    const total = Number((await this.#rows(`SELECT count() c FROM mastra_threads FINAL WHERE ${w}`))[0]?.c ?? 0)
+    let sql = `SELECT record FROM mastra_threads FINAL WHERE ${w} ORDER BY _created DESC`
+    if (perPage !== false) sql += ` LIMIT ${perPage} OFFSET ${page * perPage}`
+    const threads = (await this.#rows(sql)).map((r) => reviveDates(JSON.parse(r.record), ['createdAt', 'updatedAt']))
+    return { threads, total, page, perPage, hasMore: perPage === false ? false : page * perPage + threads.length < total }
+  }
+
+  async saveMessages({ messages }) {
+    if (!messages?.length) return { messages: [] }
+    await this.#s.insert({
+      table: 'mastra_messages',
+      values: messages.map((m) => ({
+        id: m.id,
+        threadId: m.threadId ?? '',
+        resourceId: m.resourceId ?? '',
+        _created: ms(m.createdAt) || now(),
+        _updated: now(),
+        record: JSON.stringify(m),
+      })),
+    })
+    return { messages }
+  }
+
+  async listMessages(args) {
+    const { threadId, perPage = 40, page = 0 } = args
+    const ids = Array.isArray(threadId) ? threadId : [threadId]
+    const inList = ids.map(esc).join(', ')
+    const total = Number(
+      (await this.#rows(`SELECT count() c FROM mastra_messages FINAL WHERE threadId IN (${inList})`))[0]?.c ?? 0,
+    )
+    let sql = `SELECT record FROM mastra_messages FINAL WHERE threadId IN (${inList}) ORDER BY _created ASC`
+    if (perPage !== false) sql += ` LIMIT ${perPage} OFFSET ${page * perPage}`
+    const messages = (await this.#rows(sql)).map((r) => reviveDates(JSON.parse(r.record), ['createdAt']))
+    return { messages, total, page, perPage, hasMore: perPage === false ? false : page * perPage + messages.length < total }
+  }
+
+  async listMessagesById({ messageIds }) {
+    if (!messageIds?.length) return { messages: [] }
+    const inList = messageIds.map(esc).join(', ')
+    const messages = (await this.#rows(`SELECT record FROM mastra_messages FINAL WHERE id IN (${inList})`)).map((r) =>
+      reviveDates(JSON.parse(r.record), ['createdAt']),
+    )
+    return { messages }
+  }
+
+  async updateMessages({ messages }) {
+    const out = []
+    for (const patch of messages) {
+      const rows = await this.#rows(`SELECT record FROM mastra_messages FINAL WHERE id = ${esc(patch.id)} LIMIT 1`)
+      if (!rows[0]) continue
+      const cur = JSON.parse(rows[0].record)
+      const merged = { ...cur, ...patch, content: { ...(cur.content ?? {}), ...(patch.content ?? {}) } }
+      await this.saveMessages({ messages: [reviveDates(merged, ['createdAt'])] })
+      out.push(reviveDates(merged, ['createdAt']))
+    }
+    return out
+  }
+}
+
+// --- observability domain (AI tracing) ---------------------------------------
+
+class ChDBObservabilityStore extends ObservabilityStorage {
+  #s
+  constructor(session) {
+    super()
+    this.#s = session
+    this.#s.query(
+      `CREATE TABLE IF NOT EXISTS mastra_ai_spans (` +
+        `traceId String, spanId String, parentSpanId String, name String, spanType String, ` +
+        `isRoot UInt8, startedAt Int64, endedAt Int64, _updated Int64, record String` +
+        `) ENGINE = ReplacingMergeTree(_updated) ORDER BY (traceId, spanId)`,
+      'CSV',
+    )
+  }
+
+  async #rows(sql) {
+    const r = await this.#s.queryAsync(sql, { format: 'JSON' })
+    return r.json()?.data ?? []
+  }
+
+  #row(span) {
+    const full = { createdAt: new Date(), updatedAt: null, ...span }
+    return {
+      traceId: span.traceId,
+      spanId: span.spanId,
+      parentSpanId: span.parentSpanId ?? '',
+      name: span.name ?? '',
+      spanType: String(span.spanType ?? ''),
+      isRoot: span.parentSpanId ? 0 : 1,
+      startedAt: ms(span.startedAt),
+      endedAt: ms(span.endedAt),
+      _updated: now(),
+      record: JSON.stringify(full),
+    }
+  }
+
+  async createSpan({ span }) {
+    await this.#s.insert({ table: 'mastra_ai_spans', values: [this.#row(span)] })
+  }
+
+  async batchCreateSpans({ records }) {
+    if (!records?.length) return
+    await this.#s.insert({ table: 'mastra_ai_spans', values: records.map((r) => this.#row(r)) })
+  }
+
+  async updateSpan(args) {
+    const { traceId, spanId } = args
+    const patch = args.updates ?? args.span ?? args
+    const rows = await this.#rows(
+      `SELECT record FROM mastra_ai_spans FINAL WHERE traceId = ${esc(traceId)} AND spanId = ${esc(spanId)} LIMIT 1`,
+    )
+    if (!rows[0]) throw new Error(`ChDBStore: span ${traceId}/${spanId} not found`)
+    const cur = JSON.parse(rows[0].record)
+    const merged = { ...cur, ...patch, traceId, spanId, updatedAt: new Date() }
+    await this.#s.insert({ table: 'mastra_ai_spans', values: [this.#row(merged)] })
+  }
+
+  #parseSpan(r) {
+    return reviveDates(JSON.parse(r.record), ['createdAt', 'updatedAt', 'startedAt', 'endedAt'])
+  }
+
+  async getSpan({ traceId, spanId }) {
+    const rows = await this.#rows(
+      `SELECT record FROM mastra_ai_spans FINAL WHERE traceId = ${esc(traceId)} AND spanId = ${esc(spanId)} LIMIT 1`,
+    )
+    return rows[0] ? { span: this.#parseSpan(rows[0]) } : null
+  }
+
+  async getRootSpan({ traceId }) {
+    const rows = await this.#rows(
+      `SELECT record FROM mastra_ai_spans FINAL WHERE traceId = ${esc(traceId)} AND isRoot = 1 LIMIT 1`,
+    )
+    return rows[0] ? { span: this.#parseSpan(rows[0]) } : null
+  }
+
+  async getTrace({ traceId }) {
+    const rows = await this.#rows(
+      `SELECT record FROM mastra_ai_spans FINAL WHERE traceId = ${esc(traceId)} ORDER BY startedAt ASC`,
+    )
+    return { traceId, spans: rows.map((r) => this.#parseSpan(r)) }
+  }
+
+  async getSpans({ traceId, spanIds }) {
+    const inList = (spanIds ?? []).map(esc).join(', ') || `''`
+    const rows = await this.#rows(
+      `SELECT record FROM mastra_ai_spans FINAL WHERE traceId = ${esc(traceId)} AND spanId IN (${inList})`,
+    )
+    return { traceId, spans: rows.map((r) => this.#parseSpan(r)) }
+  }
+
+  async listTraces(args = {}) {
+    const page = args.pagination?.page ?? 0
+    const perPage = args.pagination?.perPage ?? 100
+    const dir = (args.orderBy?.direction ?? 'DESC').toUpperCase() === 'ASC' ? 'ASC' : 'DESC'
+    const total = Number((await this.#rows(`SELECT count() c FROM mastra_ai_spans FINAL WHERE isRoot = 1`))[0]?.c ?? 0)
+    const rows = await this.#rows(
+      `SELECT record FROM mastra_ai_spans FINAL WHERE isRoot = 1 ORDER BY startedAt ${dir} LIMIT ${perPage} OFFSET ${page * perPage}`,
+    )
+    const spans = rows.map((r) => {
+      const s = this.#parseSpan(r)
+      const status = s.error ? 'error' : s.endedAt ? 'success' : 'running'
+      return { ...s, status }
+    })
+    return { spans, pagination: { total, page, perPage, hasMore: page * perPage + spans.length < total } }
+  }
+}
+
+// --- composite store ---------------------------------------------------------
+
+export class ChDBStore extends MastraStorage {
+  /** @param {{ session?: any, path?: string, id?: string }} [opts] */
+  constructor(opts = {}) {
+    super({ id: opts.id ?? 'chdb' })
+    const session = opts.session ?? new Session(opts.path ?? '')
+    this.stores = {
+      memory: new ChDBMemoryStore(session),
+      observability: new ChDBObservabilityStore(session),
+    }
+  }
+}

--- a/integrations/chdb-tool-core.mjs
+++ b/integrations/chdb-tool-core.mjs
@@ -1,0 +1,97 @@
+// Framework-agnostic core for the chDB agent toolset. The Vercel AI SDK and Mastra
+// adapters (./ai-sdk.mjs, ./mastra.mjs) wrap these executors, so behavior is identical
+// across frameworks. Authored as ESM because both target frameworks are ESM-only.
+
+import { Session, queryAsync } from '../index.mjs'
+
+export const CHDB_QUERY_DESCRIPTION =
+  'Run a read-only ClickHouse SQL query with chDB, an in-process ClickHouse engine ' +
+  '(full SQL dialect: 1000+ functions, window functions, arrays, JSON). First use ' +
+  'chdbListTables / chdbDescribeSource to learn the schema, then write the query. Read ' +
+  'external data inline with table functions: file(\'path\'[, \'format\']), s3(\'url\', \'format\'), ' +
+  'url(\'url\', \'format\'), postgresql(\'host:port\',\'db\',\'table\',\'user\',\'pass\'), mysql(...), ' +
+  'mongodb(...). Returns result rows as JSON. Only SELECT-style reads are allowed.'
+
+export const CHDB_LIST_TABLES_DESCRIPTION =
+  'List the tables and views available in the chDB session. Call this to discover what ' +
+  'you can query before writing SQL.'
+
+export const CHDB_DESCRIBE_DESCRIPTION =
+  'Describe the columns and types of a chDB source so you can write a correct query. The ' +
+  'source is a table name, or a table function for external data, e.g. ' +
+  "s3('https://bucket/f.parquet','Parquet'), file('data.csv'), postgresql('host:5432','db','tbl','u','p')."
+
+export const CHDB_SQL_FIELD_DESCRIPTION = 'A complete read-only ClickHouse SQL statement.'
+export const CHDB_SOURCE_FIELD_DESCRIPTION =
+  "A table name or a table-function expression, e.g. \"events\" or \"s3('s3://b/f.parquet','Parquet')\"."
+
+/**
+ * Build the shared executors the framework adapters wrap.
+ * @param {{ session?: any, allowWrite?: boolean, maxRows?: number }} [opts]
+ *   session: a chdb Session whose data to query (defaults to the in-process default
+ *     connection, suitable for stateless file/s3/url queries).
+ *   allowWrite: false (default) runs reads on a dedicated engine-level read-only session
+ *     (SET readonly = 1) bound to the same data path, so a write/DDL the model emits is
+ *     rejected by the engine, not just by a prompt. true uses the session directly.
+ *   maxRows: cap on rows returned (default 1000); `truncated` flags when hit.
+ */
+export function createChdbExecutor(opts = {}) {
+  const { session, allowWrite = false, maxRows = 1000 } = opts
+  let roSession // lazy read-only twin
+
+  function conn() {
+    if (allowWrite) return session ?? null
+    if (roSession === undefined) {
+      roSession = new Session(session ? session.path : '')
+      roSession.query('SET readonly = 1', 'CSV')
+    }
+    return roSession
+  }
+
+  async function runJson(sql) {
+    const c = conn()
+    return c ? c.queryAsync(sql, { format: 'JSON' }) : queryAsync(sql, { format: 'JSON' })
+  }
+
+  return {
+    async query(sql) {
+      if (typeof sql !== 'string' || sql.trim() === '') {
+        return { rows: [], rowCount: 0, truncated: false, error: 'sql must be a non-empty string' }
+      }
+      try {
+        const parsed = (await runJson(sql)).json() // ClickHouse JSON: { data, rows, statistics }
+        const data = Array.isArray(parsed?.data) ? parsed.data : []
+        const truncated = data.length > maxRows
+        return {
+          rows: truncated ? data.slice(0, maxRows) : data,
+          rowCount: typeof parsed?.rows === 'number' ? parsed.rows : data.length,
+          truncated,
+        }
+      } catch (e) {
+        // Return the engine error to the model (so it can fix the SQL) rather than throw.
+        return { rows: [], rowCount: 0, truncated: false, error: (e && e.message) || String(e) }
+      }
+    },
+
+    async listTables() {
+      try {
+        const parsed = (await runJson('SHOW TABLES')).json()
+        return { tables: (parsed?.data ?? []).map((r) => r.name) }
+      } catch (e) {
+        return { tables: [], error: (e && e.message) || String(e) }
+      }
+    },
+
+    async describeSource(source) {
+      if (typeof source !== 'string' || source.trim() === '') {
+        return { columns: [], error: 'source must be a non-empty string' }
+      }
+      try {
+        const parsed = (await runJson(`DESCRIBE TABLE ${source}`)).json()
+        return { columns: (parsed?.data ?? []).map((r) => ({ name: r.name, type: r.type })) }
+      } catch (e) {
+        return { columns: [], error: (e && e.message) || String(e) }
+      }
+    },
+  }
+}

--- a/integrations/chdb-tool-core.mjs
+++ b/integrations/chdb-tool-core.mjs
@@ -31,8 +31,10 @@ export const CHDB_SOURCE_FIELD_DESCRIPTION =
  *   session: a chdb Session whose data to query (defaults to the in-process default
  *     connection, suitable for stateless file/s3/url queries).
  *   allowWrite: false (default) runs reads on a dedicated engine-level read-only session
- *     (SET readonly = 1) bound to the same data path, so a write/DDL the model emits is
- *     rejected by the engine, not just by a prompt. true uses the session directly.
+ *     (SET readonly = 2) bound to the same data path, so a write/DDL the model emits is
+ *     rejected by the engine, not just by a prompt. readonly=2 (not 1) is required so
+ *     external table functions like file()/url()/s3() still work — readonly=1 rejects
+ *     them with Code:164. true uses the session directly.
  *   maxRows: cap on rows returned (default 1000); `truncated` flags when hit.
  */
 export function createChdbExecutor(opts = {}) {
@@ -46,7 +48,7 @@ export function createChdbExecutor(opts = {}) {
     if (allowWrite) return session ?? null
     if (roSession === undefined) {
       roSession = new Session(session ? session.path : '')
-      roSession.query('SET readonly = 1', 'CSV')
+      roSession.query('SET readonly = 2', 'CSV')
     }
     return roSession
   }

--- a/integrations/chdb-tool-core.mjs
+++ b/integrations/chdb-tool-core.mjs
@@ -36,7 +36,10 @@ export const CHDB_SOURCE_FIELD_DESCRIPTION =
  *   maxRows: cap on rows returned (default 1000); `truncated` flags when hit.
  */
 export function createChdbExecutor(opts = {}) {
-  const { session, allowWrite = false, maxRows = 1000 } = opts
+  const { session, allowWrite = false } = opts
+  // Coerce to a positive integer once so a bad maxRows can't make slice()/`truncated`
+  // misbehave (e.g. 0, negative, NaN, or a non-integer).
+  const maxRows = Math.max(1, Math.floor(Number(opts.maxRows) || 1000))
   let roSession // lazy read-only twin
 
   function conn() {

--- a/integrations/chdb-vector.mjs
+++ b/integrations/chdb-vector.mjs
@@ -1,0 +1,199 @@
+// ChDBVector — a Mastra vector store backed by chDB's ClickHouse vector engine.
+//
+// Similarity search uses chDB-core's HNSW vector index (`vector_similarity`), so a
+// query is index-accelerated ANN, not a brute-force distance scan over every row:
+//   INDEX vec_idx vector TYPE vector_similarity('hnsw', '<distFn>', <dim>)
+//   ... ORDER BY <distFn>(vector, [q]) LIMIT k   -- the index prunes granules
+// (verified via EXPLAIN indexes=1: the vec_idx skip-index is used).
+//
+// `@mastra/core` and `zod` are optional peer dependencies of chdb.
+
+import { MastraVector } from '@mastra/core/vector'
+import { Session } from '../index.mjs'
+
+// Mastra metric -> ClickHouse distance function used by the vector_similarity index.
+// The index supports cosineDistance and L2Distance; dotproduct has no index form.
+const METRIC_FN = { cosine: 'cosineDistance', euclidean: 'L2Distance' }
+const IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/
+const META_TABLE = '__chdb_vector_meta'
+
+function assertIdent(name) {
+  if (typeof name !== 'string' || !IDENT.test(name)) {
+    throw new Error(`ChDBVector: invalid indexName ${JSON.stringify(name)} (must match ${IDENT})`)
+  }
+  return name
+}
+
+export class ChDBVector extends MastraVector {
+  #session
+
+  /** @param {{ session?: any, path?: string, id?: string }} [opts] reuse a chdb Session, or bind a path (':memory:' default). */
+  constructor(opts = {}) {
+    super({ id: opts.id ?? 'chdb' })
+    this.#session = opts.session ?? new Session(opts.path ?? '')
+    this.#session.query('SET allow_experimental_vector_similarity_index = 1', 'CSV')
+    this.#session.query(
+      `CREATE TABLE IF NOT EXISTS ${META_TABLE} (name String, dimension UInt32, metric String)` +
+        ` ENGINE = ReplacingMergeTree ORDER BY name`,
+      'CSV',
+    )
+  }
+
+  async createIndex({ indexName, dimension, metric = 'cosine' }) {
+    assertIdent(indexName)
+    const fn = METRIC_FN[metric]
+    if (!fn) {
+      throw new Error(
+        `ChDBVector: metric '${metric}' is not supported by chDB's vector index; use 'cosine' or 'euclidean'`,
+      )
+    }
+    const dim = Number(dimension)
+    if (!Number.isInteger(dim) || dim <= 0) throw new Error(`ChDBVector: dimension must be a positive integer`)
+    this.#session.query(
+      `CREATE TABLE IF NOT EXISTS \`${indexName}\` (` +
+        `id String, vector Array(Float32), metadata String DEFAULT '{}', ` +
+        `INDEX vec_idx vector TYPE vector_similarity('hnsw', '${fn}', ${dim}) GRANULARITY 1` +
+        `) ENGINE = MergeTree ORDER BY id`,
+      'CSV',
+    )
+    await this.#session.queryBindAsync(
+      `INSERT INTO ${META_TABLE} (name, dimension, metric) VALUES ({n:String}, {d:UInt32}, {m:String})`,
+      { n: indexName, d: dim, m: metric },
+      { format: 'CSV' },
+    )
+  }
+
+  async upsert({ indexName, vectors, metadata, ids }) {
+    assertIdent(indexName)
+    if (!Array.isArray(vectors) || vectors.length === 0) return []
+    const outIds = vectors.map((_, i) => (ids && ids[i] != null ? String(ids[i]) : cryptoId()))
+    // True upsert: drop any existing rows for these ids, then insert.
+    await this.#session.queryBindAsync(
+      `DELETE FROM \`${indexName}\` WHERE id IN {ids:Array(String)}`,
+      { ids: outIds },
+      { format: 'CSV' },
+    )
+    const rows = vectors.map((v, i) => ({
+      id: outIds[i],
+      vector: Array.from(v, Number),
+      metadata: JSON.stringify(metadata && metadata[i] ? metadata[i] : {}),
+    }))
+    await this.#session.insert({ table: indexName, values: rows })
+    return outIds
+  }
+
+  async query({ indexName, queryVector, topK = 10, filter, includeVector = false }) {
+    assertIdent(indexName)
+    const fn = await this.#metricFn(indexName)
+    const where = filterToSql(filter)
+    const cols = includeVector ? 'id, metadata, vector' : 'id, metadata'
+    const sql =
+      `SELECT ${cols}, ${fn}(vector, {q:Array(Float32)}) AS _dist FROM \`${indexName}\`` +
+      `${where} ORDER BY _dist ASC LIMIT {k:UInt32}`
+    const res = await this.#session.queryBindAsync(
+      sql,
+      { q: Array.from(queryVector, Number), k: topK | 0 },
+      { format: 'JSON' },
+    )
+    const data = res.json()?.data ?? []
+    return data.map((r) => ({
+      id: r.id,
+      score: fn === 'cosineDistance' ? 1 - Number(r._dist) : 1 / (1 + Number(r._dist)),
+      metadata: safeJson(r.metadata),
+      ...(includeVector ? { vector: (r.vector ?? []).map(Number) } : {}),
+    }))
+  }
+
+  async listIndexes() {
+    const res = await this.#session.queryAsync(`SELECT name FROM ${META_TABLE} FINAL ORDER BY name`, {
+      format: 'JSON',
+    })
+    return (res.json()?.data ?? []).map((r) => r.name)
+  }
+
+  async describeIndex({ indexName }) {
+    assertIdent(indexName)
+    const m = await this.#session.queryBindAsync(
+      `SELECT dimension, metric FROM ${META_TABLE} FINAL WHERE name = {n:String} LIMIT 1`,
+      { n: indexName },
+      { format: 'JSON' },
+    )
+    const meta = m.json()?.data?.[0]
+    if (!meta) throw new Error(`ChDBVector: index '${indexName}' does not exist`)
+    const c = await this.#session.queryAsync(`SELECT count() AS c FROM \`${indexName}\``, { format: 'JSON' })
+    return { dimension: Number(meta.dimension), count: Number(c.json()?.data?.[0]?.c ?? 0), metric: meta.metric }
+  }
+
+  async deleteIndex({ indexName }) {
+    assertIdent(indexName)
+    this.#session.query(`DROP TABLE IF EXISTS \`${indexName}\``, 'CSV')
+    await this.#session.queryBindAsync(`DELETE FROM ${META_TABLE} WHERE name = {n:String}`, { n: indexName }, { format: 'CSV' })
+  }
+
+  async deleteVector({ indexName, id }) {
+    assertIdent(indexName)
+    await this.#session.queryBindAsync(`DELETE FROM \`${indexName}\` WHERE id = {id:String}`, { id: String(id) }, { format: 'CSV' })
+  }
+
+  async deleteVectors({ indexName, filter }) {
+    assertIdent(indexName)
+    const where = filterToSql(filter)
+    if (!where) throw new Error('ChDBVector: deleteVectors requires a filter')
+    this.#session.query(`DELETE FROM \`${indexName}\`${where.replace(/^ WHERE/, ' WHERE')}`, 'CSV')
+  }
+
+  async updateVector({ indexName, id, update }) {
+    assertIdent(indexName)
+    if (id == null) throw new Error('ChDBVector: updateVector requires an id')
+    // Read the existing row so a metadata-only or vector-only update preserves the other field.
+    const res = await this.#session.queryBindAsync(
+      `SELECT vector, metadata FROM \`${indexName}\` WHERE id = {id:String} LIMIT 1`,
+      { id: String(id) },
+      { format: 'JSON' },
+    )
+    const existing = res.json()?.data?.[0]
+    if (!existing) throw new Error(`ChDBVector: id '${id}' not found in '${indexName}'`)
+    const vector = update?.vector ? Array.from(update.vector, Number) : (existing.vector ?? []).map(Number)
+    const metadata = update?.metadata ?? safeJson(existing.metadata)
+    await this.upsert({ indexName, vectors: [vector], metadata: [metadata], ids: [String(id)] })
+  }
+
+  async #metricFn(indexName) {
+    const m = await this.#session.queryBindAsync(
+      `SELECT metric FROM ${META_TABLE} FINAL WHERE name = {n:String} LIMIT 1`,
+      { n: indexName },
+      { format: 'JSON' },
+    )
+    const metric = m.json()?.data?.[0]?.metric ?? 'cosine'
+    return METRIC_FN[metric] ?? 'cosineDistance'
+  }
+}
+
+function cryptoId() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require('crypto').randomUUID()
+}
+
+function safeJson(s) {
+  try {
+    return s ? JSON.parse(s) : {}
+  } catch {
+    return {}
+  }
+}
+
+// Translate a flat equality metadata filter ({ key: value }) to a WHERE clause over
+// the JSON metadata column. Operator filters ($gt, $in, …) are not supported yet.
+function filterToSql(filter) {
+  if (!filter || typeof filter !== 'object' || Object.keys(filter).length === 0) return ''
+  const parts = []
+  for (const [k, v] of Object.entries(filter)) {
+    if (v !== null && typeof v === 'object') {
+      throw new Error(`ChDBVector: operator filters are not supported yet (key ${JSON.stringify(k)})`)
+    }
+    if (!IDENT.test(k)) throw new Error(`ChDBVector: invalid filter key ${JSON.stringify(k)}`)
+    const lit = typeof v === 'number' || typeof v === 'boolean' ? String(v) : `'${String(v).replace(/'/g, "''")}'`
+    parts.push(`JSONExtractString(metadata, '${k}') = ${lit}`)
+  }
+  return ` WHERE ${parts.join(' AND ')}`
+}

--- a/integrations/chdb-vector.mjs
+++ b/integrations/chdb-vector.mjs
@@ -1,10 +1,15 @@
 // ChDBVector — a Mastra vector store backed by chDB's ClickHouse vector engine.
 //
 // Similarity search uses chDB-core's HNSW vector index (`vector_similarity`), so a
-// query is index-accelerated ANN, not a brute-force distance scan over every row:
-//   INDEX vec_idx vector TYPE vector_similarity('hnsw', '<distFn>', <dim>)
-//   ... ORDER BY <distFn>(vector, [q]) LIMIT k   -- the index prunes granules
-// (verified via EXPLAIN indexes=1: the vec_idx skip-index is used).
+// query is index-accelerated approximate ANN, not a brute-force scan over every row:
+//   INDEX vec_idx vector TYPE vector_similarity('hnsw', '<distFn>', <dim>) GRANULARITY <big>
+//   ... ORDER BY <distFn>(vector, [q]) LIMIT k
+// The GRANULARITY must be large enough that one HNSW graph covers a whole part;
+// with the default GRANULARITY 1 a sub-index is built per 8192-row granule and a
+// top-k search consults every one, so no granules are pruned and it degrades to a
+// full scan (EXPLAIN indexes=1 shows all granules read). With a large GRANULARITY
+// the index prunes granules (EXPLAIN shows a fraction read) and results are
+// approximate nearest neighbours.
 //
 // `@mastra/core` and `zod` are optional peer dependencies of chdb.
 
@@ -15,6 +20,9 @@ import { Session } from '../index.mjs'
 // Mastra metric -> ClickHouse distance function used by the vector_similarity index.
 // The index supports cosineDistance and L2Distance; dotproduct has no index form.
 const METRIC_FN = { cosine: 'cosineDistance', euclidean: 'L2Distance' }
+// One HNSW graph per part rather than per 8192-row granule; anything past a part's
+// granule count collapses to "whole part", so this is effectively unbounded.
+const HNSW_GRANULARITY = 100000000
 const IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/
 const META_TABLE = '__chdb_vector_meta'
 
@@ -53,7 +61,10 @@ export class ChDBVector extends MastraVector {
     this.#session.query(
       `CREATE TABLE IF NOT EXISTS \`${indexName}\` (` +
         `id String, vector Array(Float32), metadata String DEFAULT '{}', _v Int64, ` +
-        `INDEX vec_idx vector TYPE vector_similarity('hnsw', '${fn}', ${dim}) GRANULARITY 1` +
+        `INDEX vec_idx vector TYPE vector_similarity('hnsw', '${fn}', ${dim}) GRANULARITY ${HNSW_GRANULARITY}, ` +
+        // Reject wrong-length vectors at the engine: a mismatched dimension would
+        // otherwise insert silently and corrupt the HNSW graph.
+        `CONSTRAINT check_dim CHECK length(vector) = ${dim}` +
         `) ENGINE = ReplacingMergeTree(_v) ORDER BY id`,
       'CSV',
     )
@@ -85,14 +96,14 @@ export class ChDBVector extends MastraVector {
   async query({ indexName, queryVector, topK = 10, filter, includeVector = false }) {
     assertIdent(indexName)
     const fn = await this.#metricFn(indexName)
-    const where = filterToSql(filter)
+    const { where, params } = filterToSql(filter)
     const cols = includeVector ? 'id, metadata, vector' : 'id, metadata'
     const sql =
       `SELECT ${cols}, ${fn}(vector, {q:Array(Float32)}) AS _dist FROM \`${indexName}\` FINAL` +
       `${where} ORDER BY _dist ASC LIMIT {k:UInt32}`
     const res = await this.#session.queryBindAsync(
       sql,
-      { q: Array.from(queryVector, Number), k: Math.max(1, Math.floor(Number(topK) || 10)) },
+      { q: Array.from(queryVector, Number), k: Math.max(1, Math.floor(Number(topK) || 10)), ...params },
       { format: 'JSON' },
     )
     const data = res.json()?.data ?? []
@@ -137,9 +148,9 @@ export class ChDBVector extends MastraVector {
 
   async deleteVectors({ indexName, filter }) {
     assertIdent(indexName)
-    const where = filterToSql(filter)
+    const { where, params } = filterToSql(filter)
     if (!where) throw new Error('ChDBVector: deleteVectors requires a filter')
-    this.#session.query(`DELETE FROM \`${indexName}\`${where.replace(/^ WHERE/, ' WHERE')}`, 'CSV')
+    await this.#session.queryBindAsync(`DELETE FROM \`${indexName}\`${where}`, params, { format: 'CSV' })
   }
 
   async updateVector({ indexName, id, update }) {
@@ -177,21 +188,26 @@ function safeJson(s) {
   }
 }
 
-// Translate a flat equality metadata filter ({ key: value }) to a WHERE clause over
-// the JSON metadata column. Operator filters ($gt, $in, …) are not supported yet.
+// Translate a flat equality metadata filter ({ key: value }) to a WHERE clause plus
+// the params to bind for it. Operator filters ($gt, $in, …) are not supported yet.
+// Keys are validated as identifiers (safe to inline); values are always bound as
+// String params — never interpolated into the SQL — which matters on the destructive
+// deleteVectors() path and also makes numeric/boolean filters work: metadata is
+// stored as JSON text, so JSONExtractString yields the value's string form and every
+// filter must compare against that string ("2024", "true"), not a bare literal.
 function filterToSql(filter) {
-  if (!filter || typeof filter !== 'object' || Object.keys(filter).length === 0) return ''
+  if (!filter || typeof filter !== 'object' || Object.keys(filter).length === 0) return { where: '', params: {} }
   const parts = []
+  const params = {}
+  let i = 0
   for (const [k, v] of Object.entries(filter)) {
     if (v !== null && typeof v === 'object') {
       throw new Error(`ChDBVector: operator filters are not supported yet (key ${JSON.stringify(k)})`)
     }
     if (!IDENT.test(k)) throw new Error(`ChDBVector: invalid filter key ${JSON.stringify(k)}`)
-    const lit =
-      typeof v === 'number' || typeof v === 'boolean'
-        ? String(v)
-        : `'${String(v).replace(/\\/g, '\\\\').replace(/'/g, "''")}'`
-    parts.push(`JSONExtractString(metadata, '${k}') = ${lit}`)
+    const p = `f${i++}`
+    parts.push(`JSONExtractString(metadata, '${k}') = {${p}:String}`)
+    params[p] = String(v)
   }
-  return ` WHERE ${parts.join(' AND ')}`
+  return { where: ` WHERE ${parts.join(' AND ')}`, params }
 }

--- a/integrations/chdb-vector.mjs
+++ b/integrations/chdb-vector.mjs
@@ -8,6 +8,7 @@
 //
 // `@mastra/core` and `zod` are optional peer dependencies of chdb.
 
+import { randomUUID } from 'node:crypto'
 import { MastraVector } from '@mastra/core/vector'
 import { Session } from '../index.mjs'
 
@@ -33,8 +34,8 @@ export class ChDBVector extends MastraVector {
     this.#session = opts.session ?? new Session(opts.path ?? '')
     this.#session.query('SET allow_experimental_vector_similarity_index = 1', 'CSV')
     this.#session.query(
-      `CREATE TABLE IF NOT EXISTS ${META_TABLE} (name String, dimension UInt32, metric String)` +
-        ` ENGINE = ReplacingMergeTree ORDER BY name`,
+      `CREATE TABLE IF NOT EXISTS ${META_TABLE} (name String, dimension UInt32, metric String, _updated Int64)` +
+        ` ENGINE = ReplacingMergeTree(_updated) ORDER BY name`,
       'CSV',
     )
   }
@@ -51,14 +52,14 @@ export class ChDBVector extends MastraVector {
     if (!Number.isInteger(dim) || dim <= 0) throw new Error(`ChDBVector: dimension must be a positive integer`)
     this.#session.query(
       `CREATE TABLE IF NOT EXISTS \`${indexName}\` (` +
-        `id String, vector Array(Float32), metadata String DEFAULT '{}', ` +
+        `id String, vector Array(Float32), metadata String DEFAULT '{}', _v Int64, ` +
         `INDEX vec_idx vector TYPE vector_similarity('hnsw', '${fn}', ${dim}) GRANULARITY 1` +
-        `) ENGINE = MergeTree ORDER BY id`,
+        `) ENGINE = ReplacingMergeTree(_v) ORDER BY id`,
       'CSV',
     )
     await this.#session.queryBindAsync(
-      `INSERT INTO ${META_TABLE} (name, dimension, metric) VALUES ({n:String}, {d:UInt32}, {m:String})`,
-      { n: indexName, d: dim, m: metric },
+      `INSERT INTO ${META_TABLE} (name, dimension, metric, _updated) VALUES ({n:String}, {d:UInt32}, {m:String}, {u:Int64})`,
+      { n: indexName, d: dim, m: metric, u: Date.now() },
       { format: 'CSV' },
     )
   }
@@ -66,17 +67,16 @@ export class ChDBVector extends MastraVector {
   async upsert({ indexName, vectors, metadata, ids }) {
     assertIdent(indexName)
     if (!Array.isArray(vectors) || vectors.length === 0) return []
-    const outIds = vectors.map((_, i) => (ids && ids[i] != null ? String(ids[i]) : cryptoId()))
-    // True upsert: drop any existing rows for these ids, then insert.
-    await this.#session.queryBindAsync(
-      `DELETE FROM \`${indexName}\` WHERE id IN {ids:Array(String)}`,
-      { ids: outIds },
-      { format: 'CSV' },
-    )
-    const rows = vectors.map((v, i) => ({
+    const outIds = vectors.map((_, i) => (ids && ids[i] != null ? String(ids[i]) : randomUUID()))
+    // Idempotent upsert without a separate DELETE: ReplacingMergeTree(_v) keeps the
+    // highest _v per id, and reads use FINAL — so a re-inserted id resolves to the
+    // latest row (no async-DELETE race, no transient duplicates).
+    const v = Date.now()
+    const rows = vectors.map((vec, i) => ({
       id: outIds[i],
-      vector: Array.from(v, Number),
+      vector: Array.from(vec, Number),
       metadata: JSON.stringify(metadata && metadata[i] ? metadata[i] : {}),
+      _v: v,
     }))
     await this.#session.insert({ table: indexName, values: rows })
     return outIds
@@ -88,11 +88,11 @@ export class ChDBVector extends MastraVector {
     const where = filterToSql(filter)
     const cols = includeVector ? 'id, metadata, vector' : 'id, metadata'
     const sql =
-      `SELECT ${cols}, ${fn}(vector, {q:Array(Float32)}) AS _dist FROM \`${indexName}\`` +
+      `SELECT ${cols}, ${fn}(vector, {q:Array(Float32)}) AS _dist FROM \`${indexName}\` FINAL` +
       `${where} ORDER BY _dist ASC LIMIT {k:UInt32}`
     const res = await this.#session.queryBindAsync(
       sql,
-      { q: Array.from(queryVector, Number), k: topK | 0 },
+      { q: Array.from(queryVector, Number), k: Math.max(1, Math.floor(Number(topK) || 10)) },
       { format: 'JSON' },
     )
     const data = res.json()?.data ?? []
@@ -120,7 +120,7 @@ export class ChDBVector extends MastraVector {
     )
     const meta = m.json()?.data?.[0]
     if (!meta) throw new Error(`ChDBVector: index '${indexName}' does not exist`)
-    const c = await this.#session.queryAsync(`SELECT count() AS c FROM \`${indexName}\``, { format: 'JSON' })
+    const c = await this.#session.queryAsync(`SELECT count() AS c FROM \`${indexName}\` FINAL`, { format: 'JSON' })
     return { dimension: Number(meta.dimension), count: Number(c.json()?.data?.[0]?.c ?? 0), metric: meta.metric }
   }
 
@@ -147,7 +147,7 @@ export class ChDBVector extends MastraVector {
     if (id == null) throw new Error('ChDBVector: updateVector requires an id')
     // Read the existing row so a metadata-only or vector-only update preserves the other field.
     const res = await this.#session.queryBindAsync(
-      `SELECT vector, metadata FROM \`${indexName}\` WHERE id = {id:String} LIMIT 1`,
+      `SELECT vector, metadata FROM \`${indexName}\` FINAL WHERE id = {id:String} LIMIT 1`,
       { id: String(id) },
       { format: 'JSON' },
     )
@@ -169,11 +169,6 @@ export class ChDBVector extends MastraVector {
   }
 }
 
-function cryptoId() {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  return require('crypto').randomUUID()
-}
-
 function safeJson(s) {
   try {
     return s ? JSON.parse(s) : {}
@@ -192,7 +187,10 @@ function filterToSql(filter) {
       throw new Error(`ChDBVector: operator filters are not supported yet (key ${JSON.stringify(k)})`)
     }
     if (!IDENT.test(k)) throw new Error(`ChDBVector: invalid filter key ${JSON.stringify(k)}`)
-    const lit = typeof v === 'number' || typeof v === 'boolean' ? String(v) : `'${String(v).replace(/'/g, "''")}'`
+    const lit =
+      typeof v === 'number' || typeof v === 'boolean'
+        ? String(v)
+        : `'${String(v).replace(/\\/g, '\\\\').replace(/'/g, "''")}'`
     parts.push(`JSONExtractString(metadata, '${k}') = ${lit}`)
   }
   return ` WHERE ${parts.join(' AND ')}`

--- a/integrations/mastra.d.mts
+++ b/integrations/mastra.d.mts
@@ -9,10 +9,37 @@ export interface ChdbToolOptions {
   maxRows?: number
 }
 
-/** A schema-aware chDB toolset for Mastra: { chdbQuery, chdbListTables, chdbDescribeSource }. */
-export function chdbTools(opts?: ChdbToolOptions): Record<string, unknown>
+export interface ChdbQueryResult {
+  rows: Array<Record<string, unknown>>
+  rowCount: number
+  truncated: boolean
+  error?: string
+}
+export interface ChdbListTablesResult {
+  tables: string[]
+  error?: string
+}
+export interface ChdbDescribeResult {
+  columns: Array<{ name: string; type: string }>
+  error?: string
+}
+
+/** A Mastra tool whose `execute` resolves to a typed result `T`. */
+export interface ChdbTool<T> {
+  id: string
+  description: string
+  execute(input: Record<string, unknown>): Promise<T>
+  [key: string]: unknown
+}
+
+/** A schema-aware chDB toolset for Mastra agents. */
+export function chdbTools(opts?: ChdbToolOptions): {
+  chdbQuery: ChdbTool<ChdbQueryResult>
+  chdbListTables: ChdbTool<ChdbListTablesResult>
+  chdbDescribeSource: ChdbTool<ChdbDescribeResult>
+}
 /** Just the read-only query tool. */
-export function chdbQueryTool(opts?: ChdbToolOptions): unknown
+export function chdbQueryTool(opts?: ChdbToolOptions): ChdbTool<ChdbQueryResult>
 export default chdbTools
 
 export interface ChDBVectorOptions {

--- a/integrations/mastra.d.mts
+++ b/integrations/mastra.d.mts
@@ -1,0 +1,52 @@
+import type { Session } from '../index.js'
+
+export interface ChdbToolOptions {
+  /** A chdb Session whose data to query. Defaults to the in-process default connection. */
+  session?: Session
+  /** Allow writes/DDL. Default false: reads run on an engine-level read-only session. */
+  allowWrite?: boolean
+  /** Cap on rows returned to the model (default 1000); `truncated` flags when hit. */
+  maxRows?: number
+}
+
+/** A schema-aware chDB toolset for Mastra: { chdbQuery, chdbListTables, chdbDescribeSource }. */
+export function chdbTools(opts?: ChdbToolOptions): Record<string, unknown>
+/** Just the read-only query tool. */
+export function chdbQueryTool(opts?: ChdbToolOptions): unknown
+export default chdbTools
+
+export interface ChDBVectorOptions {
+  /** Reuse a chdb Session, or omit to bind a fresh one. */
+  session?: Session
+  /** On-disk path for a new Session (':memory:' default) when `session` is omitted. */
+  path?: string
+  /** Store id (Mastra base id). */
+  id?: string
+}
+
+export interface ChDBQueryResult {
+  id: string
+  score: number
+  metadata?: Record<string, unknown>
+  vector?: number[]
+}
+
+/**
+ * A Mastra vector store backed by chDB's `vector_similarity` (HNSW) index — similarity
+ * search is index-accelerated ANN, not a brute-force distance scan. Implements the
+ * Mastra `MastraVector` contract (createIndex / upsert / query / describeIndex /
+ * listIndexes / deleteIndex / updateVector / deleteVector / deleteVectors).
+ * Metrics: 'cosine' (default) and 'euclidean'.
+ */
+export class ChDBVector {
+  constructor(opts?: ChDBVectorOptions)
+  createIndex(params: { indexName: string; dimension: number; metric?: 'cosine' | 'euclidean' }): Promise<void>
+  upsert(params: { indexName: string; vectors: number[][]; metadata?: Record<string, unknown>[]; ids?: string[] }): Promise<string[]>
+  query(params: { indexName: string; queryVector: number[]; topK?: number; filter?: Record<string, unknown>; includeVector?: boolean }): Promise<ChDBQueryResult[]>
+  listIndexes(): Promise<string[]>
+  describeIndex(params: { indexName: string }): Promise<{ dimension: number; count: number; metric?: string }>
+  deleteIndex(params: { indexName: string }): Promise<void>
+  updateVector(params: { indexName: string; id: string; update: { vector?: number[]; metadata?: Record<string, unknown> } }): Promise<void>
+  deleteVector(params: { indexName: string; id: string }): Promise<void>
+  deleteVectors(params: { indexName: string; filter: Record<string, unknown> }): Promise<void>
+}

--- a/integrations/mastra.d.mts
+++ b/integrations/mastra.d.mts
@@ -50,3 +50,23 @@ export class ChDBVector {
   deleteVector(params: { indexName: string; id: string }): Promise<void>
   deleteVectors(params: { indexName: string; filter: Record<string, unknown> }): Promise<void>
 }
+
+export interface ChDBStoreOptions {
+  /** Reuse a chdb Session, or omit to bind a fresh one. */
+  session?: Session
+  /** On-disk path for a new Session (':memory:' default) when `session` is omitted. */
+  path?: string
+  /** Storage id (Mastra base id). */
+  id?: string
+}
+
+/**
+ * A Mastra storage adapter backed by chDB, scoped to the memory (threads/messages)
+ * and observability (AI tracing spans) domains — the columnar-friendly ones; AI
+ * trace/span data becomes analytically queryable with SQL. Records are stored as
+ * JSON in ReplacingMergeTree tables (upsert by id / (traceId,spanId)). Other Mastra
+ * domains are not implemented — compose another backend for them.
+ */
+export class ChDBStore {
+  constructor(opts?: ChDBStoreOptions)
+}

--- a/integrations/mastra.mjs
+++ b/integrations/mastra.mjs
@@ -20,6 +20,7 @@ import {
 } from './chdb-tool-core.mjs'
 
 export { ChDBVector } from './chdb-vector.mjs'
+export { ChDBStore } from './chdb-store.mjs'
 
 const rowsOutput = z.object({
   rows: z.array(z.record(z.string(), z.any())),

--- a/integrations/mastra.mjs
+++ b/integrations/mastra.mjs
@@ -1,0 +1,73 @@
+// Mastra integration for chDB. Import from 'chdb/mastra'.
+//
+//   import { chdbTools, ChDBVector } from 'chdb/mastra'
+//   import { Session } from 'chdb'
+//   const db = new Session('./db')
+//   const agent = new Agent({ name: 'analyst', model, tools: chdbTools({ session: db }) })
+//   const store = new ChDBVector({ session: db })   // RAG vector store (HNSW index)
+//
+// `@mastra/core` and `zod` are optional peer dependencies — install them in your app.
+
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+import {
+  createChdbExecutor,
+  CHDB_QUERY_DESCRIPTION,
+  CHDB_LIST_TABLES_DESCRIPTION,
+  CHDB_DESCRIBE_DESCRIPTION,
+  CHDB_SQL_FIELD_DESCRIPTION,
+  CHDB_SOURCE_FIELD_DESCRIPTION,
+} from './chdb-tool-core.mjs'
+
+export { ChDBVector } from './chdb-vector.mjs'
+
+const rowsOutput = z.object({
+  rows: z.array(z.record(z.string(), z.any())),
+  rowCount: z.number(),
+  truncated: z.boolean(),
+  error: z.string().optional(),
+})
+
+// Mastra passes inputs under `.context`; fall back to the bare object for older versions.
+const field = (input, name) => (input && input.context && input.context[name]) ?? (input && input[name])
+
+/**
+ * A schema-aware chDB toolset for Mastra agents (discover → inspect → read-only query).
+ * @param {{ session?: object, allowWrite?: boolean, maxRows?: number }} [opts]
+ */
+export function chdbTools(opts = {}) {
+  const ex = createChdbExecutor(opts)
+  return {
+    chdbQuery: createTool({
+      id: 'chdb-query',
+      description: CHDB_QUERY_DESCRIPTION,
+      inputSchema: z.object({ sql: z.string().describe(CHDB_SQL_FIELD_DESCRIPTION) }),
+      outputSchema: rowsOutput,
+      execute: async (input) => ex.query(field(input, 'sql')),
+    }),
+    chdbListTables: createTool({
+      id: 'chdb-list-tables',
+      description: CHDB_LIST_TABLES_DESCRIPTION,
+      inputSchema: z.object({}),
+      outputSchema: z.object({ tables: z.array(z.string()), error: z.string().optional() }),
+      execute: async () => ex.listTables(),
+    }),
+    chdbDescribeSource: createTool({
+      id: 'chdb-describe-source',
+      description: CHDB_DESCRIBE_DESCRIPTION,
+      inputSchema: z.object({ source: z.string().describe(CHDB_SOURCE_FIELD_DESCRIPTION) }),
+      outputSchema: z.object({
+        columns: z.array(z.object({ name: z.string(), type: z.string() })),
+        error: z.string().optional(),
+      }),
+      execute: async (input) => ex.describeSource(field(input, 'source')),
+    }),
+  }
+}
+
+/** Just the query tool, for when you only want one. */
+export function chdbQueryTool(opts = {}) {
+  return chdbTools(opts).chdbQuery
+}
+
+export default chdbTools

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,50 +1,273 @@
 {
   "name": "chdb",
-  "version": "3.1.0-rc.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chdb",
-      "version": "3.1.0-rc.1",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@clickhouse/client-common": "^1.22.0",
         "node-addon-api": "^6.1.0",
         "node-gyp-build": "^4.6.0"
       },
+      "bin": {
+        "chdb-gen-types": "dist/layer3/codegen/cli.js"
+      },
       "devDependencies": {
-        "@clickhouse/client-common": "^1.22.0",
+        "@mastra/core": "^1.47.0",
         "@types/node": "^20.14.0",
+        "ai": "^7.0.2",
         "apache-arrow": "^21.1.0",
         "chai": "^4.5.0",
         "mocha": "^10.7.3",
         "node-gyp": "^9.3.1",
         "typescript": "^5.5.0",
-        "vitest": "^2.0.0"
+        "vitest": "^2.0.0",
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@chdb/lib-darwin-arm64": "26.5.1-rc.1",
-        "@chdb/lib-darwin-x64": "26.5.1-rc.1",
-        "@chdb/lib-linux-arm64-gnu": "26.5.1-rc.1",
-        "@chdb/lib-linux-x64-gnu": "26.5.1-rc.1"
+        "@chdb/lib-darwin-arm64": "26.5.2",
+        "@chdb/lib-darwin-x64": "26.5.2",
+        "@chdb/lib-linux-arm64-gnu": "26.5.2",
+        "@chdb/lib-linux-x64-gnu": "26.5.2"
       },
       "peerDependencies": {
-        "apache-arrow": ">=14"
+        "@mastra/core": ">=0.10",
+        "ai": ">=5",
+        "apache-arrow": ">=14",
+        "zod": ">=3"
       },
       "peerDependenciesMeta": {
+        "@mastra/core": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
         "apache-arrow": {
+          "optional": true
+        },
+        "zod": {
           "optional": true
         }
       }
     },
+    "node_modules/@a2a-js/sdk": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.13.tgz",
+      "integrity": "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.2.tgz",
+      "integrity": "sha512-Jz1BiiTSvhDsCBJrkFRSqLHDRMVjFtYk9GdbSi3UOqY+/epza+oIESMDzfN4m+YHT/1IYmNEmxaMfjXOvxKDjQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.0",
+        "@ai-sdk/provider-utils": "5.0.0",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.0.tgz",
+      "integrity": "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.0.tgz",
+      "integrity": "sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.0",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v5": {
+      "name": "@ai-sdk/provider-utils",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.25.tgz",
+      "integrity": "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.3",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v5/node_modules/@ai-sdk/provider": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v6": {
+      "name": "@ai-sdk/provider-utils",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v6/node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils-v7": {
+      "name": "@ai-sdk/provider-utils",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.0.tgz",
+      "integrity": "sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.0",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-v5": {
+      "name": "@ai-sdk/provider",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-v6": {
+      "name": "@ai-sdk/provider",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-v7": {
+      "name": "@ai-sdk/provider",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.0.tgz",
+      "integrity": "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@chdb/lib-darwin-arm64": {
-      "version": "26.5.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@chdb/lib-darwin-arm64/-/lib-darwin-arm64-26.5.1-rc.1.tgz",
-      "integrity": "sha512-OsGlc7Y+xjG/C6tYHPrEXdzlC5vRAWHGa7CATTFpjq3McefwbGJqHNvnTFuMPObv1WK0zSDep1acsJOq9QSfWw==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@chdb/lib-darwin-arm64/-/lib-darwin-arm64-26.5.2.tgz",
+      "integrity": "sha512-dJGw6uLmBQegU0ddWsG2N9E+uSKCW0CJqYBZK5qlz+D9hXxGGnm7Ox8Uo/nQ870Q/1qKbrTF2Zp9BOEHokluhQ==",
       "cpu": [
         "arm64"
       ],
@@ -55,9 +278,9 @@
       ]
     },
     "node_modules/@chdb/lib-darwin-x64": {
-      "version": "26.5.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@chdb/lib-darwin-x64/-/lib-darwin-x64-26.5.1-rc.1.tgz",
-      "integrity": "sha512-X6YzNT+eLudVAorAas7cAi+O48/8lgV990Yc5xuY22ydn3GI9ggUat93Ew9pGzy11Lx1JyrWp9PNvsKNTUWTgQ==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@chdb/lib-darwin-x64/-/lib-darwin-x64-26.5.2.tgz",
+      "integrity": "sha512-uY1AHR2oZyEBG1fKT24JrYO/UK8fmKNXYA7pp3jfIuKTEetz2ssIrImRJb8zMRIMWQkFcso8CwpIYrmQ0PleSg==",
       "cpu": [
         "x64"
       ],
@@ -68,9 +291,9 @@
       ]
     },
     "node_modules/@chdb/lib-linux-arm64-gnu": {
-      "version": "26.5.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@chdb/lib-linux-arm64-gnu/-/lib-linux-arm64-gnu-26.5.1-rc.1.tgz",
-      "integrity": "sha512-dxl6YAFhvBiN+xFbhHL15ibLm2oX5d0jOIf7yiw9Zypna64K763H2ixloWBx97tZWGlTLcHSR8DwM8wKDwjP0w==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@chdb/lib-linux-arm64-gnu/-/lib-linux-arm64-gnu-26.5.2.tgz",
+      "integrity": "sha512-BayHMFnyxGp3/na9Wz3jfhXk6SxY+Kxv3u7pVsZ67JViDkAhMdVTGAcGvNbv9HESrC65mk0r4yjhaz5HB9pEGg==",
       "cpu": [
         "arm64"
       ],
@@ -84,9 +307,9 @@
       ]
     },
     "node_modules/@chdb/lib-linux-x64-gnu": {
-      "version": "26.5.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@chdb/lib-linux-x64-gnu/-/lib-linux-x64-gnu-26.5.1-rc.1.tgz",
-      "integrity": "sha512-8g/P+cPX7vp1tLl3dFDDoEXuRZrevQqINfJX9DMk4uL/qPXhM5r8GDsaM8ObAai2o/L6g/cfS1/KHZ7PEl8Png==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@chdb/lib-linux-x64-gnu/-/lib-linux-x64-gnu-26.5.2.tgz",
+      "integrity": "sha512-yOUe6xu1HpkB21KFOn4MNx16SQtPnuVm5zYR3dFjIYtBf4tvapdJuHcHlKLSVgu1z5hGoI4oca/URFLSy9C4ow==",
       "cpu": [
         "x64"
       ],
@@ -103,7 +326,6 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.22.0.tgz",
       "integrity": "sha512-MQgXRhoYXut6GhRrTJlub42bnPX7+5Vm+5gHNR0zZXU5+EwZKsBgMXiWXPOerAmQd3weGKm8hzoeZJCfU3Cw2w==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -503,12 +725,289 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-2.1.5.tgz",
+      "integrity": "sha512-VwGZqqjAWPICTmxUZnbpEfO60LhPWzquik+bmyXGY7pYRn6diEvCI5i6Ca+J6o2y4vS73HrpuMTo2dOvUevH8w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mastra/core": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@mastra/core/-/core-1.47.0.tgz",
+      "integrity": "sha512-Xof13mCdwxOjNQywMWUG1ELTZuvJgAhE4m+67C6Cp4Y5XRfXD8Knb4CKv1M/JEfsPvaHLkUYZgBkwqTbf9zDzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@a2a-js/sdk": "~0.3.13",
+        "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.25",
+        "@ai-sdk/provider-utils-v6": "npm:@ai-sdk/provider-utils@4.0.27",
+        "@ai-sdk/provider-utils-v7": "npm:@ai-sdk/provider-utils@5.0.0",
+        "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.3",
+        "@ai-sdk/provider-v6": "npm:@ai-sdk/provider@3.0.10",
+        "@ai-sdk/provider-v7": "npm:@ai-sdk/provider@4.0.0",
+        "@ai-sdk/ui-utils-v5": "npm:@ai-sdk/ui-utils@1.2.11",
+        "@isaacs/ttlcache": "^2.1.4",
+        "@lukeed/uuid": "^2.0.1",
+        "@mastra/schema-compat": "1.3.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@sindresorhus/slugify": "^2.2.1",
+        "@standard-schema/spec": "^1.1.0",
+        "ajv": "^8.20.0",
+        "chat": "^4.29.0",
+        "croner": "^10.0.1",
+        "dotenv": "^17.3.1",
+        "execa": "^9.6.1",
+        "fastq": "^1.20.1",
+        "gray-matter": "^4.0.3",
+        "ignore": "^7.0.5",
+        "jpeg-js": "^0.4.4",
+        "json-schema": "^0.4.0",
+        "lru-cache": "^11.2.7",
+        "p-map": "^7.0.4",
+        "p-retry": "^7.1.1",
+        "picomatch": "^4.0.3",
+        "posthog-node": "^5.37.0",
+        "tokenx": "^1.3.0",
+        "ws": "^8.20.0",
+        "xxhash-wasm": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@mastra/core/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mastra/core/node_modules/@ai-sdk/ui-utils-v5": {
+      "name": "@ai-sdk/ui-utils",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@mastra/core/node_modules/@ai-sdk/ui-utils-v5/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@mastra/core/node_modules/@workflow/serde": {
+      "version": "4.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0-beta.2.tgz",
+      "integrity": "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@mastra/core/node_modules/chat": {
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/chat/-/chat-4.31.0.tgz",
+      "integrity": "sha512-F6oJq9JUraLFkITS96/NKgwZwBfZX8aOwOj5qMs5NNwnOGHrSXZ5+osK+EA4HjzfyUEDfFTNiOSmyzgtFLpuWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@workflow/serde": "4.1.0-beta.2",
+        "mdast-util-to-string": "^4.0.0",
+        "remark-gfm": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "remend": "^1.2.1",
+        "unified": "^11.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "ai": "^6.0.182",
+        "zod": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ai": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mastra/core/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@mastra/core/node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mastra/core/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@mastra/schema-compat": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mastra/schema-compat/-/schema-compat-1.3.1.tgz",
+      "integrity": "sha512-OEQ2jak1OvWiWCgm13Qps4IHNNGeHS4Hx+3+uh0Zw1SsCA9f3gZBd6hNAXGJcxXHO0AT/4aqO94UDZEPQSNfCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema-to-zod": "^2.7.0",
+        "zod-from-json-schema": "^0.5.2",
+        "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@npmcli/fs": {
       "version": "2.1.2",
@@ -536,6 +1035,23 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.38.0.tgz",
+      "integrity": "sha512-QLrJh0hMVpEJXHNyiJR9YhvIO5tzLDedw4UHdvB+ub4fXHMtHCA8H44qgl11HWR3ajpjxtJ8hs3HyOGVF3Zc1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.391.1"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.391.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.391.1.tgz",
+      "integrity": "sha512-ASwd7Nf4pViqdYRYaNRyPYRVKWa1CcHUAUWR0XeQJLGdNnsWACBwe0sSieb/cHnKsRXjRwO/23KIY83lm/Ccpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.61.0",
@@ -887,6 +1403,92 @@
         "win32"
       ]
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/slugify": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
+      "integrity": "sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/transliterate": "^1.0.0",
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/slugify/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/transliterate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz",
+      "integrity": "sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/transliterate/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
@@ -920,10 +1522,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -935,6 +1564,23 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1121,11 +1767,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -1164,6 +1841,59 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.2.tgz",
+      "integrity": "sha512-VMU08jHIDJnnKDrbC9AFa5ZsPpOTfAPRLvTRHtJk4FGAoeldmJROMxvZ2ak5lCjEJ2GP2OLPQbMRyEK8w0+S4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.2",
+        "@ai-sdk/provider": "4.0.0",
+        "@ai-sdk/provider-utils": "5.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-colors": {
@@ -1294,6 +2024,17 @@
         "node": "*"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1310,6 +2051,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -1340,6 +2137,16 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1421,6 +2228,37 @@
         "node": ">=10"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -1431,6 +2269,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chai": {
@@ -1493,6 +2342,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -1639,6 +2499,103 @@
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "dev": true
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/croner": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+      "integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "other",
+          "url": "https://paypal.me/hexagonpp"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/hexagon"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1669,6 +2626,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -1696,6 +2667,30 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/diff": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
@@ -1705,11 +2700,56 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -1736,12 +2776,45 @@
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1791,6 +2864,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -1803,6 +2883,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1811,6 +2905,92 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/expect-type": {
@@ -1823,6 +3003,152 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1833,6 +3159,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-replace": {
@@ -1885,6 +3233,26 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -1915,6 +3283,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gauge": {
@@ -1954,6 +3332,62 @@
         "node": "*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1986,11 +3420,64 @@
         "node": ">= 6"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2001,11 +3488,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -2016,11 +3529,42 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -2049,6 +3593,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -2069,6 +3623,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/imurmurhash": {
@@ -2112,13 +3676,23 @@
       "dev": true
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-binary-path": {
@@ -2131,6 +3705,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -2169,6 +3753,19 @@
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2185,6 +3782,26 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -2205,6 +3822,23 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2224,6 +3858,47 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-zod": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.8.1.tgz",
+      "integrity": "sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "json-schema-to-zod": "dist/cjs/cli.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/locate-path": {
@@ -2262,6 +3937,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/loupe": {
@@ -2317,6 +4003,881 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/minimatch": {
@@ -2608,6 +5169,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/npmlog": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
@@ -2621,6 +5212,42 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -2677,6 +5304,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2693,6 +5359,27 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -2730,6 +5417,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -2759,6 +5456,43 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-node": {
+      "version": "5.38.6",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.38.6.tgz",
+      "integrity": "sha512-Sm2mCAa9/lTTYppnKyy0AhQrriq8fOd8B2vwd3EE/9uihyIx9qkJ1xGYbvADxQJlF7HqM1/TIFCKsI0JvF8gjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.38.0"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -2778,6 +5512,37 @@
         "node": ">=10"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2785,6 +5550,53 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/readable-stream": {
@@ -2813,11 +5625,80 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remend": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/remend/-/remend-1.3.0.tgz",
+      "integrity": "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2829,6 +5710,17 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rimraf": {
@@ -2891,6 +5783,23 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2915,8 +5824,28 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
       "dev": true,
-      "optional": true
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -2945,6 +5874,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -2954,11 +5910,137 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -3022,6 +6104,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ssri": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -3040,6 +6129,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -3081,6 +6180,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3207,6 +6329,34 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tokenx": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tokenx/-/tokenx-1.3.0.tgz",
+      "integrity": "sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3221,6 +6371,39 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -3254,6 +6437,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
@@ -3278,11 +6507,134 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -3577,6 +6929,35 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -3644,6 +7025,81 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-from-json-schema": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/zod-from-json-schema/-/zod-from-json-schema-0.5.3.tgz",
+      "integrity": "sha512-44YFiuq+WHw9YZQAo/Ad0F7o9c/im0Q6cnHI23BsXhEmZtkNn4cD0bljLMMjkfb/EidopPWdsmKI8EvLHX5ZyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.0.17"
+      }
+    },
+    "node_modules/zod-from-json-schema-v3": {
+      "name": "zod-from-json-schema",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/zod-from-json-schema/-/zod-from-json-schema-0.0.5.tgz",
+      "integrity": "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/zod-from-json-schema-v3/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,14 @@
       "require": "./dist/connection/index.js",
       "default": "./dist/connection/index.js"
     },
+    "./ai-sdk": {
+      "types": "./integrations/ai-sdk.d.mts",
+      "import": "./integrations/ai-sdk.mjs"
+    },
+    "./mastra": {
+      "types": "./integrations/mastra.d.mts",
+      "import": "./integrations/mastra.mjs"
+    },
     "./package.json": "./package.json"
   },
   "repository": {
@@ -55,16 +63,20 @@
     "AGENTS.md",
     "llms-full.txt",
     "src/layer3/AGENTS.md",
-    "src/connection/AGENTS.md"
+    "src/connection/AGENTS.md",
+    "integrations"
   ],
   "devDependencies": {
+    "@mastra/core": "^1.47.0",
     "@types/node": "^20.14.0",
+    "ai": "^7.0.2",
     "apache-arrow": "^21.1.0",
     "chai": "^4.5.0",
     "mocha": "^10.7.3",
     "node-gyp": "^9.3.1",
     "typescript": "^5.5.0",
-    "vitest": "^2.0.0"
+    "vitest": "^2.0.0",
+    "zod": "^4.4.3"
   },
   "dependencies": {
     "@clickhouse/client-common": "^1.22.0",
@@ -78,10 +90,22 @@
     "@chdb/lib-linux-x64-gnu": "26.5.2"
   },
   "peerDependencies": {
-    "apache-arrow": ">=14"
+    "@mastra/core": ">=0.10",
+    "ai": ">=5",
+    "apache-arrow": ">=14",
+    "zod": ">=3"
   },
   "peerDependenciesMeta": {
     "apache-arrow": {
+      "optional": true
+    },
+    "ai": {
+      "optional": true
+    },
+    "@mastra/core": {
+      "optional": true
+    },
+    "zod": {
       "optional": true
     }
   },

--- a/test/v3/integrations/ai-sdk.test.ts
+++ b/test/v3/integrations/ai-sdk.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Session } from '../../../index.js'
+// @ts-expect-error - .mjs adapter has a sibling .d.mts; vitest resolves the runtime file
+import { chdbTools, chdbQueryTool } from '../../../integrations/ai-sdk.mjs'
+
+// The Vercel AI SDK adapter wraps the shared executors: a schema-aware toolset
+// (query / listTables / describeSource) with engine-level read-only by default.
+
+const callOpts = { toolCallId: 't', messages: [] }
+let db: Session
+
+beforeEach(() => {
+  db = new Session()
+  db.query(`CREATE TABLE t (id UInt64, name String) ENGINE = MergeTree ORDER BY id`)
+  db.query(`INSERT INTO t VALUES (1, 'Alice'), (2, 'Bob')`)
+})
+
+describe('chdb/ai-sdk', () => {
+  it('exposes a three-tool toolset', () => {
+    const tools = chdbTools({ session: db })
+    expect(Object.keys(tools).sort()).toEqual(['chdbDescribeSource', 'chdbListTables', 'chdbQuery'])
+    for (const t of Object.values(tools) as any[]) expect(typeof t.execute).toBe('function')
+  })
+
+  it('chdbQuery runs SQL and returns rows', async () => {
+    const { chdbQuery } = chdbTools({ session: db }) as any
+    const out = await chdbQuery.execute({ sql: 'SELECT id, name FROM t ORDER BY id' }, callOpts)
+    expect(out.error).toBeUndefined()
+    expect(out.rowCount).toBe(2)
+    expect(out.rows).toEqual([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ])
+  })
+
+  it('chdbListTables and chdbDescribeSource expose the schema', async () => {
+    const { chdbListTables, chdbDescribeSource } = chdbTools({ session: db }) as any
+    const tables = await chdbListTables.execute({}, callOpts)
+    expect(tables.tables).toContain('t')
+    const desc = await chdbDescribeSource.execute({ source: 't' }, callOpts)
+    expect(desc.columns).toEqual([
+      { name: 'id', type: 'UInt64' },
+      { name: 'name', type: 'String' },
+    ])
+  })
+
+  it('is read-only by default — a write is rejected by the engine', async () => {
+    const { chdbQuery } = chdbTools({ session: db }) as any
+    const out = await chdbQuery.execute({ sql: "INSERT INTO t VALUES (3, 'Eve')" }, callOpts)
+    expect(out.rows).toEqual([])
+    expect(out.error).toMatch(/readonly|read-only|Cannot/i)
+  })
+
+  it('returns the engine error instead of throwing', async () => {
+    const tool = chdbQueryTool({ session: db }) as any
+    const out = await tool.execute({ sql: 'SELECT * FROM does_not_exist' }, callOpts)
+    expect(out.rows).toEqual([])
+    expect(typeof out.error).toBe('string')
+  })
+})

--- a/test/v3/integrations/ai-sdk.test.ts
+++ b/test/v3/integrations/ai-sdk.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { Session } from '../../../index.js'
-// @ts-expect-error - .mjs adapter has a sibling .d.mts; vitest resolves the runtime file
+// @ts-ignore - .mjs adapter has a sibling .d.mts; vitest resolves the runtime file
 import { chdbTools, chdbQueryTool } from '../../../integrations/ai-sdk.mjs'
 
 // The Vercel AI SDK adapter wraps the shared executors: a schema-aware toolset

--- a/test/v3/integrations/chdb-store.test.ts
+++ b/test/v3/integrations/chdb-store.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Session } from '../../../index.js'
+// @ts-expect-error - .mjs adapter resolved at runtime
+import { ChDBStore } from '../../../integrations/chdb-store.mjs'
+
+// ChDBStore (Mastra storage) — memory (threads/messages) + observability (AI spans),
+// ReplacingMergeTree-backed. Round-trips records and proves the analytical value
+// (aggregate over spans with SQL).
+
+let db: Session
+let store: any
+
+beforeEach(() => {
+  db = new Session()
+  store = new ChDBStore({ session: db })
+})
+
+const thread = (id: string, resourceId = 'r1') => ({
+  id,
+  resourceId,
+  title: `t-${id}`,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  metadata: { tag: 'x' },
+})
+const msg = (id: string, threadId: string, n: number) => ({
+  id,
+  threadId,
+  resourceId: 'r1',
+  role: 'user',
+  content: { format: 2, parts: [{ type: 'text', text: `m${n}` }] },
+  createdAt: new Date(Date.parse('2026-01-01T00:00:00Z') + n * 1000),
+})
+const span = (traceId: string, spanId: string, parentSpanId: string | null, name: string) => ({
+  traceId,
+  spanId,
+  parentSpanId,
+  name,
+  spanType: 'agent_run',
+  isEvent: false,
+  startedAt: new Date(),
+})
+
+describe('ChDBStore — memory', () => {
+  it('saves and reads back a thread', async () => {
+    await store.stores.memory.saveThread({ thread: thread('th1') })
+    const got = await store.stores.memory.getThreadById({ threadId: 'th1' })
+    expect(got.id).toBe('th1')
+    expect(got.title).toBe('t-th1')
+    expect(got.createdAt).toBeInstanceOf(Date)
+  })
+
+  it('updateThread merges title + metadata', async () => {
+    await store.stores.memory.saveThread({ thread: thread('th1') })
+    const up = await store.stores.memory.updateThread({ id: 'th1', title: 'new', metadata: { extra: 1 } })
+    expect(up.title).toBe('new')
+    expect(up.metadata).toEqual({ tag: 'x', extra: 1 })
+  })
+
+  it('saves messages and lists them in order', async () => {
+    await store.stores.memory.saveThread({ thread: thread('th1') })
+    await store.stores.memory.saveMessages({ messages: [msg('m2', 'th1', 2), msg('m1', 'th1', 1)] })
+    const { messages, total } = await store.stores.memory.listMessages({ threadId: 'th1' })
+    expect(total).toBe(2)
+    expect(messages.map((m: any) => m.id)).toEqual(['m1', 'm2']) // by createdAt asc
+  })
+
+  it('lists threads filtered by resourceId, and deletes', async () => {
+    await store.stores.memory.saveThread({ thread: thread('a', 'r1') })
+    await store.stores.memory.saveThread({ thread: thread('b', 'r2') })
+    const { threads } = await store.stores.memory.listThreads({ filter: { resourceId: 'r1' } })
+    expect(threads.map((t: any) => t.id)).toEqual(['a'])
+    await store.stores.memory.deleteThread({ threadId: 'a' })
+    expect(await store.stores.memory.getThreadById({ threadId: 'a' })).toBeNull()
+  })
+})
+
+describe('ChDBStore — observability', () => {
+  it('stores spans and reads a trace', async () => {
+    await store.stores.observability.createSpan({ span: span('tr1', 's0', null, 'root') })
+    await store.stores.observability.batchCreateSpans({
+      records: [span('tr1', 's1', 's0', 'child-a'), span('tr1', 's2', 's0', 'child-b')],
+    })
+    const trace = await store.stores.observability.getTrace({ traceId: 'tr1' })
+    expect(trace.spans).toHaveLength(3)
+    const root = await store.stores.observability.getRootSpan({ traceId: 'tr1' })
+    expect(root.span.spanId).toBe('s0')
+  })
+
+  it('updateSpan merges and listTraces returns roots with status', async () => {
+    await store.stores.observability.createSpan({ span: span('tr1', 's0', null, 'root') })
+    await store.stores.observability.updateSpan({ traceId: 'tr1', spanId: 's0', updates: { endedAt: new Date() } })
+    const got = await store.stores.observability.getSpan({ traceId: 'tr1', spanId: 's0' })
+    expect(got.span.endedAt).toBeInstanceOf(Date)
+    const list = await store.stores.observability.listTraces({})
+    expect(list.spans).toHaveLength(1)
+    expect(list.spans[0].status).toBe('success') // endedAt set, no error
+    expect(list.pagination.total).toBe(1)
+  })
+
+  it('spans are analytically queryable with SQL (the value prop)', async () => {
+    await store.stores.observability.batchCreateSpans({
+      records: [span('tr1', 's0', null, 'a'), span('tr1', 's1', 's0', 'b'), span('tr2', 's0', null, 'c')],
+    })
+    const out = db.query(
+      `SELECT spanType, count() AS n FROM mastra_ai_spans FINAL GROUP BY spanType`,
+      'CSV',
+    )
+    expect(out.trim()).toBe('"agent_run",3')
+  })
+})

--- a/test/v3/integrations/chdb-store.test.ts
+++ b/test/v3/integrations/chdb-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { Session } from '../../../index.js'
-// @ts-expect-error - .mjs adapter resolved at runtime
+// @ts-ignore - .mjs adapter resolved at runtime
 import { ChDBStore } from '../../../integrations/chdb-store.mjs'
 
 // ChDBStore (Mastra storage) — memory (threads/messages) + observability (AI spans),

--- a/test/v3/integrations/chdb-vector.test.ts
+++ b/test/v3/integrations/chdb-vector.test.ts
@@ -51,6 +51,42 @@ describe('ChDBVector', () => {
     expect(res.map((r: any) => r.id)).toEqual(['a'])
   })
 
+  it('filters by numeric and boolean metadata', async () => {
+    await store.createIndex({ indexName: 'docs', dimension: 3 })
+    await store.upsert({
+      indexName: 'docs',
+      vectors: [[0.1, 0.2, 0.3], [0.11, 0.21, 0.31], [0.12, 0.22, 0.32]],
+      metadata: [{ year: 2024, ok: true }, { year: 2023, ok: true }, { year: 2024, ok: false }],
+      ids: ['a', 'b', 'c'],
+    })
+    const byYear = await store.query({ indexName: 'docs', queryVector: [0.1, 0.2, 0.3], topK: 5, filter: { year: 2024 } })
+    expect(byYear.map((r: any) => r.id).sort()).toEqual(['a', 'c'])
+    const byBool = await store.query({ indexName: 'docs', queryVector: [0.1, 0.2, 0.3], topK: 5, filter: { ok: true } })
+    expect(byBool.map((r: any) => r.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('deletes by metadata filter (bound params on the destructive path)', async () => {
+    await store.createIndex({ indexName: 'docs', dimension: 3 })
+    await store.upsert({
+      indexName: 'docs',
+      vectors: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+      metadata: [{ tag: 'drop' }, { tag: 'keep' }, { tag: 'drop' }],
+      ids: ['a', 'b', 'c'],
+    })
+    await store.deleteVectors({ indexName: 'docs', filter: { tag: 'drop' } })
+    expect((await store.describeIndex({ indexName: 'docs' })).count).toBe(1)
+    const res = await store.query({ indexName: 'docs', queryVector: [0, 1, 0], topK: 5 })
+    expect(res.map((r: any) => r.id)).toEqual(['b'])
+  })
+
+  it('rejects a vector whose length does not match the index dimension', async () => {
+    await store.createIndex({ indexName: 'docs', dimension: 3 })
+    await expect(
+      store.upsert({ indexName: 'docs', vectors: [[1, 0]], ids: ['bad'] }),
+    ).rejects.toThrow(/check_dim|[Cc]onstraint/)
+    expect((await store.describeIndex({ indexName: 'docs' })).count).toBe(0)
+  })
+
   it('upsert replaces an existing id (true upsert)', async () => {
     await store.createIndex({ indexName: 'docs', dimension: 3 })
     await store.upsert({ indexName: 'docs', vectors: [[1, 0, 0]], metadata: [{ v: 1 }], ids: ['x'] })

--- a/test/v3/integrations/chdb-vector.test.ts
+++ b/test/v3/integrations/chdb-vector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-// @ts-expect-error - .mjs adapter resolved at runtime; types via the package subpath
+// @ts-ignore - .mjs adapter resolved at runtime; types via the package subpath
 import { ChDBVector } from '../../../integrations/chdb-vector.mjs'
 
 // ChDBVector backed by chDB's vector_similarity (HNSW) index — verifies the store
@@ -72,5 +72,13 @@ describe('ChDBVector', () => {
 
   it('rejects metrics with no index form', async () => {
     await expect(store.createIndex({ indexName: 'd', dimension: 3, metric: 'dotproduct' })).rejects.toThrow(/not supported/)
+  })
+
+  it('generates ids when none are provided (randomUUID, ESM-safe)', async () => {
+    await store.createIndex({ indexName: 'docs', dimension: 2 })
+    const ids = await store.upsert({ indexName: 'docs', vectors: [[1, 0], [0, 1]] })
+    expect(ids).toHaveLength(2)
+    expect(ids[0]).toMatch(/^[0-9a-f-]{36}$/)
+    expect((await store.describeIndex({ indexName: 'docs' })).count).toBe(2)
   })
 })

--- a/test/v3/integrations/chdb-vector.test.ts
+++ b/test/v3/integrations/chdb-vector.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+// @ts-expect-error - .mjs adapter resolved at runtime; types via the package subpath
+import { ChDBVector } from '../../../integrations/chdb-vector.mjs'
+
+// ChDBVector backed by chDB's vector_similarity (HNSW) index — verifies the store
+// contract end to end (create / upsert / ANN query / metadata / update / describe /
+// list / delete) against the real engine.
+
+let store: any
+
+beforeEach(() => {
+  store = new ChDBVector()
+})
+afterEach(() => {
+  // the underlying Session is force-closed by the global afterEach
+})
+
+describe('ChDBVector', () => {
+  it('creates an index and returns the nearest vectors by similarity', async () => {
+    await store.createIndex({ indexName: 'docs', dimension: 3, metric: 'cosine' })
+    await store.upsert({
+      indexName: 'docs',
+      vectors: [
+        [0.1, 0.2, 0.3],
+        [0.9, 0.1, 0.0],
+        [0.2, 0.2, 0.25],
+        [0.0, 0.9, 0.1],
+      ],
+      metadata: [{ tag: 'a' }, { tag: 'b' }, { tag: 'a' }, { tag: 'c' }],
+      ids: ['v1', 'v2', 'v3', 'v4'],
+    })
+
+    const res = await store.query({ indexName: 'docs', queryVector: [0.1, 0.2, 0.3], topK: 2 })
+    expect(res.map((r: any) => r.id)).toEqual(['v1', 'v3'])
+    expect(res[0].score).toBeGreaterThan(res[1].score) // higher score = nearer
+    expect(res[0].metadata).toEqual({ tag: 'a' })
+  })
+
+  it('filters by metadata equality', async () => {
+    await store.createIndex({ indexName: 'docs', dimension: 3 })
+    await store.upsert({
+      indexName: 'docs',
+      vectors: [
+        [0.1, 0.2, 0.3],
+        [0.11, 0.21, 0.31],
+      ],
+      metadata: [{ tag: 'keep' }, { tag: 'skip' }],
+      ids: ['a', 'b'],
+    })
+    const res = await store.query({ indexName: 'docs', queryVector: [0.1, 0.2, 0.3], topK: 5, filter: { tag: 'keep' } })
+    expect(res.map((r: any) => r.id)).toEqual(['a'])
+  })
+
+  it('upsert replaces an existing id (true upsert)', async () => {
+    await store.createIndex({ indexName: 'docs', dimension: 3 })
+    await store.upsert({ indexName: 'docs', vectors: [[1, 0, 0]], metadata: [{ v: 1 }], ids: ['x'] })
+    await store.upsert({ indexName: 'docs', vectors: [[0, 1, 0]], metadata: [{ v: 2 }], ids: ['x'] })
+    const stats = await store.describeIndex({ indexName: 'docs' })
+    expect(stats).toEqual({ dimension: 3, count: 1, metric: 'cosine' })
+    const res = await store.query({ indexName: 'docs', queryVector: [0, 1, 0], topK: 1, includeVector: true })
+    expect(res[0].metadata).toEqual({ v: 2 })
+    expect(res[0].vector).toEqual([0, 1, 0])
+  })
+
+  it('lists and deletes indexes', async () => {
+    await store.createIndex({ indexName: 'docs', dimension: 3 })
+    await store.createIndex({ indexName: 'more', dimension: 4 })
+    expect((await store.listIndexes()).sort()).toEqual(['docs', 'more'])
+    await store.deleteIndex({ indexName: 'more' })
+    expect(await store.listIndexes()).toEqual(['docs'])
+  })
+
+  it('rejects metrics with no index form', async () => {
+    await expect(store.createIndex({ indexName: 'd', dimension: 3, metric: 'dotproduct' })).rejects.toThrow(/not supported/)
+  })
+})

--- a/test/v3/integrations/mastra.test.ts
+++ b/test/v3/integrations/mastra.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { Session } from '../../../index.js'
 // @ts-expect-error - .mjs adapter has a sibling .d.mts; vitest resolves the runtime file
-import { chdbTools, chdbQueryTool, ChDBVector } from '../../../integrations/mastra.mjs'
+import { chdbTools, chdbQueryTool, ChDBVector, ChDBStore } from '../../../integrations/mastra.mjs'
 
 // The Mastra adapter wraps the same executors via createTool, and re-exports ChDBVector.
 
@@ -38,5 +38,14 @@ describe('chdb/mastra', () => {
 
   it('chdbQueryTool returns a single tool', () => {
     expect(chdbQueryTool({ session: db }).id).toBe('chdb-query')
+  })
+
+  it('re-exports ChDBStore (memory + observability)', async () => {
+    expect(typeof ChDBStore).toBe('function')
+    const store = new ChDBStore({ session: db }) as any
+    await store.stores.memory.saveThread({
+      thread: { id: 't', resourceId: 'r', title: 'x', createdAt: new Date(), updatedAt: new Date(), metadata: {} },
+    })
+    expect((await store.stores.memory.getThreadById({ threadId: 't' })).id).toBe('t')
   })
 })

--- a/test/v3/integrations/mastra.test.ts
+++ b/test/v3/integrations/mastra.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Session } from '../../../index.js'
+// @ts-expect-error - .mjs adapter has a sibling .d.mts; vitest resolves the runtime file
+import { chdbTools, chdbQueryTool, ChDBVector } from '../../../integrations/mastra.mjs'
+
+// The Mastra adapter wraps the same executors via createTool, and re-exports ChDBVector.
+
+let db: Session
+
+beforeEach(() => {
+  db = new Session()
+  db.query(`CREATE TABLE t (id UInt64, name String) ENGINE = MergeTree ORDER BY id`)
+  db.query(`INSERT INTO t VALUES (1, 'Alice')`)
+})
+
+describe('chdb/mastra', () => {
+  it('builds a three-tool toolset with createTool ids', () => {
+    const tools = chdbTools({ session: db }) as any
+    expect(Object.keys(tools).sort()).toEqual(['chdbDescribeSource', 'chdbListTables', 'chdbQuery'])
+    expect(tools.chdbQuery.id).toBe('chdb-query')
+  })
+
+  it('chdbQuery executes and returns rows', async () => {
+    const { chdbQuery } = chdbTools({ session: db }) as any
+    const out = await chdbQuery.execute({ sql: 'SELECT id, name FROM t' })
+    expect(out.error).toBeUndefined()
+    expect(out.rows).toEqual([{ id: 1, name: 'Alice' }])
+  })
+
+  it('re-exports ChDBVector (a working vector store)', async () => {
+    expect(typeof ChDBVector).toBe('function')
+    const store = new ChDBVector({ session: db })
+    await store.createIndex({ indexName: 'v', dimension: 2 })
+    await store.upsert({ indexName: 'v', vectors: [[1, 0]], ids: ['a'] })
+    const res = await store.query({ indexName: 'v', queryVector: [1, 0], topK: 1 })
+    expect(res[0].id).toBe('a')
+  })
+
+  it('chdbQueryTool returns a single tool', () => {
+    expect(chdbQueryTool({ session: db }).id).toBe('chdb-query')
+  })
+})

--- a/test/v3/integrations/mastra.test.ts
+++ b/test/v3/integrations/mastra.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { Session } from '../../../index.js'
-// @ts-expect-error - .mjs adapter has a sibling .d.mts; vitest resolves the runtime file
+// @ts-ignore - .mjs adapter has a sibling .d.mts; vitest resolves the runtime file
 import { chdbTools, chdbQueryTool, ChDBVector, ChDBStore } from '../../../integrations/mastra.mjs'
 
 // The Mastra adapter wraps the same executors via createTool, and re-exports ChDBVector.


### PR DESCRIPTION
## What

First-class chDB integrations for the two main TypeScript agent frameworks, over one
shared, framework-agnostic executor core so behavior is identical across them.

**Tools — `chdb/ai-sdk` and `chdb/mastra`** (`chdbTools()` returns three tools so an
agent can discover then query, not guess SQL):
- `chdbListTables` — tables/views in the session.
- `chdbDescribeSource` — columns/types of a table or any table function
  (`s3()`/`file()`/`postgresql()`/…), via ClickHouse `DESCRIBE TABLE`.
- `chdbQuery` — **read-only by default**: reads run on a dedicated engine-level
  read-only session (`SET readonly = 1`) bound to the same data path, so a write/DDL
  is rejected by the engine, not just a prompt. `allowWrite` opts out.
Results are JSON (capped at `maxRows`), engine errors are handed back to the model
rather than thrown. `chdbQueryTool()` remains for the single-tool case.

**`ChDBVector` (`chdb/mastra`)** — a Mastra vector store backed by chDB-core's HNSW
`vector_similarity` index, so similarity search is index-accelerated ANN (verified via
`EXPLAIN indexes=1`), not a brute-force scan. Full `MastraVector` contract; cosine +
euclidean; idempotent upsert (ReplacingMergeTree + FINAL); flat metadata filters.

**`ChDBStore` (`chdb/mastra`)** — a Mastra storage adapter for the two columnar-friendly
domains: **memory** (threads/messages) and **observability** (AI tracing spans, so
trace/span data is analytically queryable with SQL). Records are stored as JSON +
indexed key columns in ReplacingMergeTree tables (upsert by id / (traceId,spanId), read
via FINAL). Other Mastra domains (workflows, scores, …) are point-update/OLTP-shaped and
left to the base — compose another backend for them.

Authored as ESM (`.mjs` + `.d.mts`) because both frameworks are ESM-only; exposed via the
`chdb/ai-sdk` and `chdb/mastra` subpath exports. `ai`, `@mastra/core`, and `zod` are
optional peer dependencies.

## Tests

23 integration tests, all green: the toolset (incl. read-only enforcement and engine
errors), `ChDBVector` (ANN / filter / upsert-replace / describe / list / delete /
generated ids), and `ChDBStore` (thread+message round-trips and filters; span/trace
read-write; updateSpan merge; listTraces status; an analytical `GROUP BY` over spans).
Full v3 suite green (390 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Vercel AI SDK and Mastra tool adapters under `chdb/ai-sdk` and `chdb/mastra` subpaths
> - Adds [`integrations/chdb-tool-core.mjs`](https://github.com/chdb-io/chdb-node/pull/61/files#diff-ba3ff46f90f7674aba842775da17a4a7016b3eb3a731d80b976f9282f1311626) with a framework-agnostic `createChdbExecutor` factory that provides `query`, `listTables`, and `describeSource` methods with read-only enforcement and capped row results (errors returned as strings, not thrown).
> - Adds [`integrations/ai-sdk.mjs`](https://github.com/chdb-io/chdb-node/pull/61/files#diff-c8a080bf25e657357fbc616545a8d2164642bbebd3a8e409a02c225727f09a71) exposing a `chdbTools` factory and `chdbQueryTool` helper for the Vercel AI SDK using `ai.tool` with Zod input schemas.
> - Adds [`integrations/mastra.mjs`](https://github.com/chdb-io/chdb-node/pull/61/files#diff-8ff540f81adfc30e7a5fafd282eb81ce6c7ad1e881f1cefb5b46082d6a0d62ba) with equivalent Mastra-compatible tools via `createTool`, plus re-exports of `ChDBVector` (HNSW vector store) and `ChDBStore` (thread/message/span persistence).
> - [`integrations/chdb-vector.mjs`](https://github.com/chdb-io/chdb-node/pull/61/files#diff-7abfcca40abb2b732b488c3f4c9ed426768effe50356854b3181dabcf0b7635b) implements a `MastraVector`-compatible store backed by chDB's HNSW index with upsert, ANN query, metadata filtering, and full index lifecycle management.
> - [`integrations/chdb-store.mjs`](https://github.com/chdb-io/chdb-node/pull/61/files#diff-6a78268aa17f50590a9efd1e4f10bef40e6c6b9b8dd253af563d84138c0b97a8) implements Mastra memory (threads/messages) and observability (AI spans) storage using `ReplacingMergeTree` tables with paginated, filterable reads.
> - New subpath exports `chdb/ai-sdk` and `chdb/mastra` are published via `package.json`; `@mastra/core`, `ai`, and `zod` are added as optional peer dependencies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb7d0a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
