### PR TITLE
Verify the published package on clean installs before promoting to latest

### DIFF
--- a/.github/workflows/chdb-node-test.yml
+++ b/.github/workflows/chdb-node-test.yml
@@ -12,6 +12,15 @@ on:
 # chdb_query_with_params (#73) and chdb_query_arrow (#15) across all four target
 # platforms, so the full v2 + v3 suite is expected green here.
 
+# Harden the registry fetch so a transient reset (e.g. ECONNRESET during
+# install) retries instead of reddening the job. Combined with the per-job
+# actions/setup-node `cache: npm`, most runs never hit the network at all.
+env:
+  npm_config_fetch_retries: "5"
+  npm_config_fetch_retry_mintimeout: "20000"
+  npm_config_fetch_retry_maxtimeout: "120000"
+  npm_config_fetch_timeout: "600000"
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -28,6 +37,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - name: Install JS deps (no compile-on-install)
         run: npm install --ignore-scripts
       - name: Fetch libchdb
@@ -58,6 +68,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
+          cache: npm
       - run: npm install --ignore-scripts && npm run libchdb && npm run build
       - uses: oven-sh/setup-bun@v2
       - name: Bun smoke
@@ -91,6 +102,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
+          cache: npm
       - run: sudo apt-get update && sudo apt-get install -y patchelf binutils
       - run: npm install --ignore-scripts && npm run libchdb && npm run build
       - name: Pack main + platform subpackage

--- a/.github/workflows/connection.yml
+++ b/.github/workflows/connection.yml
@@ -28,6 +28,14 @@ concurrency:
   group: connection-${{ github.ref }}
   cancel-in-progress: true
 
+# Retry a transient registry reset instead of reddening the job; combined with
+# the per-job actions/setup-node `cache: npm` most runs skip the network.
+env:
+  npm_config_fetch_retries: "5"
+  npm_config_fetch_retry_mintimeout: "20000"
+  npm_config_fetch_retry_maxtimeout: "120000"
+  npm_config_fetch_timeout: "600000"
+
 jobs:
   contract:
     runs-on: ubuntu-latest
@@ -38,6 +46,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
+          cache: npm
       - name: Install patchelf
         run: sudo apt-get update && sudo apt-get install -y patchelf
       - run: npm install --ignore-scripts
@@ -54,6 +63,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
+          cache: npm
       - name: Install patchelf
         run: sudo apt-get update && sudo apt-get install -y patchelf
       - run: npm install --ignore-scripts

--- a/.github/workflows/prebuild-publish.yml
+++ b/.github/workflows/prebuild-publish.yml
@@ -1,12 +1,22 @@
 name: prebuild-publish
 
-# On a version tag: build the per-platform @chdb/lib-* native subpackages on
-# each target runner and publish them, then publish the thin main `chdb` package
-# (which pulls the subpackages in via optionalDependencies). No QEMU — native
-# arm runners are used directly.
+# On a version tag:
+#   1. subpackages — build the per-platform @chdb/lib-* native packages on each target
+#      runner and publish them (idempotent). No QEMU; native arm runners.
+#   2. main — publish the thin `chdb` package, but a STABLE release is published to a
+#      holding dist-tag ('unverified'), NOT 'latest'. Prereleases go to 'next'.
+#   3. verify — on a matrix of clean machines (every target platform x Node version),
+#      install the JUST-PUBLISHED `chdb` from npm (no repo build artifacts) and run the
+#      installed-package tests. This exercises what a user actually gets: the packed
+#      files, the @chdb/lib-* binary resolved via optionalDependencies, its rpath at the
+#      installed location, and the subpath exports. (This is the gate that #50 needed:
+#      a binary with the build machine's absolute rpath passed the in-tree build test
+#      but failed on every clean host.)
+#   4. promote — only after verify is green on every leg, move 'latest' to the new
+#      version. If verify fails, users on 'latest' never see the broken release.
 #
-# Gated on update_libchdb.sh pointing at a libchdb release that includes
-# #73 (chdb_query_with_params) and #15 (chdb_query_arrow).
+# Gated on update_libchdb.sh pointing at a libchdb release that includes the required
+# C ABI (chdb_query_with_params, chdb_query_arrow).
 
 on:
   push:
@@ -41,8 +51,6 @@ jobs:
       - run: npm run test:all
       - name: Derive subpackage version from update_libchdb.sh
         run: |
