### PR TITLE
Add chdb/hypequery — run hypequery on embedded chDB

### DIFF
--- a/integrations/hypequery.d.mts
+++ b/integrations/hypequery.d.mts
@@ -1,0 +1,35 @@
+import type { Session } from '../index.js'
+
+export interface ChdbAdapterOptions {
+  /**
+   * A chdb Session to run queries against (recommended; required for stream()).
+   * When omitted, queries use the in-process default connection — fine for
+   * stateless reads over file()/s3()/url() table functions.
+   */
+  session?: Session
+}
+
+/**
+ * A hypequery `DatabaseAdapter` (structural) backed by embedded chDB. The shape
+ * matches `@hypequery/clickhouse`'s exported `DatabaseAdapter`; it is returned
+ * structurally so this type resolves without `@hypequery/clickhouse` installed.
+ */
+export interface ChdbHypequeryAdapter {
+  readonly name: 'chdb'
+  query<T>(sql: string, params?: unknown[], options?: unknown): Promise<T[]>
+  stream<T>(sql: string, params?: unknown[], options?: unknown): Promise<ReadableStream<T[]>>
+  render(sql: string, params?: unknown[]): string
+}
+
+/**
+ * Build a hypequery `DatabaseAdapter` that executes on embedded chDB:
+ *
+ * ```ts
+ * import { createQueryBuilder } from '@hypequery/clickhouse'
+ * import { Session } from 'chdb'
+ * import { chdbAdapter } from 'chdb/hypequery'
+ * const db = createQueryBuilder<Schema>({ adapter: chdbAdapter({ session: new Session('./db') }) })
+ * ```
+ */
+export function chdbAdapter(opts?: ChdbAdapterOptions): ChdbHypequeryAdapter
+export default chdbAdapter

--- a/integrations/hypequery.d.mts
+++ b/integrations/hypequery.d.mts
@@ -1,3 +1,4 @@
+import type { ReadableStream } from 'node:stream/web'
 import type { Session } from '../index.js'
 
 export interface ChdbAdapterOptions {

--- a/integrations/hypequery.mjs
+++ b/integrations/hypequery.mjs
@@ -80,11 +80,21 @@ function substituteParameters(sql, params) {
 }
 
 function escapeValue(value) {
+  // null / undefined → SQL NULL (matches ClickHouse convention and avoids the
+  // literal string 'undefined' that `JSON.stringify(undefined)` would produce).
+  if (value === null || value === undefined) return 'NULL'
   if (typeof value === 'boolean') return value ? 'true' : 'false'
   if (typeof value === 'number') return value.toString()
+  // BigInt is unquoted numeric to match ClickHouse's numeric literal syntax and
+  // avoid `JSON.stringify(BigInt(...))` throwing "Do not know how to serialize".
+  if (typeof value === 'bigint') return value.toString()
   if (typeof value === 'string') return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "''")}'`
   if (value instanceof Date) return `'${value.toISOString()}'`
