### PR TITLE
ci: prebuild-publish must test the just-built addon; bump @chdb/lib-* to 26.5.3

### DIFF
--- a/.github/workflows/prebuild-publish.yml
+++ b/.github/workflows/prebuild-publish.yml
@@ -48,6 +48,16 @@ jobs:
       - run: npm install --ignore-scripts
       - run: npm run libchdb
       - run: npm run build
+      - name: Drop the installed @chdb/lib-* so tests exercise the just-built addon
+        # The loader prefers an installed @chdb/lib-<platform> subpackage over the
+        # local build (src/loader.ts). npm install pulls the PREVIOUSLY published
+        # subpackage via optionalDependencies, which lags behind the native source
+        # being released here — so test:all would validate the wrong binary (red on
+        # every new native export, e.g. v3.2.0 / #72). Mirror chdb-node-test.yml:
+        # remove it so loadNative() falls through to build/Release/chdb_node.node,
+        # the exact binary this job is about to package and publish.
+        shell: bash
+        run: rm -rf node_modules/@chdb/lib-*
       - run: npm run test:all
       - name: Derive subpackage version from update_libchdb.sh
         run: |

--- a/package.json
+++ b/package.json
@@ -93,10 +93,10 @@
     "node-gyp-build": "^4.6.0"
   },
   "optionalDependencies": {
-    "@chdb/lib-darwin-arm64": "26.5.2",
-    "@chdb/lib-darwin-x64": "26.5.2",
-    "@chdb/lib-linux-arm64-gnu": "26.5.2",
-    "@chdb/lib-linux-x64-gnu": "26.5.2"
+    "@chdb/lib-darwin-arm64": "26.5.3",
+    "@chdb/lib-darwin-x64": "26.5.3",
+    "@chdb/lib-linux-arm64-gnu": "26.5.3",
+    "@chdb/lib-linux-x64-gnu": "26.5.3"
   },
   "peerDependencies": {
     "@clickhouse/client": ">=1.23.0",

--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -16,15 +16,18 @@ set -e
 LATEST_RELEASE=v26.5.1-rc.1
 
 # Version published for the @chdb/lib-<platform> native subpackages on npm.
-# DECOUPLED from LATEST_RELEASE on purpose: chdb-core has no 26.5.2 release, but
-# the previously published subpackage versions (26.5.0, 26.5.1-rc.1) shipped a
-# non-relocatable Linux binary (chdb-io/chdb-node#50). npm forbids republishing
-# over an existing version, so the relocatability fix needs a NEW version — a
-# formal packaging revision — while the bundled libchdb stays LATEST_RELEASE
-# above (the only build carrying the #73/#15 C-ABI the binding requires). The
-# publish + cleanroom workflows read CHDB_LIB_VERSION from here, and the main
-# package's optionalDependencies pin this exact value.
-LIBCHDB_NPM_VERSION=26.5.2
+# DECOUPLED from LATEST_RELEASE on purpose: chdb-core has no 26.5.2/26.5.3
+# release. 26.5.2 was a packaging revision for the non-relocatable Linux binary
+# (chdb-io/chdb-node#50); 26.5.3 is another one: the native addon source gained
+# the Layer 3 Arrow C Data Interface exports (ArrowRegisterColumns, 98d81b6) and
+# .stream() server-side parameter binding (f6457ee) AFTER 26.5.2 was published,
+# and npm forbids republishing over an existing version — without a bump the
+# release pipeline "skips already-published" and the new native code never ships
+# (chdb-io/chdb-node#72). The bundled libchdb stays LATEST_RELEASE above (the
+# only build carrying the #73/#15 C-ABI the binding requires). The publish +
+# cleanroom workflows read CHDB_LIB_VERSION from here, and the main package's
+# optionalDependencies pin this exact value.
+LIBCHDB_NPM_VERSION=26.5.3
 
 # Download the correct version based on the platform
 case "$(uname -s)" in


### PR DESCRIPTION
Fixes #72 — the `prebuild-publish` run for **v3.2.0** (https://github.com/chdb-io/chdb-node/actions/runs/29225306812) went red on all 4 `subpackages` legs, and the release never shipped.

### Root cause

Two coupled defects, both from the same fact: `@chdb/lib-*@26.5.2` already exists on npm (published 2026-06-24, v3.1.0-era native source — before `ArrowRegisterColumns` (98d81b6) and `.stream()` server-side param binding (f6457ee) existed):

1. **The release pipeline tested the wrong binary.** `npm install --ignore-scripts` pulls the published `@chdb/lib-*@26.5.2` via optionalDependencies, and `src/loader.ts` prefers the installed subpackage over the freshly built `build/Release/chdb_node.node`. So `npm run test:all` exercised the stale 26.5.2 binary → 8× `TypeError: chdbNode.ArrowRegisterColumns is not a function` + 5× `Code: 456 Substitution 'p0' is not set (UNKNOWN_QUERY_PARAMETER)` per job, identical on all 4 platforms. `chdb-node-test.yml` is green on the same sha only because it already drops the installed subpackage before testing; `prebuild-publish.yml` was missing that step.
2. **Even with green tests, v3.2.0 would have shipped the stale binary.** The subpackage publish step intentionally skips already-published versions, and `LIBCHDB_NPM_VERSION` was still `26.5.2` — so the freshly built binaries would never publish and `chdb@3.2.0` would resolve to the old 26.5.2 binaries, breaking the Layer 3 Arrow API at runtime for every user.

### Fix

- `prebuild-publish.yml` (subpackages job): drop `node_modules/@chdb/lib-*` before `npm run test:all`, mirroring `chdb-node-test.yml`, so the release pipeline tests the exact binary it is about to package and publish.
- `update_libchdb.sh`: `LIBCHDB_NPM_VERSION` 26.5.2 → **26.5.3** (packaging revision — npm forbids republishing 26.5.2), with the history documented in the comment.
- `package.json`: bump the four `@chdb/lib-*` optionalDependencies pins to 26.5.3.

### Reproduction + validation (linux-x64, commit 0513de20, exact CI sequence)

```
npm install --ignore-scripts        # installs @chdb/lib-linux-x64-gnu@26.5.2
npm run libchdb && npm run build
npx vitest run test/v3/layer3/arrow-input.test.ts test/v3/layer3/stream.test.ts
#  → 9 failed | 6 passed — 16× "ArrowRegisterColumns is not a function",
#    "Substitution `p0` is not set" — identical frames to the CI run
rm -rf node_modules/@chdb/lib-*     # the fix's new step
npx vitest run ...                  # → 15 passed (15)
```

With this branch applied: `npm install --ignore-scripts` exits 0 with 26.5.3 not yet on the registry (optional dep skipped, loader falls through to the local build — same state CI will be in until the subpackages job publishes), and the full suite passes: **`npm run test:all` → 39 files, 452 passed | 11 skipped**.

### Notes for re-release

After merge, re-running the release (re-tag v3.2.0 or cut v3.2.1) is a maintainer call. The `verify` job then installs the *published* `chdb` + `@chdb/lib-*@26.5.3` from the registry on all 12 legs, which independently gates `promote` → `latest`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix prebuild-publish CI to test the locally built addon and bump @chdb/lib-* to 26.5.3
> - Adds a step in [prebuild-publish.yml](.github/workflows/prebuild-publish.yml) that removes installed `@chdb/lib-*` packages from `node_modules` before running `test:all`, ensuring the test exercises the freshly built `chdb_node.node` binary rather than a previously published subpackage.
> - Bumps `LIBCHDB_NPM_VERSION` in [update_libchdb.sh](update_libchdb.sh) and `optionalDependencies` in [package.json](package.json) from `26.5.2` to `26.5.3`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91433b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->