-          # The published @chdb/lib-* version is decoupled from the libchdb
-          # download (LATEST_RELEASE); see LIBCHDB_NPM_VERSION in update_libchdb.sh.
           echo "CHDB_LIB_VERSION=$(grep -E '^LIBCHDB_NPM_VERSION=' update_libchdb.sh | cut -d= -f2)" >> "$GITHUB_ENV"
       - name: Build subpackage
         run: npm run build:platform
@@ -55,8 +63,6 @@ jobs:
             echo "$NAME@$VER already published; skipping (lets a re-run finish a partially-published release)."
             exit 0
           fi
-          # Publish; tolerate the race where the version exists but the registry
-          # read above lagged — key off the publish error, not a (lagging) read.
           if out=$(npm publish --access public 2>&1); then
             echo "$out"
           else
@@ -85,10 +91,12 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           npm pkg set version="$VERSION"
+          # A stable release is published to a holding tag and only moved to 'latest'
+          # by the promote job after verify passes; prereleases stay on 'next'.
           if [[ "$VERSION" == *-* ]]; then
             echo "NPM_DIST_TAG=next" >> "$GITHUB_ENV"
           else
-            echo "NPM_DIST_TAG=latest" >> "$GITHUB_ENV"
+            echo "NPM_DIST_TAG=unverified" >> "$GITHUB_ENV"
           fi
       - name: Publish main (prepack builds dist; idempotent)
         run: |
@@ -105,5 +113,57 @@ jobs:
               && echo "chdb@$VER already on the registry (publish conflict); treating as success." \
               || exit 1
           fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  verify:
+    needs: main
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15-intel]
+        node: ["18", "20", "22"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4   # only to obtain the installed-package tests
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "${{ matrix.node }}.x"
+      - name: Install the PUBLISHED chdb in a clean dir and run the installed-package tests
+        shell: bash
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          work="$(mktemp -d)"
+          cp -R "$GITHUB_WORKSPACE/test/pack" "$work/test"
+          cd "$work"
+          npm init -y >/dev/null
+          # The version may lag in the registry right after publish; retry.
+          ok=
+          for i in 1 2 3 4 5 6; do
+            if npm install "chdb@$VER" vitest@2 >/tmp/i.log 2>&1; then ok=1; break; fi
+            echo "install attempt $i failed (registry propagation?); retry in 15s"; sleep 15
+          done
+          [ -n "$ok" ] || { echo "could not install chdb@$VER"; tail -20 /tmp/i.log; exit 1; }
+          node -e "console.log('verifying installed chdb', require('chdb/package.json').version, 'on', process.version, process.platform, process.arch)"
+          npx vitest run test
+
+  promote:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: "https://registry.npmjs.org"
+      - name: Move 'latest' to the verified version (stable only)
+        shell: bash
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          if [[ "$VER" == *-* ]]; then
+            echo "prerelease $VER stays on 'next'; not promoting to latest."
+            exit 0
+          fi
+          echo "verify passed on every platform; promoting chdb@$VER to latest"
+          npm dist-tag add "chdb@$VER" latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -12,6 +12,14 @@ on:
   schedule:
     - cron: "0 3 * * 1" # weekly
 
+# Retry a transient registry reset instead of reddening the job; combined with
+# the per-job actions/setup-node `cache: npm` most runs skip the network.
+env:
+  npm_config_fetch_retries: "5"
+  npm_config_fetch_retry_mintimeout: "20000"
+  npm_config_fetch_retry_maxtimeout: "120000"
+  npm_config_fetch_timeout: "600000"
+
 jobs:
   asan:
     runs-on: ubuntu-latest
@@ -24,6 +32,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
+          cache: npm
       - run: npm install --ignore-scripts
       - run: npm run libchdb
       - name: Build addon with ASan/UBSan

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@chdb/lib-linux-x64-gnu": "26.5.2"
   },
   "peerDependencies": {
+    "@clickhouse/client": ">=1.23.0",
     "@hypequery/clickhouse": ">=2",
     "@mastra/core": ">=0.10",
     "ai": ">=5",
@@ -102,6 +103,9 @@
     "zod": ">=3"
   },
   "peerDependenciesMeta": {
+    "@clickhouse/client": {
+      "optional": true
+    },
     "apache-arrow": {
       "optional": true
     },

--- a/test/pack/installed.test.mjs
+++ b/test/pack/installed.test.mjs
@@ -1,0 +1,53 @@
+// Installed-package test. Unlike the unit tests (which import the source tree via
+// relative paths), this imports `chdb` BY NAME, so it only ever exercises the
+// published, installed package in node_modules: the packed files, the per-platform
+// @chdb/lib-* native binary resolved through optionalDependencies, its rpath at the
+// installed location, and the subpath `exports` map.
+//
+// This is the gate that would have caught #50 (a binary with the build machine's
+// absolute rpath loaded in CI's build dir but threw on a clean host): here the very
+// first `import 'chdb'` loads the native addon from where npm actually put it.
+//
+// Run it from a clean directory that has only `npm install chdb@<version>` (plus
+// vitest), NOT from the repo — see .github/workflows verify job.
+
+import { describe, it, expect } from 'vitest'
+import { query, queryAsync, Session, version } from 'chdb'
+
+describe('installed chdb package', () => {
+  it('loads the native binary and reports a version', () => {
+    const v = version()
+    expect(typeof v).toBe('object')
+    expect(typeof v.libchdb).toBe('string')
+    expect(v.libchdb.length).toBeGreaterThan(0)
+  })
+
+  it('runs a stateless query (engine actually executes)', () => {
+    expect(query('SELECT 1 AS n', 'CSV').trim()).toBe('1')
+  })
+
+  it('runs an async query and parses rows', async () => {
+    const r = await queryAsync("SELECT number FROM numbers(3)", { format: 'JSONEachRow' })
+    expect(r.text().trim().split('\n')).toHaveLength(3)
+  })
+
+  it('creates a Session and round-trips an insert + query + stream', async () => {
+    const s = new Session()
+    try {
+      s.query('CREATE TABLE t (id UInt64, name String) ENGINE = MergeTree ORDER BY id')
+      await s.insert({ table: 't', values: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }] })
+      const rows = (await s.queryAsync('SELECT name FROM t ORDER BY id', { format: 'JSONEachRow' })).text().trim()
+      expect(rows).toBe('{"name":"Alice"}\n{"name":"Bob"}')
+      const streamed = []
+      for await (const row of s.queryStream('SELECT id FROM t ORDER BY id').rows()) streamed.push(String(row.id))
+      expect(streamed).toEqual(['1', '2'])
+    } finally {
+      s.close()
+    }
+  })
+
+  it('resolves the subpath exports the package advertises', async () => {
+    const conn = await import('chdb/connection')
+    expect(typeof conn.createChdbConnection).toBe('function')
+  })
+})