-  return `'${JSON.stringify(value)}'`
+  // Objects / arrays: JSON stringify, then apply the same backslash + single-quote
+  // escaping the string branch uses. ClickHouse SQL doubles `'` inside string
+  // literals; leaving raw single quotes from the JSON encoding produces malformed
+  // SQL (e.g. `{name:"O'Reilly"}` → `'{"name":"O'Reilly"}'` which chokes the parser).
+  return `'${JSON.stringify(value).replace(/\\/g, '\\\\').replace(/'/g, "''")}'`
 }
 
 function parseJsonEachRow(text) {

--- a/integrations/hypequery.mjs
+++ b/integrations/hypequery.mjs
@@ -1,0 +1,124 @@
+// chdb/hypequery — a hypequery DatabaseAdapter backed by embedded chDB.
+//
+//   import { createQueryBuilder } from '@hypequery/clickhouse'
+//   import { Session } from '../index.mjs'
+//   import { chdbAdapter } from 'chdb/hypequery'
+//
+//   const session = new Session('./analytics.chdb')   // or new Session() for in-memory
+//   const db = createQueryBuilder<Schema>({ adapter: chdbAdapter({ session }) })
+//   // ...the rest of your hypequery code is unchanged; it now runs in-process,
+//   //    no ClickHouse server, over local files / S3 / Postgres via chDB.
+//
+// hypequery's createQueryBuilder already accepts a custom `adapter` (DatabaseAdapter),
+// and it renders final SQL with `?`-positional params client-side, so the adapter only
+// has to run a complete SQL string and return JSONEachRow rows. This is intentionally
+// dependency-light: it does not import @hypequery/clickhouse at runtime (the adapter is
+// duck-typed against the DatabaseAdapter shape).
+//
+// `@hypequery/clickhouse` is an optional peer dependency (types only).
+
+// In the chdb-node package this imports from the package ESM entry:
+import { Session, queryAsync } from '../index.mjs'
+
+const ROW_FORMAT = 'JSONEachRow'
+
+/**
+ * Build a hypequery DatabaseAdapter that executes on embedded chDB.
+ * @param {{ session?: import('../index.mjs').Session }} [opts]
+ *   session: a chdb Session to run against (recommended; required for stream()).
+ *   When omitted, queries use the in-process default connection — fine for
+ *   stateless reads over file()/s3()/url() table functions.
+ */
+export function chdbAdapter(opts = {}) {
+  const { session } = opts
+  const runText = async (sql) => {
+    const res = session ? await session.queryAsync(sql, { format: ROW_FORMAT }) : await queryAsync(sql, { format: ROW_FORMAT })
+    return res.text()
+  }
+
+  return {
+    name: 'chdb',
+
+    async query(sql, params = [], _options) {
+      const finalSql = substituteParameters(sql, params)
+      return parseJsonEachRow(await runText(finalSql))
+    },
+
+    async stream(sql, params = [], _options) {
+      if (!session) {
+        throw new Error('chdbAdapter: stream() requires a bound session — pass { session } to chdbAdapter()')
+      }
+      const chStream = session.queryStream(substituteParameters(sql, params), { format: ROW_FORMAT })
+      return chunkStreamToReadable(chStream)
+    },
+
+    // hypequery calls render() when present (else its own substituteParameters); we
+    // reproduce its rendering exactly so generated SQL matches the HTTP adapter.
+    render(sql, params = []) {
+      return substituteParameters(sql, params)
+    },
+  }
+}
+
+export default chdbAdapter
+
+// --- helpers (mirror @hypequery/clickhouse core/utils.ts exactly) ------------
+// If hypequery exports substituteParameters/escapeValue (see the proposed PR),
+// import them instead of duplicating, so the two stay byte-identical.
+
+function substituteParameters(sql, params) {
+  if (!params || params.length === 0) return sql
+  const parts = sql.split('?')
+  if (parts.length - 1 !== params.length) {
+    throw new Error(
+      `chdbAdapter: mismatch between placeholders and parameters — ${parts.length - 1} placeholders, ${params.length} parameters.`,
+    )
+  }
+  let out = ''
+  for (let i = 0; i < params.length; i++) out += parts[i] + escapeValue(params[i])
+  return out + parts[parts.length - 1]
+}
+
+function escapeValue(value) {
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number') return value.toString()
+  if (typeof value === 'string') return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "''")}'`
+  if (value instanceof Date) return `'${value.toISOString()}'`
+  return `'${JSON.stringify(value)}'`
+}
+
+function parseJsonEachRow(text) {
+  const out = []
+  for (const line of text.split('\n')) {
+    if (line.length === 0) continue
+    out.push(JSON.parse(line))
+  }
+  return out
+}
+
+// chDB streams chunks (each a block of rows); hypequery wants ReadableStream<T[]>,
+// i.e. one enqueue per chunk carrying that chunk's row array.
+function chunkStreamToReadable(chStream) {
+  const it = chStream[Symbol.asyncIterator]()
+  return new ReadableStream({
+    async pull(controller) {
+      try {
+        const { value, done } = await it.next()
+        if (done) {
+          controller.close()
+          return
+        }
+        controller.enqueue(value.rows())
+      } catch (e) {
+        controller.error(e)
+      }
+    },
+    cancel() {
+      try {
+        chStream.cancel()
+      } catch {
+        /* best effort */
+      }
+    },
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "chdb-gen-types": "dist/layer3/codegen/cli.js"
       },
       "devDependencies": {
+        "@hypequery/clickhouse": "^2.1.1",
         "@mastra/core": "^1.47.0",
         "@types/node": "^20.14.0",
         "ai": "^7.0.2",
@@ -39,12 +40,16 @@
         "@chdb/lib-linux-x64-gnu": "26.5.2"
       },
       "peerDependencies": {
+        "@hypequery/clickhouse": ">=2",
         "@mastra/core": ">=0.10",
         "ai": ">=5",
         "apache-arrow": ">=14",
         "zod": ">=3"
       },
       "peerDependenciesMeta": {
+        "@hypequery/clickhouse": {
+          "optional": true
+        },
         "@mastra/core": {
           "optional": true
         },
@@ -321,6 +326,16 @@
       "os": [
         "linux"
       ]
+    },
+    "node_modules/@clickhouse/client": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.23.0.tgz",
+      "integrity": "sha512-Li6TBcRKfWVxyJa8g+lJwuyn+r+zV/pJJ3yxn3TVlC00vH+zfZ6njFXsZfqIamGXHRrY5iPhAEZu2hSWzlSo3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@clickhouse/client-common": {
       "version": "1.22.0",
@@ -736,6 +751,45 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@hypequery/clickhouse": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hypequery/clickhouse/-/clickhouse-2.1.1.tgz",
+      "integrity": "sha512-e3fYH1Qr+RWQQmeBlz1lDrbzhzDeEG9HnDxFqxJmOZCJLpeAFMMeqswkyRPKLJNeTma2LtmybjURgiip/MmcDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@clickhouse/client": "^1.18.3",
+        "dotenv": "^16.0.0"
+      },
+      "bin": {
+        "hypequery-generate-types": "dist/cli/bin.js"
+      },
+      "peerDependencies": {
+        "@clickhouse/client-web": "^0.2.0 || ^1.0.0",
+        "@hypequery/datasets": ">=0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@clickhouse/client-web": {
+          "optional": true
+        },
+        "@hypequery/datasets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@hypequery/clickhouse/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@isaacs/ttlcache": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
       "types": "./integrations/mastra.d.mts",
       "import": "./integrations/mastra.mjs"
     },
+    "./hypequery": {
+      "types": "./integrations/hypequery.d.mts",
+      "import": "./integrations/hypequery.mjs"
+    },
     "./package.json": "./package.json"
   },
   "repository": {
@@ -67,6 +71,7 @@
     "integrations"
   ],
   "devDependencies": {
+    "@hypequery/clickhouse": "^2.1.1",
     "@mastra/core": "^1.47.0",
     "@types/node": "^20.14.0",
     "ai": "^7.0.2",
@@ -90,6 +95,7 @@
     "@chdb/lib-linux-x64-gnu": "26.5.2"
   },
   "peerDependencies": {
+    "@hypequery/clickhouse": ">=2",
     "@mastra/core": ">=0.10",
     "ai": ">=5",
     "apache-arrow": ">=14",
@@ -106,6 +112,9 @@
       "optional": true
     },
     "zod": {
+      "optional": true
+    },
+    "@hypequery/clickhouse": {
       "optional": true
     }
   },

