### PR TITLE
integrations(hypequery): import substituteParameters instead of copying it

### DIFF
--- a/integrations/hypequery.mjs
+++ b/integrations/hypequery.mjs
@@ -11,14 +11,17 @@
 //
 // hypequery's createQueryBuilder already accepts a custom `adapter` (DatabaseAdapter),
 // and it renders final SQL with `?`-positional params client-side, so the adapter only
-// has to run a complete SQL string and return JSONEachRow rows. This is intentionally
-// dependency-light: it does not import @hypequery/clickhouse at runtime (the adapter is
-// duck-typed against the DatabaseAdapter shape).
+// has to run a complete SQL string and return JSONEachRow rows. It renders those params
+// with hypequery's own substituteParameters (exported since @hypequery/clickhouse 2.1.2),
+// so the SQL it produces is byte-identical to hypequery's built-in HTTP adapter — no
+// copied escaping to drift out of sync.
 //
-// `@hypequery/clickhouse` is an optional peer dependency (types only).
+// `@hypequery/clickhouse` is an optional peer dependency: it's only needed when you use
+// this adapter, which by definition means hypequery is already installed.
 
 // In the chdb-node package this imports from the package ESM entry:
 import { Session, queryAsync } from '../index.mjs'
+import { substituteParameters } from '@hypequery/clickhouse'
 
 const ROW_FORMAT = 'JSONEachRow'
 
@@ -52,8 +55,8 @@ export function chdbAdapter(opts = {}) {
       return chunkStreamToReadable(chStream)
     },
 
-    // hypequery calls render() when present (else its own substituteParameters); we
-    // reproduce its rendering exactly so generated SQL matches the HTTP adapter.
+    // hypequery calls render() when present (else its own substituteParameters); we call
+    // the very same substituteParameters, so generated SQL matches the HTTP adapter exactly.
     render(sql, params = []) {
       return substituteParameters(sql, params)
     },
@@ -62,40 +65,7 @@ export function chdbAdapter(opts = {}) {
 
 export default chdbAdapter
 
-// --- helpers (mirror @hypequery/clickhouse core/utils.ts exactly) ------------
-// If hypequery exports substituteParameters/escapeValue (see the proposed PR),
-// import them instead of duplicating, so the two stay byte-identical.
-
-function substituteParameters(sql, params) {
-  if (!params || params.length === 0) return sql
-  const parts = sql.split('?')
-  if (parts.length - 1 !== params.length) {
-    throw new Error(
-      `chdbAdapter: mismatch between placeholders and parameters — ${parts.length - 1} placeholders, ${params.length} parameters.`,
-    )
-  }
-  let out = ''
-  for (let i = 0; i < params.length; i++) out += parts[i] + escapeValue(params[i])
-  return out + parts[parts.length - 1]
-}
-
-function escapeValue(value) {
-  // null / undefined → SQL NULL (matches ClickHouse convention and avoids the
-  // literal string 'undefined' that `JSON.stringify(undefined)` would produce).
-  if (value === null || value === undefined) return 'NULL'
-  if (typeof value === 'boolean') return value ? 'true' : 'false'
-  if (typeof value === 'number') return value.toString()
-  // BigInt is unquoted numeric to match ClickHouse's numeric literal syntax and
-  // avoid `JSON.stringify(BigInt(...))` throwing "Do not know how to serialize".
-  if (typeof value === 'bigint') return value.toString()
-  if (typeof value === 'string') return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "''")}'`
-  if (value instanceof Date) return `'${value.toISOString()}'`
-  // Objects / arrays: JSON stringify, then apply the same backslash + single-quote
-  // escaping the string branch uses. ClickHouse SQL doubles `'` inside string
-  // literals; leaving raw single quotes from the JSON encoding produces malformed
-  // SQL (e.g. `{name:"O'Reilly"}` → `'{"name":"O'Reilly"}'` which chokes the parser).
-  return `'${JSON.stringify(value).replace(/\\/g, '\\\\').replace(/'/g, "''")}'`
-}
+// --- helpers ----------------------------------------------------------------
 
 function parseJsonEachRow(text) {
   const out = []

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "chdb-gen-types": "dist/layer3/codegen/cli.js"
       },
       "devDependencies": {
-        "@hypequery/clickhouse": "^2.1.1",
+        "@hypequery/clickhouse": "^2.1.2",
         "@mastra/core": "^1.47.0",
         "@types/node": "^20.14.0",
         "ai": "^7.0.2",
@@ -40,13 +40,17 @@
         "@chdb/lib-linux-x64-gnu": "26.5.2"
       },
       "peerDependencies": {
-        "@hypequery/clickhouse": ">=2",
+        "@clickhouse/client": ">=1.23.0",
+        "@hypequery/clickhouse": ">=2.1.2",
         "@mastra/core": ">=0.10",
         "ai": ">=5",
         "apache-arrow": ">=14",
         "zod": ">=3"
       },
       "peerDependenciesMeta": {
+        "@clickhouse/client": {
+          "optional": true
+        },
         "@hypequery/clickhouse": {
           "optional": true
         },
@@ -331,7 +335,7 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.23.0.tgz",
       "integrity": "sha512-Li6TBcRKfWVxyJa8g+lJwuyn+r+zV/pJJ3yxn3TVlC00vH+zfZ6njFXsZfqIamGXHRrY5iPhAEZu2hSWzlSo3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -754,9 +758,9 @@
       }
     },
     "node_modules/@hypequery/clickhouse": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@hypequery/clickhouse/-/clickhouse-2.1.1.tgz",
