### PR TITLE
Re-sync parity runner to clickhouse-js monorepo Vitest layout

### DIFF
--- a/tests/clickhouse-js/runner.mjs
+++ b/tests/clickhouse-js/runner.mjs
@@ -3,11 +3,18 @@
  * chdb-node × @clickhouse/client cross-suite parity runner.
  *
  * Clones @clickhouse/client at a configured ref, builds it, patches
- * upstream's `vitest.node.setup.ts` in-place to wrap
+ * upstream's `packages/client-node/vitest.setup.ts` in-place to wrap
  * `globalThis.environmentSpecificCreateClient` with `createChdbConnection`,
  * then runs the integration suite filtered by
  * `tests/clickhouse-js/skip_list.json`. The setup patch is restored in a
  * try/finally block so the upstream checkout isn't left dirty.
+ *
+ * Upstream layout note: clickhouse-js #931 embedded the Vitest config and
+ * setup into the node package, moving the root `vitest.node.setup.ts` /
+ * `vitest.node.config.ts` to `packages/client-node/vitest.setup.ts` /
+ * `vitest.config.ts`. The integration specs themselves stay package-rooted
+ * (`packages/{client-common,client-node}/__tests__/...`), so skip_list paths
+ * are unaffected.
  *
  * Sync policy (encoded in skip_list.json's `syncedAgainst` block):
  *
@@ -94,17 +101,17 @@ const CHDB_INJECTION_END   = "// <<< chdb-runner injection — DO NOT EDIT <<<";
 
 /**
  * Append the ChdbConnection wrapping snippet to upstream's
- * `vitest.node.setup.ts` so vitest actually loads it (the setup file is
- * already in upstream's `setupFiles` config, so appending to it is the
- * one mechanism guaranteed to be picked up regardless of vitest version
- * or CLI flag support). Returns a `{file, original}` snapshot for
+ * `packages/client-node/vitest.setup.ts` so vitest actually loads it (the
+ * setup file is already in upstream's `setupFiles` config, so appending to
+ * it is the one mechanism guaranteed to be picked up regardless of vitest
+ * version or CLI flag support). Returns a `{file, original}` snapshot for
  * try/finally restoration.
  */
 function injectSetup() {
-  const target = join(WORK_DIR, "vitest.node.setup.ts");
+  const target = join(WORK_DIR, "packages", "client-node", "vitest.setup.ts");
   if (!existsSync(target)) {
     throw new Error(
-      `[runner] upstream vitest.node.setup.ts not found at ${target}; ` +
+      `[runner] upstream packages/client-node/vitest.setup.ts not found at ${target}; ` +
       `injection cannot proceed`,
     );
   }
@@ -235,12 +242,20 @@ function runVitest() {
   const excludes = buildSkipPattern();
   const patches = applyPerTestSkips();
   try {
+    // Call the node package's `test:integration` script directly rather than
+    // the root `test:node:integration` aggregator. The aggregator is itself an
+    // `npm --prefix packages/client-node run test:integration`, so forwarding
+    // vitest flags through it (`npm run test:node:integration -- --exclude X`)
+    // would feed `--exclude X` to the inner `npm`, not to vitest. Going
+    // straight to the package script keeps a single `--` hop to vitest. The
+    // config is auto-loaded from packages/client-node/vitest.config.ts (its
+    // `root` is the repo root, so the repo-root-relative skip_list globs match).
     const args = [
+      "--prefix",
+      "packages/client-node",
       "run",
-      "test:node:integration",
+      "test:integration",
       "--",
-      "--config",
-      "vitest.node.config.ts",
     ];
     for (const f of excludes) args.push("--exclude", f);
     const env = {

--- a/tests/clickhouse-js/skip_list.json
+++ b/tests/clickhouse-js/skip_list.json
@@ -2,9 +2,9 @@
   "$schema_comment": "chdb-node skip list for @clickhouse/client's integration suite. AUTHORITATIVE blacklist applied by tests/clickhouse-js/runner.mjs when running @clickhouse/client's tests with ChdbConnection injected. Format: skipFiles is per-file (entire suite of tests in the file is excluded — for files where chdb does not implement the capability the file exercises); skipTests is per-case for cases inside an otherwise-runnable file (the runner patches the file in place to convert it(...) → it.skip(...) before vitest collects, and restores after). reasons documents WHY each entry is here. Maintained per @clickhouse/client release; chdb-node refreshes the list when upstream cuts a new version.",
   "syncedAgainst": {
     "ref": "ClickHouse/clickhouse-js main",
-    "policy": "While the createClient({ connection }) injection PR is open: ShawnChen-Sirius fork branch. After merge: ClickHouse/clickhouse-js main (CURRENT — PR #879 was merged 2026-06-23 as commit c2e28b9; PR #880 follow-up was merged 2026-06-23 as commit 274844f). After next release: latest released tag.",
-    "lastSyncedSha": "274844f",
-    "lastSyncedAt": "2026-06-24"
+    "policy": "While the createClient({ connection }) injection PR is open: ShawnChen-Sirius fork branch. After merge: ClickHouse/clickhouse-js main (CURRENT — PR #879 was merged 2026-06-23 as commit c2e28b9; PR #880 follow-up was merged 2026-06-23 as commit 274844f). After next release: latest released tag. NOTE: PR #931 (commit 199f9946) embedded the Vitest config/setup into the node package — the runner now patches packages/client-node/vitest.setup.ts and runs the packages/client-node test:integration script; the spec files stayed package-rooted so the paths below are unchanged.",
+    "lastSyncedSha": "199f9946",
+    "lastSyncedAt": "2026-06-30"
   },
   "skipFiles": [
     {


### PR DESCRIPTION
## Problem

The cross-suite parity job (`tests/clickhouse-js/runner.mjs`) is failing on `main` and on every open PR:

```
Error: [runner] upstream vitest.node.setup.ts not found at .../.chdb-runner/clickhouse-js/vitest.node.setup.ts; injection cannot proceed
```

The runner pins `REF=main` of `ClickHouse/clickhouse-js`. Upstream **#931 "Embed Vitest configs into client packages"** (commit `199f9946`) moved the repo-root `vitest.node.setup.ts` / `vitest.node.config.ts` into `packages/client-node/` (`vitest.setup.ts` / `vitest.config.ts`). The runner could no longer find the file to inject into. This is upstream drift, unrelated to any feature PR.

## Fix

- **Injection target** → `packages/client-node/vitest.setup.ts`. It still defines `globalThis.environmentSpecificCreateClient`, so the `ChdbConnection`-wrapping snippet is unchanged.
- **Run command** → call the package script directly:
  `npm --prefix packages/client-node run test:integration -- --exclude …`
  rather than the root `test:node:integration` aggregator. The aggregator is itself an `npm --prefix … run`, so forwarded `-- --exclude` flags would be consumed by the inner `npm` instead of vitest. Going straight to the package script keeps a single `--` hop to vitest (verified). The package's `vitest.config.ts` is auto-loaded and roots at the repo, so the stale `--config vitest.node.config.ts` override is dropped and the repo-root-relative skip_list globs still match.
- **skip_list** → spec files stayed package-rooted (`packages/{client-common,client-node}/__tests__/…`); verified all **27 skipFiles** and **31 skipTests** entries still resolve against current `main`. Only `syncedAgainst` metadata is bumped to `199f9946`.

## Validation

- All skip_list paths exist in upstream `main` (checked against a fresh clone).
- `npm --prefix <pkg> run <script> -- --exclude X` arg-forwarding confirmed to reach the underlying command.
- Runtime parity (in-process via `CH_TEST_BACKEND=chdb`) is validated by this repo's `parity` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-sync parity runner to clickhouse-js monorepo Vitest layout
> - Updates `injectSetup` in [runner.mjs](https://github.com/chdb-io/chdb-node/pull/62/files#diff-ca64f60bc086bd6074c06f53465be0ff725bd40d290b15864028c52dbace1739) to target `packages/client-node/vitest.setup.ts` instead of the repo-root `vitest.node.setup.ts`.
> - Updates `runVitest` to invoke `npm --prefix packages/client-node run test:integration` instead of the old `test:node:integration` script with an explicit `--config` flag.
> - Updates [skip_list.json](https://github.com/chdb-io/chdb-node/pull/62/files#diff-2ab5e33cf2e743a17bbef170b6bdf106aa5d3ab034b9778225cff165362db297) metadata to reflect the upstream PR #931 change and bumps `lastSyncedSha` to `199f9946`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee7a481.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->