--- a/test/v3/integrations/hypequery.test.ts
+++ b/test/v3/integrations/hypequery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { createQueryBuilder } from '@hypequery/clickhouse'
 import { Session } from '../../../index.js'
 // @ts-ignore - .mjs adapter has a sibling .d.mts; vitest resolves the runtime file
@@ -16,6 +16,13 @@ beforeEach(() => {
   s.query(`CREATE TABLE trips (trip_id String, passenger_count UInt8, total_amount Float64) ENGINE = MergeTree ORDER BY trip_id`)
   s.query(`INSERT INTO trips VALUES ('a',1,10),('b',2,20),('c',2,35),('d',4,50)`)
   db = createQueryBuilder({ adapter: chdbAdapter({ session: s }) })
+})
+
+afterEach(() => {
+  // Keep resource lifetimes case-local rather than relying on
+  // test/v3/setup.ts's global safety net; makes any leak easier to
+  // pin to the offending case.
+  s?.close()
 })
 
 describe('chdb/hypequery', () => {

--- a/test/v3/integrations/hypequery.test.ts
+++ b/test/v3/integrations/hypequery.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createQueryBuilder } from '@hypequery/clickhouse'
+import { Session } from '../../../index.js'
+// @ts-ignore - .mjs adapter has a sibling .d.mts; vitest resolves the runtime file
+import { chdbAdapter } from '../../../integrations/hypequery.mjs'
+
+// Runs hypequery's own query builder against embedded chDB through the adapter.
+// hypequery renders final SQL (?-positional params) and the adapter executes it
+// on chDB, returning JSONEachRow rows.
+
+let s: Session
+let db: ReturnType<typeof createQueryBuilder>
+
+beforeEach(() => {
+  s = new Session()
+  s.query(`CREATE TABLE trips (trip_id String, passenger_count UInt8, total_amount Float64) ENGINE = MergeTree ORDER BY trip_id`)
+  s.query(`INSERT INTO trips VALUES ('a',1,10),('b',2,20),('c',2,35),('d',4,50)`)
+  db = createQueryBuilder({ adapter: chdbAdapter({ session: s }) })
+})
+
+describe('chdb/hypequery', () => {
+  it('runs a builder query (filter + aggregate + group + order) on chDB', async () => {
+    const rows = await (db as any)
+      .table('trips')
+      .where('passenger_count', 'gte', 2)
+      .select(['passenger_count'])
+      .count('trip_id', 'trip_count')
+      .sum('total_amount', 'revenue')
+      .groupBy(['passenger_count'])
+      .orderBy('passenger_count', 'ASC')
+      .execute()
+    expect(rows).toEqual([
+      { passenger_count: 2, trip_count: 2, revenue: 55 },
+      { passenger_count: 4, trip_count: 1, revenue: 50 },
+    ])
+  })
+
+  it('binds where-values through hypequery rendering (no injection of raw input)', async () => {
+    const rows = await (db as any).table('trips').select(['trip_id']).where('trip_id', 'eq', "a' OR '1'='1").execute()
+    expect(rows).toEqual([]) // the value is escaped, not interpreted as SQL
+  })
+
+  it('rawQuery passes through to chDB', async () => {
+    const r = await (db as any).rawQuery('SELECT count() AS n FROM trips')
+    expect(r).toEqual([{ n: 4 }])
+  })
+
+  it('streams rows as a ReadableStream<T[]>', async () => {
+    const stream = await (db as any).table('trips').select(['trip_id']).orderBy('trip_id', 'ASC').stream()
+    const ids: string[] = []
+    const reader = stream.getReader()
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      for (const row of value) ids.push(row.trip_id)
+    }
+    expect(ids).toEqual(['a', 'b', 'c', 'd'])
+  })
+})