-      "integrity": "sha512-e3fYH1Qr+RWQQmeBlz1lDrbzhzDeEG9HnDxFqxJmOZCJLpeAFMMeqswkyRPKLJNeTma2LtmybjURgiip/MmcDA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@hypequery/clickhouse/-/clickhouse-2.1.2.tgz",
+      "integrity": "sha512-CFkMewsVEhKlgp6h9s1L2QLyXjbGN0CZxWqkRHBrDdtAt3c4VTomx2Ytjrd+9rNlrJRQY+YoS3hjwE96Qjmn5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "integrations"
   ],
   "devDependencies": {
-    "@hypequery/clickhouse": "^2.1.1",
+    "@hypequery/clickhouse": "^2.1.2",
     "@mastra/core": "^1.47.0",
     "@types/node": "^20.14.0",
     "ai": "^7.0.2",
@@ -96,7 +96,7 @@
   },
   "peerDependencies": {
     "@clickhouse/client": ">=1.23.0",
-    "@hypequery/clickhouse": ">=2",
+    "@hypequery/clickhouse": ">=2.1.2",
     "@mastra/core": ">=0.10",
     "ai": ">=5",
     "apache-arrow": ">=14",


### PR DESCRIPTION
Follow-up cleanup now that both halves have landed:
- chdb-io/chdb-node#63 shipped the `chdb/hypequery` adapter, which carried a byte-for-byte **copy** of hypequery's `substituteParameters`/`escapeValue` because they weren't exported yet.
- hypequery/hypequery#239 exported them, released in **`@hypequery/clickhouse@2.1.2`**.

So the copy can go.

## Change
- `import { substituteParameters } from '@hypequery/clickhouse'` and delete the duplicated `substituteParameters`/`escapeValue` helpers (~40 lines).
- Bump the `@hypequery/clickhouse` **optional peer** to `>=2.1.2` (first version with the exports) and the devDependency to `^2.1.2`.

## Why it's safe
- Anyone using `chdb/hypequery` is by definition using hypequery, so `@hypequery/clickhouse` is already installed — the runtime import adds no real dependency, and it stays an *optional* peer.
- Using hypequery's own `substituteParameters` guarantees the SQL the adapter renders stays byte-identical to hypequery's built-in HTTP adapter, instead of relying on a copy that can drift.

## Verification
- Installed `@hypequery/clickhouse@2.1.2` and confirmed both `substituteParameters` and `escapeValue` are exported (runtime + `.d.ts`).
- `test/v3/integrations/hypequery.test.ts` passes 4/4 against the real imported helper (the run logs show hypequery itself engaged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace local `substituteParameters` implementation with import from `@hypequery/clickhouse`
> Removes the local `substituteParameters` and `escapeValue` helpers from [hypequery.mjs](https://github.com/chdb-io/chdb-node/pull/65/files#diff-29c7b9010c97ae86b8cc5dff47c945f3d0d645da0a06fb4bfca3b293cdd547d8) and delegates parameter substitution to the upstream library instead. Bumps the `@hypequery/clickhouse` dependency from `^2.1.1` to `^2.1.2` and tightens the peer dependency range to `>=2.1.2` to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da149e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->