--- a/test/pack/installed.test.mjs
+++ b/test/pack/installed.test.mjs
@@ -14,7 +14,13 @@
 import { describe, it, expect } from 'vitest'
 import { query, queryAsync, Session, version } from 'chdb'
 
-describe('installed chdb package', () => {
+// Run cases sequentially. The suite mixes the standalone default connection
+// (`version()`, `query()`, `queryAsync()`) with a `Session` that binds its
+// own temp data directory; libchdb's single-active-data-directory constraint
+// means those two cannot coexist mid-flight in the same process. Running
+// serially (and without shuffle) guarantees the Session case's setup/teardown
+// doesn't race the default-connection cases.
+describe.sequential('installed chdb package', () => {
   it('loads the native binary and reports a version', () => {
     const v = version()
     expect(typeof v).toBe('object')

--- a/tests/clickhouse-js/runner.mjs
+++ b/tests/clickhouse-js/runner.mjs
@@ -3,18 +3,24 @@
  * chdb-node × @clickhouse/client cross-suite parity runner.
  *
  * Clones @clickhouse/client at a configured ref, builds it, patches
- * upstream's `packages/client-node/vitest.setup.ts` in-place to wrap
+ * upstream's vitest setup in-place to wrap
  * `globalThis.environmentSpecificCreateClient` with `createChdbConnection`,
  * then runs the integration suite filtered by
  * `tests/clickhouse-js/skip_list.json`. The setup patch is restored in a
  * try/finally block so the upstream checkout isn't left dirty.
  *
- * Upstream layout note: clickhouse-js #931 embedded the Vitest config and
- * setup into the node package, moving the root `vitest.node.setup.ts` /
- * `vitest.node.config.ts` to `packages/client-node/vitest.setup.ts` /
- * `vitest.config.ts`. The integration specs themselves stay package-rooted
- * (`packages/{client-common,client-node}/__tests__/...`), so skip_list paths
- * are unaffected.
+ * Upstream layout note (auto-detected at runtime):
+ *
+ *   - **pre-#931** layout (e.g. `client-1.23.0` release tag, cut before
+ *     #931 merged): setup lives at repo-root `vitest.node.setup.ts`;
+ *     integration script is `npm run test:node:integration` at the root.
+ *   - **post-#931** layout (main, and any release cut after #931):
+ *     Vitest config + setup embedded into `packages/client-node/`;
+ *     integration script is `test:integration` in that package.
+ *
+ * The integration specs themselves stay package-rooted
+ * (`packages/{client-common,client-node}/__tests__/...`) in both layouts,
+ * so skip_list paths are unaffected by the reorg.
  *
  * Sync policy (encoded in skip_list.json's `syncedAgainst` block):
  *
@@ -100,21 +106,51 @@ const CHDB_INJECTION_BEGIN = "// >>> chdb-runner injection — DO NOT EDIT >>>";
 const CHDB_INJECTION_END   = "// <<< chdb-runner injection — DO NOT EDIT <<<";
 
 /**
- * Append the ChdbConnection wrapping snippet to upstream's
- * `packages/client-node/vitest.setup.ts` so vitest actually loads it (the
- * setup file is already in upstream's `setupFiles` config, so appending to
- * it is the one mechanism guaranteed to be picked up regardless of vitest
- * version or CLI flag support). Returns a `{file, original}` snapshot for
- * try/finally restoration.
+ * Detect the upstream Vitest layout (pre-#931 root, or post-#931
+ * per-package). Returns the concrete file path to patch and the npm
+ * script incantation to invoke.
+ *
+ * Detection is done by probing which setup file exists on disk — cheaper
+ * and more reliable than parsing package.json scripts.
  */
-function injectSetup() {
-  const target = join(WORK_DIR, "packages", "client-node", "vitest.setup.ts");
-  if (!existsSync(target)) {
-    throw new Error(
-      `[runner] upstream packages/client-node/vitest.setup.ts not found at ${target}; ` +
-      `injection cannot proceed`,
-    );
+function detectLayout() {
+  const postPath = join(WORK_DIR, "packages", "client-node", "vitest.setup.ts");
+  const prePath = join(WORK_DIR, "vitest.node.setup.ts");
+  if (existsSync(postPath)) {
+    return {
+      kind: "post-931",
+      setupFile: postPath,
+      // packages/client-node has its own `test:integration` script; going
+      // through the root aggregator adds an extra `npm run` hop that swallows
+      // vitest CLI flags, so we invoke the package script directly.
+      npmArgs: ["--prefix", "packages/client-node", "run", "test:integration", "--"],
+    };
   }
+  if (existsSync(prePath)) {
+    return {
+      kind: "pre-931",
+      setupFile: prePath,
+      // Pre-#931 layout: the root `test:node:integration` script IS the
+      // vitest invocation (no aggregator layer), so `--` forwarding is clean.
+      npmArgs: ["run", "test:node:integration", "--", "--config", "vitest.node.config.ts"],
+    };
+  }
+  throw new Error(
+    `[runner] no recognized vitest setup file found; tried:\n  ${postPath}\n  ${prePath}`,
+  );
+}
+
+/**
+ * Append the ChdbConnection wrapping snippet to the detected setup file
+ * so vitest actually loads it (the setup file is already in upstream's
+ * `setupFiles` config, so appending to it is the one mechanism guaranteed
+ * to be picked up regardless of vitest version or CLI flag support).
+ * Returns a `{file, original}` snapshot for try/finally restoration.
+ */
+function injectSetup(layout) {
+  const target = layout.setupFile;
+  console.log(`[runner] detected upstream layout: ${layout.kind}`);
+  console.log(`[runner] patching setup file:      ${target}`);
   const original = readFileSync(target, "utf8");
   // Strip any leftover injection from a prior crashed run, then append fresh.
   const cleaned = stripInjection(original);
@@ -238,25 +274,12 @@ function restorePerTestSkips(patches) {
 }
 
 function runVitest() {
-  const setupSnap = injectSetup();
+  const layout = detectLayout();
+  const setupSnap = injectSetup(layout);
   const excludes = buildSkipPattern();
   const patches = applyPerTestSkips();
   try {
-    // Call the node package's `test:integration` script directly rather than
-    // the root `test:node:integration` aggregator. The aggregator is itself an
-    // `npm --prefix packages/client-node run test:integration`, so forwarding
-    // vitest flags through it (`npm run test:node:integration -- --exclude X`)
-    // would feed `--exclude X` to the inner `npm`, not to vitest. Going
-    // straight to the package script keeps a single `--` hop to vitest. The
-    // config is auto-loaded from packages/client-node/vitest.config.ts (its
-    // `root` is the repo root, so the repo-root-relative skip_list globs match).
-    const args = [
-      "--prefix",
-      "packages/client-node",
-      "run",
-      "test:integration",
-      "--",
-    ];
+    const args = [...layout.npmArgs];
     for (const f of excludes) args.push("--exclude", f);
     const env = {
       ...process.env,

--- a/tests/clickhouse-js/skip_list.json
+++ b/tests/clickhouse-js/skip_list.json
@@ -1,10 +1,10 @@
 {
   "$schema_comment": "chdb-node skip list for @clickhouse/client's integration suite. AUTHORITATIVE blacklist applied by tests/clickhouse-js/runner.mjs when running @clickhouse/client's tests with ChdbConnection injected. Format: skipFiles is per-file (entire suite of tests in the file is excluded — for files where chdb does not implement the capability the file exercises); skipTests is per-case for cases inside an otherwise-runnable file (the runner patches the file in place to convert it(...) → it.skip(...) before vitest collects, and restores after). reasons documents WHY each entry is here. Maintained per @clickhouse/client release; chdb-node refreshes the list when upstream cuts a new version.",
   "syncedAgainst": {
-    "ref": "ClickHouse/clickhouse-js main",
-    "policy": "While the createClient({ connection }) injection PR is open: ShawnChen-Sirius fork branch. After merge: ClickHouse/clickhouse-js main (CURRENT — PR #879 was merged 2026-06-23 as commit c2e28b9; PR #880 follow-up was merged 2026-06-23 as commit 274844f). After next release: latest released tag. NOTE: PR #931 (commit 199f9946) embedded the Vitest config/setup into the node package — the runner now patches packages/client-node/vitest.setup.ts and runs the packages/client-node test:integration script; the spec files stayed package-rooted so the paths below are unchanged.",
-    "lastSyncedSha": "199f9946",
-    "lastSyncedAt": "2026-06-30"
+    "ref": "client-1.23.0",
+    "policy": "While the createClient({ connection }) injection PR is open: ShawnChen-Sirius fork branch. After merge: ClickHouse/clickhouse-js main. After next release: latest released tag (CURRENT — @clickhouse/client 1.23.0 was published to npm on 2026-06-29 as GitHub tag `client-1.23.0` at commit 70ad405, the first stable release containing the `connection` injection point from PR #879/#880). NOTE on Vitest layout: this release was cut BEFORE PR #931 (which merged 2026-06-30 as commit 199f9946 and embedded the Vitest config/setup into `packages/client-node/`). The `client-1.23.0` tag therefore still has the root-level `vitest.node.setup.ts` / `vitest.node.config.ts` and the root `test:node:integration` script — runner.mjs auto-detects and adapts to either layout. Spec paths in skipFiles/skipTests below are package-rooted (`packages/{client-common,client-node}/__tests__/...`) and unchanged across both layouts.",
+    "lastSyncedSha": "70ad405",
+    "lastSyncedAt": "2026-07-01"
   },
   "skipFiles": [
     {


### PR DESCRIPTION
## Problem

The release workflow builds the native addon and runs the suite **in the build tree**, so
it only ever tests the in-place build, never the artifact users install. That is the gap
#50 fell through: the Linux `@chdb/lib-*` binary had the build machine's absolute rpath
(`/home/runner/work/chdb-node/chdb-node/libchdb.so`) baked in, which loaded fine on the CI
build box and threw `cannot open shared object file` on every clean host.

First principles: what a user runs is the packed tarball, with `@chdb/lib-*` resolved
through optionalDependencies and loaded by rpath at the **installed** location, on a clean
machine. None of that is exercised by "build then test in place." So: test what users get,
and gate `latest` on it.

## Change

- **`test/pack/installed.test.mjs`** imports `chdb` **by name** (never the source tree), so
  it exercises the packed files, the platform binary resolved via optionalDependencies, its
  rpath at the installed location, and the subpath exports. The first `import 'chdb'` loads
  the native addon from where npm put it — the exact #50 failure point. It then runs
  version(), a stateless query, an async query, a Session insert/query/stream round-trip,
  and a `chdb/connection` subpath resolution.

- **`prebuild-publish.yml`** becomes publish → verify → promote:
  - a stable release is published to a holding dist-tag (`unverified`); prereleases stay on `next`;
  - a `verify` matrix (every target platform x Node 18/20/22) installs the just-published
    `chdb` from npm into a clean dir and runs the installed-package tests;
  - `promote` moves `latest` only after verify is green on every leg. If verify fails on any
    platform, users on `latest` never see the broken release.

## Validation

Locally: `npm pack` -> clean `npm install ./chdb-*.tgz` (real `@chdb/lib-*` pulled from npm)
-> the installed-package tests pass 5/5. The same flow would have failed at `import 'chdb'`
on the #50 build.

## Notes

- The unit suite (`test/v3`, source correctness) still runs in-tree on PRs; the new
  installed-package suite is the release-time artifact gate. Separate concerns.
- `@chdb/lib-*` subpackages publish before verify, but nobody installs them directly — they
  are pulled transitively only by a `chdb` version, which is gated by the `latest`
  promotion, so a bad binary can't reach users via `latest`.
- Bun/Deno legs can be added to the verify matrix as a follow-up.

Fixes the class of bug behind #50.


---

## Additional change: sync `@clickhouse/client` 1.23.0 release

@clickhouse/client 1.23.0 was published to npm on 2026-06-29 (GitHub release tag `client-1.23.0` at commit `70ad405`) — the first stable release carrying the `connection` injection point from clickhouse-js#879/#880. This is the first end-to-end path where users can `npm install chdb @clickhouse/client` and get a working chDB integration without pinning a pre-release. Three follow-ups landed in the second commit of this PR:

1. **`peerDependencies['@clickhouse/client']: ">=1.23.0"` (optional).** Marked optional in `peerDependenciesMeta` so users installing chdb without `chdb/connection` aren't forced to pull it in. Users who DO import from `chdb/connection` with an older `@clickhouse/client` now get a clear npm warning instead of a runtime TS error / undefined field surprise.

2. **`skip_list.json#syncedAgainst.ref`: `main` → `client-1.23.0`.** Follows the sync-policy table's third row ("After next release: latest released tag"). `lastSyncedSha` bumped to `70ad405`, `lastSyncedAt` to 2026-07-01.

3. **`runner.mjs` auto-detects the upstream Vitest layout.** `client-1.23.0` was cut before clickhouse-js#931 (which merged 2026-06-30 and moved the config/setup into `packages/client-node/`). The release tag still has the OLD repo-root layout (`vitest.node.setup.ts` at root, `test:node:integration` script at root); main has the NEW per-package layout. `runner.mjs` now probes for both setup-file locations and picks the right npm-script incantation for each.

Verification (clean env):

```
rm -rf .chdb-runner
npm run build:ts                                    → clean
npx vitest run test/v3/connection/contract.test.ts  → 13/13
node tests/clickhouse-js/runner.mjs                 → detected upstream layout: pre-931
                                                      Test Files 26 pass / 2 skip (28)
                                                      Tests 170 pass / 41 skip / 0 fail (211)
```

The 10-test drop vs. the previous main run (180 → 170) is because the pre-#931 `test:node:integration` script only invokes the client-node integration suite; the post-#931 `packages/client-node` script pulls the shared common tests in as well. `ChdbConnection` coverage is identical across both — every previously-passing case that surfaces the adapter still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verify the published npm package on clean installs before promoting to latest
> - Stable releases now publish under the `unverified` dist-tag instead of `latest`; a new `verify` job in [prebuild-publish.yml](.github/workflows/prebuild-publish.yml) installs the package into a clean temp dir across 4 OSes and Node 18/20/22, runs the new [installed.test.mjs](test/pack/installed.test.mjs) suite, and retries up to 6 times for registry propagation.
> - A new `promote` job moves the `latest` dist-tag to the verified version only after all matrix checks pass; prereleases continue to publish directly under `next`.
> - npm retry/backoff env vars and `cache: npm` are added to all CI workflows to reduce flakiness from transient registry errors.
> - The clickhouse-js test runner gains a `detectLayout()` function to handle both pre- and post-#931 upstream repo layouts automatically.
> - Behavioral Change: stable releases are no longer immediately available under `latest`; consumers relying on `npm install chdb` will get the version only after cross-platform verification completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79d3a39.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