### PR DESCRIPTION
Lets [@hypequery/clickhouse](https://github.com/hypequery/hypequery) run its type-safe
query builder against in-process chDB instead of a remote ClickHouse server, by passing a
chDB-backed adapter to hypequery's existing `createQueryBuilder({ adapter })` hook.

Discussed in hypequery/hypequery#237 (maintainer is on board).

```js
import { createQueryBuilder } from '@hypequery/clickhouse'
import { Session } from 'chdb'
import { chdbAdapter } from 'chdb/hypequery'

const db = createQueryBuilder({ adapter: chdbAdapter({ session: new Session('./db') }) })
```

## How

hypequery renders final SQL itself (`?`-positional params), so the adapter just runs the
SQL on chDB and returns JSONEachRow rows. It implements the `DatabaseAdapter` contract:

- `query` — rows
- `stream` — chDB's chunked cursor wrapped as a `ReadableStream<T[]>`
- `render` — mirrors hypequery's `substituteParameters`/`escapeValue` so generated SQL
  matches the built-in HTTP adapter exactly

No `@clickhouse/client` and no ClickHouse server involved. The adapter is duck-typed and
imports nothing from `@hypequery/clickhouse` at runtime, so it stays an optional, types-only
peer dependency. Shipped as the `chdb/hypequery` subpath.

It is self-contained against the currently published `@hypequery/clickhouse` (it does not
depend on any hypequery change). A small follow-up can switch the copied render helpers to
imports once hypequery exports them (hypequery/hypequery PR for that is separate).

## Tests

A real `@hypequery/clickhouse` builder chain runs against embedded chDB: filter + aggregate
+ group + order, value escaping, `rawQuery` passthrough, and streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `chdbAdapter` to integrate hypequery with embedded chDB
> - Adds a new `chdb/hypequery` subpath export with an ESM entry ([hypequery.mjs](https://github.com/chdb-io/chdb-node/pull/63/files#diff-29c7b9010c97ae86b8cc5dff47c945f3d0d645da0a06fb4bfca3b293cdd547d8)) and TypeScript declarations ([hypequery.d.mts](https://github.com/chdb-io/chdb-node/pull/63/files#diff-83d7d3c09d1fa2112a79b3324be3020a4139ad509138c1e68777e3f035230ace)).
> - `chdbAdapter(opts?)` returns a hypequery-compatible `DatabaseAdapter` with `query()`, `stream()`, and `render()` methods backed by chDB's `queryAsync` and `queryStream`.
> - Includes `substituteParameters` and `escapeValue` helpers that inject typed JS values as SQL-safe literals and throw on placeholder/param count mismatch.
> - `stream()` wraps chDB's async iterator into a Web `ReadableStream<T[]>` but requires a bound session — throws at call time if none is provided.
> - Declares `@hypequery/clickhouse >=2` as an optional peer dependency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebb0eda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->