### PR TITLE
release: publish subpackages as 26.5.3 and test the freshly built addon

### DIFF
--- a/.github/workflows/prebuild-publish.yml
+++ b/.github/workflows/prebuild-publish.yml
@@ -48,6 +48,14 @@ jobs:
       - run: npm install --ignore-scripts
       - run: npm run libchdb
       - run: npm run build
+      - name: Exercise the freshly built addon (not the published prebuilt)
+        # The loader prefers the installed @chdb/lib-<platform> subpackage over
+        # a local build (see dist/loader.js). npm install pulls the PREVIOUS
+        # published subpackage via optionalDependencies, whose addon lags the
+        # in-repo native source — so without this, test:all exercises the old
+        # binary instead of the one this run is about to package and publish.
+        shell: bash
+        run: rm -rf node_modules/@chdb/lib-*
       - run: npm run test:all
       - name: Derive subpackage version from update_libchdb.sh
         run: |

--- a/package.json
+++ b/package.json
@@ -93,10 +93,10 @@
     "node-gyp-build": "^4.6.0"
   },
   "optionalDependencies": {
-    "@chdb/lib-darwin-arm64": "26.5.2",
-    "@chdb/lib-darwin-x64": "26.5.2",
-    "@chdb/lib-linux-arm64-gnu": "26.5.2",
-    "@chdb/lib-linux-x64-gnu": "26.5.2"
+    "@chdb/lib-darwin-arm64": "26.5.3",
+    "@chdb/lib-darwin-x64": "26.5.3",
+    "@chdb/lib-linux-arm64-gnu": "26.5.3",
+    "@chdb/lib-linux-x64-gnu": "26.5.3"
   },
   "peerDependencies": {
     "@clickhouse/client": ">=1.23.0",

--- a/test/pack/installed.test.mjs
+++ b/test/pack/installed.test.mjs
@@ -13,6 +13,9 @@
 
 import { describe, it, expect } from 'vitest'
 import { query, queryAsync, Session, version } from 'chdb'
+// The Layer 3 fluent surface (registerArrowTable / selectFrom / chTable) is
+// reached through the default export in ESM — see the index.mjs comment.
+import chdb from 'chdb'
 
 // Run cases sequentially. The suite mixes the standalone default connection
 // (`version()`, `query()`, `queryAsync()`) with a `Session` that binds its
@@ -35,6 +38,30 @@ describe.sequential('installed chdb package', () => {
   it('runs an async query and parses rows', async () => {
     const r = await queryAsync("SELECT number FROM numbers(3)", { format: 'JSONEachRow' })
     expect(r.text().trim().split('\n')).toHaveLength(3)
+  })
+
+  it('round-trips Arrow C Data Interface input (native ArrowRegisterColumns)', async () => {
+    // Guards the addon's export surface, not just its loadability: the
+    // installed binary comes from the @chdb/lib-* subpackage, which is
+    // versioned independently of this package — a stale subpackage loads
+    // and queries fine but lacks the Arrow registration natives.
+    const t = chdb.registerArrowTable('installed_arrow', [
+      { name: 'id', type: 'Int32', data: new Int32Array([1, 2, 3]) },
+      { name: 'tag', type: 'String', data: ['a', 'b', 'c'] },
+    ])
+    try {
+      const rows = await chdb.selectFrom(chdb.chTable.arrowstream('installed_arrow').as('t'))
+        .select(['id', 'tag'])
+        .orderBy('id')
+        .execute()
+      expect(rows).toEqual([
+        { id: 1, tag: 'a' },
+        { id: 2, tag: 'b' },
+        { id: 3, tag: 'c' },
+      ])
+    } finally {
+      t.close()
+    }
   })
 
   it('creates a Session and round-trips an insert + query + stream', async () => {

--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -16,15 +16,17 @@ set -e
 LATEST_RELEASE=v26.5.1-rc.1
 
 # Version published for the @chdb/lib-<platform> native subpackages on npm.
-# DECOUPLED from LATEST_RELEASE on purpose: chdb-core has no 26.5.2 release, but
-# the previously published subpackage versions (26.5.0, 26.5.1-rc.1) shipped a
-# non-relocatable Linux binary (chdb-io/chdb-node#50). npm forbids republishing
-# over an existing version, so the relocatability fix needs a NEW version — a
-# formal packaging revision — while the bundled libchdb stays LATEST_RELEASE
-# above (the only build carrying the #73/#15 C-ABI the binding requires). The
-# publish + cleanroom workflows read CHDB_LIB_VERSION from here, and the main
-# package's optionalDependencies pin this exact value.
-LIBCHDB_NPM_VERSION=26.5.2
+# DECOUPLED from LATEST_RELEASE on purpose: chdb-core has no 26.5.x releases
+# past 26.5.1-rc.1, but the subpackage also ships the N-API addon, so any
+# change to the addon's export surface needs a NEW subpackage version — npm
+# forbids republishing over an existing one. 26.5.2 was the relocatability
+# packaging revision (chdb-io/chdb-node#50); 26.5.3 adds the Arrow C Data
+# Interface exports (ArrowRegisterColumns/…) the Layer 3 arrow-input path
+# requires. The bundled libchdb stays LATEST_RELEASE above (the only build
+# carrying the #73/#15 C-ABI the binding requires). The publish + cleanroom
+# workflows read CHDB_LIB_VERSION from here, and the main package's
+# optionalDependencies pin this exact value.
+LIBCHDB_NPM_VERSION=26.5.3
 
 # Download the correct version based on the platform
 case "$(uname -s)" in


### PR DESCRIPTION
The v3.2.0 publish run ([29225306812](https://github.com/chdb-io/chdb-node/actions/runs/29225306812)) failed in the subpackages job, and the failure exposed a release blocker the tests were right to catch.

**Why it failed:** the loader prefers the installed `@chdb/lib-<platform>` subpackage over `build/Release`, and the publish workflow (unlike the test workflow) did not remove the installed subpackages before `test:all` — so the suite exercised the published 26.5.2 addon, which predates the Arrow C Data Interface exports (`ArrowRegisterColumns`/…) the Layer 3 arrow-input path requires.

**The real blocker:** the subpackage version was still 26.5.2, which is already on the registry. The publish step would have skipped, `optionalDependencies` would keep resolving the stale addon, and `chdb@3.2.0` would have shipped broken Arrow input to user machines even with green tests.

**Changes:**
- `update_libchdb.sh`: `LIBCHDB_NPM_VERSION` 26.5.2 → 26.5.3 (packaging revision; the bundled libchdb stays v26.5.1-rc.1)
- `package.json`: pin the four `optionalDependencies` to 26.5.3
- `prebuild-publish.yml`: remove the installed `@chdb/lib-*` before `test:all`, matching the test workflow
- `test/pack/installed.test.mjs`: add an Arrow C Data Interface round-trip so the verify job exercises the addon's export surface — a stale subpackage passes every existing case and still lacks the Arrow natives

Verified locally with the cleanroom recipe (pack main + 26.5.3 subpackage tgz → clean-dir install → installed suite 6/6 green on darwin-arm64).

After merge: re-tag `v3.2.0` on the merge commit to re-trigger the publish pipeline (the failed run published nothing, so the tag can be reused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish subpackages as version 26.5.3 and test the freshly built addon
> - Bumps `@chdb/lib-*` optionalDependencies in [package.json](https://github.com/chdb-io/chdb-node/pull/71/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and `LIBCHDB_NPM_VERSION` in [update_libchdb.sh](https://github.com/chdb-io/chdb-node/pull/71/files#diff-6f35e23173ec48cae47760551bfa867846783d6a777bcf30354d7dd8e2e11ecb) from 26.5.2 to 26.5.3, which adds Arrow C Data Interface exports.
> - Adds a CI step in [prebuild-publish.yml](https://github.com/chdb-io/chdb-node/pull/71/files#diff-0078c6dcea484b8b3ecd301c31b6258ac37751511a77938a02c7ca977dbc1efb) that deletes installed `@chdb/lib-*` subpackages before running `test:all`, ensuring tests run against the freshly built addon rather than the published prebuilt.
> - Extends [installed.test.mjs](https://github.com/chdb-io/chdb-node/pull/71/files#diff-8c4654189490f944a1890ec0444dc3194592dda26ddaa5dc09a68d60c0ae1af3) with an Arrow table registration test that validates the Arrow C Data Interface path through the default ESM export.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac4c15d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->