### PR TITLE
Bind Tuple parameters and integer Map keys, matching @clickhouse/client

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -143,7 +143,8 @@ function serializeNumber(value: number): string {
  *  - string                  -> escaped single-quoted literal
  *  - Date                    -> 'YYYY-MM-DD HH:MM:SS' (UTC)
  *  - Array / TypedArray      -> [a, b, c]
- *  - Map                     -> {k: v, ...}  (keys escaped as string literals)
+ *  - TupleParam              -> (a, b, c)    (tuple literal, elements quoted)
+ *  - Map                     -> {k: v, ...}  (keys serialized by JS type)
  *  - plain object            -> {k: v, ...}  (keys escaped as string literals)
  *
  * @throws ChdbBindError on non-finite numbers, invalid Dates, or unsupported types.
@@ -174,10 +175,15 @@ export function serializeValue(value: unknown): string {
 
   if (Array.isArray(value)) return serializeArray(value)
 
+  if (isTupleParam(value)) return serializeTuple(value.values)
+
   if (value instanceof Map) {
     const parts: string[] = []
     for (const [k, v] of value) {
-      parts.push(`${escapeStringLiteral(String(k))}:${serializeValue(v)}`)
+      // Serialize the key by its JS type, not force-quoted: a numeric key binds
+      // as `42` (an `{'42':…}` string-quoted key is rejected for `Map(Int32,…)`),
+      // a string key as `'k'`. Matches @clickhouse/client-common formatting.
+      parts.push(`${serializeValue(k)}:${serializeValue(v)}`)
     }
     return `{${parts.join(',')}}`
   }
@@ -203,6 +209,30 @@ export function serializeValue(value: unknown): string {
 // here.
 function serializeArray(arr: ReadonlyArray<unknown>): string {
   return `[${arr.map((x) => serializeValue(x)).join(',')}]`
+}
+
+function serializeTuple(values: ReadonlyArray<unknown>): string {
+  return `(${values.map((x) => serializeValue(x)).join(',')})`
+}
+
+/**
+ * Detect `@clickhouse/client-common`'s `TupleParam` (members in `.values`, binds
+ * as the tuple literal `(a,b,c)` — not the `{k:v}` form the generic-object
+ * branch would otherwise produce).
+ *
+ * Matched by shape, not `instanceof`: the instance a caller passes originates
+ * from their own `@clickhouse/client(-common)` copy, which pnpm (or any nested
+ * install) may resolve to a different module instance than ours, so an
+ * `instanceof` against our imported class would spuriously miss it. The class is
+ * shipped un-minified with its name intact, so the constructor-name check is
+ * reliable for real instances while staying a private, non-`TupleParam` object
+ * (which keeps the `{k:v}` map form) untouched.
+ */
+function isTupleParam(value: object): value is { values: ReadonlyArray<unknown> } {
+  return (
+    value.constructor?.name === 'TupleParam' &&
+    Array.isArray((value as { values?: unknown }).values)
+  )
 }
 
 /**

--- a/test/v3/querybind.test.ts
+++ b/test/v3/querybind.test.ts
@@ -27,6 +27,40 @@ describe('queryBind path A (server-side chdb_query_with_params)', () => {
     expect(row.m).toEqual({ abc: [1, 2, 3] })
   })
 
+  it('binds Tuple and Array(Tuple) params via a TupleParam-shaped value', () => {
+    // @clickhouse/client-common's TupleParam { values }, reproduced by shape so
+    // the test needs no dependency (serializeValue matches it structurally).
+    class TupleParam {
+      constructor(readonly values: unknown[]) {}
+    }
+    expect(
+      t('SELECT ({pair:Tuple(String, String)}).1', {
+        pair: new TupleParam(['main*', '^main.*$']),
+      }),
+    ).toBe('main*')
+    // The Array(Tuple(String, String)) case from the trunk check-branch-patterns
+    // query — previously failed with "cannot be parsed as Array(Tuple(...))".
+    const rows = queryBind(
+      `SELECT pair.1 AS glob, pair.2 AS re
+       FROM (SELECT arrayJoin({pairs:Array(Tuple(String, String))}) AS pair)
+       ORDER BY glob`,
+      {
+        pairs: [
+          new TupleParam(['dev*', '^dev.*$']),
+          new TupleParam(['main*', '^main.*$']),
+        ],
+      },
+      'JSONEachRow',
+    )
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l))
+    expect(rows).toEqual([
+      { glob: 'dev*', re: '^dev.*$' },
+      { glob: 'main*', re: '^main.*$' },
+    ])
+  })
+
   it('treats injection payloads as inert bound data (no interpolation)', () => {
     const payloads = ["'; DROP TABLE x; --", 'a\\b', "a' OR 1=1 --", 'tab\tend']
     for (const p of payloads) {

--- a/test/v3/serialize.test.ts
+++ b/test/v3/serialize.test.ts
@@ -96,8 +96,28 @@ describe('serializeValue (string assertions)', () => {
     expect(serializeValue(['a', "b'c"])).toBe("['a','b\\'c']")
     expect(serializeValue(new Int32Array([1, 2]))).toBe('[1,2]')
     expect(serializeValue(new Map<string, unknown>([['k', 1]]))).toBe("{'k':1}")
+    // Numeric Map key binds unquoted (Map(Int32, …)), string key stays quoted.
+    expect(serializeValue(new Map<number, unknown>([[42, 'v']]))).toBe("{42:'v'}")
     expect(serializeValue({ a: 1, b: 'x' })).toBe("{'a':1,'b':'x'}")
     expect(serializeValue([[1, 2], [3]])).toBe('[[1,2],[3]]')
+  })
+
+  it('serializes a TupleParam as a tuple literal, not an object', () => {
+    // @clickhouse/client-common's TupleParam { values }. Reproduce its shape
+    // (matched structurally, not by instanceof) so the test needs no dependency.
+    class TupleParam {
+      constructor(readonly values: unknown[]) {}
+    }
+    expect(serializeValue(new TupleParam(['main*', '^main.*$']))).toBe(
+      "('main*','^main.*$')",
+    )
+    expect(serializeValue(new TupleParam([42, 'foo', null]))).toBe("(42,'foo',NULL)")
+    // Nested inside an Array — the Array(Tuple(...)) param case.
+    expect(
+      serializeValue([new TupleParam(['a', 'b']), new TupleParam(['c', 'd'])]),
+    ).toBe("[('a','b'),('c','d')]")
+    // A private object literally named-differently keeps the {k:v} map form.
+    expect(serializeValue({ values: ['a', 'b'] })).toBe("{'values':['a','b']}")
   })
 })
 

--- a/tests/clickhouse-js/skip_list.json
+++ b/tests/clickhouse-js/skip_list.json
@@ -226,41 +226,6 @@
       "file": "packages/client-node/__tests__/integration/node_streaming_e2e.test.ts",
       "test": "[Node.js] streaming e2e > should stream a Parquet file",
       "reason": "Streams a Parquet file into chdb via `INSERT FORMAT Parquet`; chdb's `ParquetV3BlockInputFormat` rejects this specific fixture with `apache::thrift::protocol::TProtocolException: invalid TType`. The server's older Parquet input format accepts it. Engine-version divergence in Parquet decoder."
-    },
-    {
-      "file": "packages/client-common/__tests__/integration/select_query_binding.test.ts",
-      "test": "select with query binding > handles tuples in a parametrized query",
-      "reason": "chdb's `queryBindAsync` serializes Tuple parameter values using `{'field':value}` map-literal form. The engine's parser expects `(value1, value2, ...)` positional form. Real chdb-engine parameter-binding gap for compound types."
-    },
-    {
-      "file": "packages/client-common/__tests__/integration/select_query_binding.test.ts",
-      "test": "select with query binding > handles arrays of tuples in a parametrized query",
-      "reason": "Same chdb parameter-binding gap for Tuple — applies to Array(Tuple(...))."
-    },
-    {
-      "file": "packages/client-common/__tests__/integration/select_query_binding.test.ts",
-      "test": "select with query binding > handles maps with tuples in a parametrized query",
-      "reason": "Same chdb parameter-binding gap for Tuple — applies to Map(K, Tuple(...))."
-    },
-    {
-      "file": "packages/client-common/__tests__/integration/select_query_binding.test.ts",
-      "test": "select with query binding > handles maps with nested arrays in a parametrized query",
-      "reason": "chdb parameter-binding for Map(K, Array(...)) generates a serialization the engine parser rejects."
-    },
-    {
-      "file": "packages/client-common/__tests__/integration/select_query_binding.test.ts",
-      "test": "select with query binding > handles maps with nullable values in a parametrized query",
-      "reason": "chdb parameter-binding for Map(K, Nullable(V)) generates a serialization the engine parser rejects."
-    },
-    {
-      "file": "packages/client-common/__tests__/integration/select_query_binding.test.ts",
-      "test": "select with query binding > Nested boolean types > handles boolean in a tuple",
-      "reason": "Boolean inside Tuple parameter binding hits the same Tuple-serialization divergence above."
-    },
-    {
-      "file": "packages/client-common/__tests__/integration/select_query_binding.test.ts",
-      "test": "select with query binding > Nested boolean types > handles boolean in a mixed nested structure",
-      "reason": "Boolean inside nested Tuple/Map parameter binding — same root cause."
     }
   ]
 }


### PR DESCRIPTION
## What

`serializeValue` (the JS-value serializer behind `formatParamValue`, used by the `queryBindAsync` `{name:Type}` server-side binding path) mishandled two compound-type parameter shapes, so `@clickhouse/client` code passing them through `ChdbConnection` failed with engine parse errors:

- A `@clickhouse/client-common` **`TupleParam`** fell through to the generic-object branch and serialized as the map literal `{'values':[...]}`, which the engine rejects for a `Tuple(...)` param.
- **`Map` keys** were force-stringified and quoted (`{'42':...}`), which the engine rejects for `Map(Int32, ...)`.

## Why

chdb-node is a byte-compatible `@clickhouse/client` façade. The reference client serializes a `TupleParam` as the positional form `(v1, v2, …)` and a `Map` key by its JS type (numbers unquoted); chdb-node's divergent output was a serialization bug, not an engine limitation. These are exactly the compound-type divergences called out as out-of-scope in #68's "Scope / non-goals".

## The diff

```diff
   if (Array.isArray(value)) return serializeArray(value)

+  if (isTupleParam(value)) return serializeTuple(value.values)
+
   if (value instanceof Map) {
     const parts: string[] = []
     for (const [k, v] of value) {
-      parts.push(`${escapeStringLiteral(String(k))}:${serializeValue(v)}`)
+      // key by JS type: numeric → `42`, string → `'k'`
+      parts.push(`${serializeValue(k)}:${serializeValue(v)}`)
     }
     return `{${parts.join(',')}}`
   }
```

`TupleParam` is detected **by shape** (constructor name + `values` array), not `instanceof`: the instance a caller passes originates from *their* `@clickhouse/client(-common)` copy, which under pnpm/nested installs may resolve to a different module instance than ours, so `instanceof` against our imported class would spuriously miss it. Both fixes live in `serializeValue`, so they apply at any nesting depth (`Array(Tuple(...))`, `Map(K, Tuple(...))`), mirroring the reference client's recursion.

## Verification

Confirmed end-to-end against the native `chdb_query_with_params` path:

| param | placeholder | result |
|-------|-------------|--------|
| `new TupleParam(['main*','^main.*$'])` | `Tuple(String, String)` | `('main*','^main.*$')` |
| `[TupleParam, TupleParam]` | `Array(Tuple(String, String))` | rows parse correctly |
| `new Map([[42, 'v']])` | `Map(Int32, String)` | `{42:'v'}` (was `{'42':'v'}` → rejected) |

## Parity suite

Removes the 7 tuple/map entries from `tests/clickhouse-js/skip_list.json`. Verified against the upstream `select_query_binding.test.ts` (`@clickhouse/client` `client-1.23.0`, `ChdbConnection` injected, `:memory:`) — all 7 previously-skipped cases now pass:

```
✓ … handles tuples in a parametrized query
✓ … handles arrays of tuples in a parametrized query
✓ … handles maps with tuples in a parametrized query
✓ … handles maps with nested arrays in a parametrized query
✓ … handles maps with nullable values in a parametrized query
✓ … Nested boolean types > handles boolean in a tuple
✓ … Nested boolean types > handles boolean in a mixed nested structure
```

## Tests

- `test/v3/serialize.test.ts`: tuple literal, `Array(Tuple)`, numeric-key `Map`, and a guard that a plain `{ values: [...] }` object still serializes as a map.
- `test/v3/querybind.test.ts`: real-engine round-trips for `Tuple(String, String)` and `Array(Tuple(String, String))`.
- Full `test/v3` suite green: 454 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind Tuple parameters and integer Map keys in query serialization, matching @clickhouse/client
> - Adds `TupleParam` support to `serializeValue` in [serialize.ts](https://github.com/chdb-io/chdb-node/pull/75/files#diff-f67530420fc9d2d62beca6f10a909cbd087938e8c44325c5eaa3acbeaa1067b3): objects matching the `TupleParam` shape (constructor name `'TupleParam'` with an array `.values`) are rendered as SQL tuple literals, e.g. `('a','b')`.
> - Changes Map key serialization to call `serializeValue(k)` instead of always quoting keys as strings, so numeric keys render unquoted.
> - Removes tuple-related entries from the integration test skip list in [skip_list.json](https://github.com/chdb-io/chdb-node/pull/75/files#diff-2ab5e33cf2e743a17bbef170b6bdf106aa5d3ab034b9778225cff165362db297) as these cases now pass.
> - Behavioral Change: Map keys that are numeric will no longer be quoted in serialized SQL output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0e5360.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->