### PR TITLE
Run the suite against each new chdb-core release

### DIFF
--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -156,6 +156,10 @@ jobs:
       - name: Open an issue with the verdict
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job has nothing checked out, and gh does not read
+          # GITHUB_REPOSITORY. Without this it cannot tell which repository to
+          # open the issue in and every run reports nothing.
+          GH_REPO: ${{ github.repository }}
           RESULT: ${{ needs.test.result }}
           BUMP_PR: ${{ needs.propose_bump.outputs.pr }}
           ENGINE_VERSION: ${{ github.event.client_payload.tag || github.event.inputs.engine_version }}

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -94,12 +94,17 @@ jobs:
     outputs:
       pr: ${{ steps.bump.outputs.pr }}
     steps:
+      # Explicitly the default branch. A manual run from some other branch would
+      # otherwise root the bump there and open the pull request against it.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - id: bump
         name: Open a PR moving the pin to this engine
         env:
           GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           ENGINE_VERSION: ${{ github.event.client_payload.tag || github.event.inputs.engine_version }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -140,7 +145,7 @@ jobs:
             echo "just used."
           } > pr-body.md
 
-          url=$(gh pr create --base "$GITHUB_REF_NAME" --head "$branch" \
+          url=$(gh pr create --base "$DEFAULT_BRANCH" --head "$branch" \
             --title "Move the engine pin to $ENGINE_VERSION" \
             --body-file pr-body.md)
           echo "pr=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -102,6 +102,7 @@ jobs:
       pull-requests: write
     outputs:
       pr: ${{ steps.bump.outputs.pr }}
+      unproposed: ${{ steps.bump.outputs.unproposed }}
     steps:
       # The commit the suite actually ran against, not whatever the default branch
       # has become since. github.sha is fixed for the whole run, so this is the
@@ -130,16 +131,17 @@ jobs:
               exit 1 ;;
           esac
 
-          # A manual run from a branch that is not the default one would carry that
-          # branch's other changes into the bump. "behind" means the tested commit
-          # is an ancestor of the default branch; "identical" means it is the tip.
+          # Only when the tested commit is still the tip of the default branch.
+          # Anything else means merging the bump would adopt commits no run
+          # exercised against this engine, and the bump carries no CI to catch it.
+          # Declining and saying why beats a pull request claiming more than the
+          # run established.
           rel=$(gh api "repos/$GITHUB_REPOSITORY/compare/$DEFAULT_BRANCH...$GITHUB_SHA" --jq .status)
-          case "$rel" in
-            identical|behind) ;;
-            *)
-              echo "tested commit $GITHUB_SHA is $rel relative to $DEFAULT_BRANCH; not proposing a bump"
-              exit 0 ;;
-          esac
+          if [ "$rel" != identical ]; then
+            echo "unproposed=The tested commit $GITHUB_SHA is $rel relative to $DEFAULT_BRANCH, so nothing was proposed" >> "$GITHUB_OUTPUT"
+            echo "declining to propose a bump: $rel"
+            exit 0
+          fi
 
           current=$(grep -E '^CHDB_ENGINE_PIN=' update_libchdb.sh | cut -d= -f2)
           if [ "$current" = "$ENGINE_VERSION" ]; then
@@ -211,6 +213,7 @@ jobs:
           RESULT: ${{ needs.test.result }}
           BUMP_PR: ${{ needs.propose_bump.outputs.pr }}
           BUMP_RESULT: ${{ needs.propose_bump.result }}
+          BUMP_UNPROPOSED: ${{ needs.propose_bump.outputs.unproposed }}
           ENGINE_VERSION: ${{ github.event.client_payload.tag || github.event.inputs.engine_version }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -227,6 +230,9 @@ jobs:
             verdict="passes, bump PR did not open"
             keep=1
             bump_broke=1
+          elif [ -n "$BUMP_UNPROPOSED" ]; then
+            verdict="passes, no bump proposed"
+            keep=1
           else
             verdict="passes"
             keep=0
@@ -235,6 +241,8 @@ jobs:
           {
             if [ "$bump_broke" = 1 ]; then
               echo "chdb-node passes against chdb-core \`$ENGINE_VERSION\`, but the bump PR did not open."
+            elif [ -n "$BUMP_UNPROPOSED" ]; then
+              echo "chdb-node passes against chdb-core \`$ENGINE_VERSION\`, but no bump was proposed."
             else
               echo "chdb-node $verdict against chdb-core \`$ENGINE_VERSION\`."
             fi
@@ -243,6 +251,10 @@ jobs:
             if [ -n "$BUMP_PR" ]; then
               echo
               echo "Adopting it: $BUMP_PR"
+            elif [ -n "$BUMP_UNPROPOSED" ]; then
+              echo
+              echo "$BUMP_UNPROPOSED. The engine is fine and the pin is unchanged; rerun"
+              echo "the check once the default branch stops moving, or move the pin by hand."
             elif [ "$bump_broke" = 1 ]; then
               echo
               echo "The engine is fine; the automation is not. The pull request moving the"

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -194,24 +194,46 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RESULT: ${{ needs.test.result }}
           BUMP_PR: ${{ needs.propose_bump.outputs.pr }}
+          BUMP_RESULT: ${{ needs.propose_bump.result }}
           ENGINE_VERSION: ${{ github.event.client_payload.tag || github.event.inputs.engine_version }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
 
-          if [ "$RESULT" = success ]; then
-            verdict="passes"
-          else
+          # A green suite whose bump could not be opened is not a green run. Closing
+          # on needs.test.result alone would file it as "nothing to adopt" and leave
+          # the broken automation with no signal at all.
+          bump_broke=0
+          if [ "$RESULT" != success ]; then
             verdict="FAILS"
+            keep=1
+          elif [ "$BUMP_RESULT" = failure ] || [ "$BUMP_RESULT" = cancelled ]; then
+            verdict="passes, bump PR did not open"
+            keep=1
+            bump_broke=1
+          else
+            verdict="passes"
+            keep=0
           fi
 
           {
-            echo "chdb-node $verdict against chdb-core \`$ENGINE_VERSION\`."
+            if [ "$bump_broke" = 1 ]; then
+              echo "chdb-node passes against chdb-core \`$ENGINE_VERSION\`, but the bump PR did not open."
+            else
+              echo "chdb-node $verdict against chdb-core \`$ENGINE_VERSION\`."
+            fi
             echo
             echo "$RUN_URL"
             if [ -n "$BUMP_PR" ]; then
               echo
               echo "Adopting it: $BUMP_PR"
+            elif [ "$bump_broke" = 1 ]; then
+              echo
+              echo "The engine is fine; the automation is not. The pull request moving the"
+              echo "pin could not be opened, so this issue stays open. The usual cause is"
+              echo "this repository having \"Allow GitHub Actions to create and approve pull"
+              echo "requests\" turned off; the other is the branch push being rejected. The"
+              echo "pin is unchanged either way, and moving it by hand is one line."
             fi
             if [ "$RESULT" != success ]; then
               echo
@@ -229,6 +251,6 @@ jobs:
             --body-file body.md)
           echo "$url"
 
-          if [ "$RESULT" = success ]; then
+          if [ "$keep" = 0 ]; then
             gh issue close "$url" --comment "Green, closing. The run is linked above."
           fi

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -80,8 +80,74 @@ jobs:
       - name: Test (v2 mocha + v3 vitest)
         run: npm run test:all
 
-  report:
+  # Green means the engine can be adopted, not that it has been. Adoption is a
+  # one-line change to a pinned version and goes through review like any other
+  # dependency bump; this only writes the line. LIBCHDB_NPM_VERSION is left
+  # alone — it tracks the npm subpackage, not the engine.
+  propose_bump:
     needs: test
+    if: needs.test.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      pr: ${{ steps.bump.outputs.pr }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: bump
+        name: Open a PR moving the pin to this engine
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ENGINE_VERSION: ${{ github.event.client_payload.tag || github.event.inputs.engine_version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          current=$(grep -E '^CHDB_ENGINE_PIN=' update_libchdb.sh | cut -d= -f2)
+          if [ "$current" = "$ENGINE_VERSION" ]; then
+            echo "already pinned to $ENGINE_VERSION, nothing to propose"
+            exit 0
+          fi
+
+          branch="engine-pin-$ENGINE_VERSION"
+          if [ "$(gh pr list --head "$branch" --state open --json number --jq 'length')" != 0 ]; then
+            echo "a PR for $ENGINE_VERSION is already open"
+            exit 0
+          fi
+
+          git switch -c "$branch"
+          sed -i "s|^CHDB_ENGINE_PIN=.*|CHDB_ENGINE_PIN=$ENGINE_VERSION|" update_libchdb.sh
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -am "Move the engine pin from $current to $ENGINE_VERSION"
+          git push -u origin "$branch"
+
+          {
+            echo "The release check ran the v2 and v3 suites against \`$ENGINE_VERSION\` on"
+            echo "all four platforms and they passed, so the engine can be adopted. This"
+            echo "moves the pin $current → \`$ENGINE_VERSION\`."
+            echo
+            echo "\`LIBCHDB_NPM_VERSION\` is untouched. Publishing new \`@chdb/lib-<platform>\`"
+            echo "subpackages carrying this engine is a separate decision."
+            echo
+            echo "$RUN_URL"
+            echo
+            echo "No checks will appear here. GitHub does not start workflow runs for"
+            echo "commits a workflow pushed with \`GITHUB_TOKEN\`, and running CI on this"
+            echo "branch would exercise the same suites against the same engine the check"
+            echo "just used."
+          } > pr-body.md
+
+          url=$(gh pr create --base "$GITHUB_REF_NAME" --head "$branch" \
+            --title "Move the engine pin to $ENGINE_VERSION" \
+            --body-file pr-body.md)
+          echo "pr=$url" >> "$GITHUB_OUTPUT"
+          echo "$url"
+
+  report:
+    needs: [test, propose_bump]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -91,6 +157,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RESULT: ${{ needs.test.result }}
+          BUMP_PR: ${{ needs.propose_bump.outputs.pr }}
           ENGINE_VERSION: ${{ github.event.client_payload.tag || github.event.inputs.engine_version }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -106,6 +173,10 @@ jobs:
             echo "chdb-node $verdict against chdb-core \`$ENGINE_VERSION\`."
             echo
             echo "$RUN_URL"
+            if [ -n "$BUMP_PR" ]; then
+              echo
+              echo "Adopting it: $BUMP_PR"
+            fi
             if [ "$RESULT" != success ]; then
               echo
               echo "This does not mean the pinned engine is broken — update_libchdb.sh is"

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -103,11 +103,14 @@ jobs:
     outputs:
       pr: ${{ steps.bump.outputs.pr }}
     steps:
-      # Explicitly the default branch. A manual run from some other branch would
-      # otherwise root the bump there and open the pull request against it.
+      # The commit the suite actually ran against, not whatever the default branch
+      # has become since. github.sha is fixed for the whole run, so this is the
+      # same tree the test job exercised; a default branch that moved during a
+      # long matrix would otherwise put the new pin on untested code while the
+      # pull request claims the suite passed.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.sha }}
 
       - id: bump
         name: Open a PR moving the pin to this engine
@@ -125,6 +128,17 @@ jobs:
             *[!A-Za-z0-9._+-]*)
               echo "::error::refusing engine version '$ENGINE_VERSION'"
               exit 1 ;;
+          esac
+
+          # A manual run from a branch that is not the default one would carry that
+          # branch's other changes into the bump. "behind" means the tested commit
+          # is an ancestor of the default branch; "identical" means it is the tip.
+          rel=$(gh api "repos/$GITHUB_REPOSITORY/compare/$DEFAULT_BRANCH...$GITHUB_SHA" --jq .status)
+          case "$rel" in
+            identical|behind) ;;
+            *)
+              echo "tested commit $GITHUB_SHA is $rel relative to $DEFAULT_BRANCH; not proposing a bump"
+              exit 0 ;;
           esac
 
           current=$(grep -E '^CHDB_ENGINE_PIN=' update_libchdb.sh | cut -d= -f2)
@@ -165,6 +179,8 @@ jobs:
             echo "subpackages carrying this engine is a separate decision."
             echo
             echo "$RUN_URL"
+            echo
+            echo "Based on $GITHUB_SHA, the commit that run tested."
             echo
             echo "No checks will appear here. GitHub does not start workflow runs for"
             echo "commits a workflow pushed with \`GITHUB_TOKEN\`, and running CI on this"

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -50,6 +50,15 @@ jobs:
             echo "::error::no engine version in the dispatch payload or the manual input"
             exit 1
           fi
+          # The version arrives from a dispatch payload or a typed input, then flows
+          # into a URL, a branch name, a commit message and a sed replacement. Any
+          # character outside this set belongs to no chdb-core release tag, and an
+          # & or | reaching sed would quietly rewrite the wrong thing.
+          case "$ENGINE_VERSION" in
+            *[!A-Za-z0-9._+-]*)
+              echo "::error::refusing engine version '$ENGINE_VERSION': letters, digits and . _ + - only"
+              exit 1 ;;
+          esac
           echo "CHDB_ENGINE_VERSION=$ENGINE_VERSION" >> "$GITHUB_ENV"
           echo "Testing against chdb-core $ENGINE_VERSION"
 
@@ -109,6 +118,14 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
+
+          # test rejects these too, but this is the step that interpolates the
+          # version into sed replacements and a branch name.
+          case "$ENGINE_VERSION" in
+            *[!A-Za-z0-9._+-]*)
+              echo "::error::refusing engine version '$ENGINE_VERSION'"
+              exit 1 ;;
+          esac
 
           current=$(grep -E '^CHDB_ENGINE_PIN=' update_libchdb.sh | cut -d= -f2)
           if [ "$current" = "$ENGINE_VERSION" ]; then

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -1,0 +1,127 @@
+name: Engine release check
+
+# chdb-core publishes an engine and dispatches here; this runs the suite against
+# that engine and records the verdict in an issue. It gates nothing — the engine
+# has already shipped by the time this starts.
+#
+# The regular test job builds against the engine this repository pinned in
+# update_libchdb.sh, so it stays green through any change chdb-core makes after
+# that pin. The addon's C++ does get a compile error out of a changed signature,
+# but only against the header it was handed, and a struct that changes layout
+# without changing its declaration produces no error at all.
+#
+# One Node version per platform on purpose: what is under test is the C ABI, and
+# that does not vary by Node version. Platform does vary, so all four stay.
+
+on:
+  repository_dispatch:
+    types: [chdb-core-release]
+  workflow_dispatch:
+    inputs:
+      engine_version:
+        description: "chdb-core release tag, e.g. v26.5.0"
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  npm_config_fetch_retries: "5"
+  npm_config_fetch_retry_mintimeout: "20000"
+  npm_config_fetch_retry_maxtimeout: "120000"
+  npm_config_fetch_timeout: "600000"
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15-intel]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve the engine version
+        shell: bash
+        env:
+          ENGINE_VERSION: ${{ github.event.client_payload.tag || github.event.inputs.engine_version }}
+        run: |
+          if [ -z "$ENGINE_VERSION" ]; then
+            echo "::error::no engine version in the dispatch payload or the manual input"
+            exit 1
+          fi
+          echo "CHDB_ENGINE_VERSION=$ENGINE_VERSION" >> "$GITHUB_ENV"
+          echo "Testing against chdb-core $ENGINE_VERSION"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+
+      - name: Install JS deps (no compile-on-install)
+        run: npm install --ignore-scripts
+
+      - name: Fetch the published engine
+        run: npm run libchdb
+
+      - name: Build (addon + dist)
+        run: npm run build
+
+      - name: Exercise the freshly built addon (not the published prebuilt)
+        # loadNative() prefers the published @chdb/lib-<platform> subpackage,
+        # which carries its own engine and would mask the one under test.
+        shell: bash
+        run: rm -rf node_modules/@chdb/lib-*
+
+      - name: Test (v2 mocha + v3 vitest)
+        run: npm run test:all
+
+  report:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open an issue with the verdict
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT: ${{ needs.test.result }}
+          ENGINE_VERSION: ${{ github.event.client_payload.tag || github.event.inputs.engine_version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [ "$RESULT" = success ]; then
+            verdict="passes"
+          else
+            verdict="FAILS"
+          fi
+
+          {
+            echo "chdb-node $verdict against chdb-core \`$ENGINE_VERSION\`."
+            echo
+            echo "$RUN_URL"
+            if [ "$RESULT" != success ]; then
+              echo
+              echo "This does not mean the pinned engine is broken — update_libchdb.sh is"
+              echo "untouched. It means adopting \`$ENGINE_VERSION\` needs addon work first."
+              echo "Start with the C declarations the addon uses against"
+              echo "\`programs/local/chdb.h\` at this tag."
+            fi
+            echo
+            echo "cc @auxten @wudidapaopao @ShawnChen-Sirius"
+          } > body.md
+
+          url=$(gh issue create \
+            --title "Engine check: chdb-core $ENGINE_VERSION — $verdict" \
+            --body-file body.md)
+          echo "$url"
+
+          if [ "$RESULT" = success ]; then
+            gh issue close "$url" --comment "Green, closing. The run is linked above."
+          fi

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -127,7 +127,17 @@ jobs:
           git -c user.name="github-actions[bot]" \
               -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
               commit -am "Move the engine pin from $current to $ENGINE_VERSION"
-          git push -u origin "$branch"
+          # The branch can already exist on the remote: a bump PR closed without
+          # merging leaves it behind, and a plain push is then rejected as a
+          # non-fast-forward, silently costing the adoption PR. No open PR uses it
+          # — that was checked above — and its only content is one generated line,
+          # so replacing it is safe.
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "$branch is left over from an earlier attempt, replacing it"
+            git push --force -u origin "$branch"
+          else
+            git push -u origin "$branch"
+          fi
 
           {
             echo "The release check ran the v2 and v3 suites against \`$ENGINE_VERSION\` on"

--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -13,7 +13,11 @@ set -e
 
 # Pre-release engine for the 3.1.0-rc.1 test line (carries the written-rows
 # accessors the raw/streaming insert needs; absent in the v26.5.0 stable line).
-LATEST_RELEASE=v26.5.1-rc.1
+#
+# CHDB_ENGINE_VERSION overrides it, which is how the release-check workflow runs
+# the suite against an engine this repository has not adopted yet. It is a
+# different thing from CHDB_LIB_VERSION below, which names the npm subpackage.
+LATEST_RELEASE="${CHDB_ENGINE_VERSION:-v26.5.1-rc.1}"
 
 # Version published for the @chdb/lib-<platform> native subpackages on npm.
 # DECOUPLED from LATEST_RELEASE on purpose: chdb-core has no 26.5.2/26.5.3

--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -14,10 +14,14 @@ set -e
 # Pre-release engine for the 3.1.0-rc.1 test line (carries the written-rows
 # accessors the raw/streaming insert needs; absent in the v26.5.0 stable line).
 #
-# CHDB_ENGINE_VERSION overrides it, which is how the release-check workflow runs
-# the suite against an engine this repository has not adopted yet. It is a
-# different thing from CHDB_LIB_VERSION below, which names the npm subpackage.
-LATEST_RELEASE="${CHDB_ENGINE_VERSION:-v26.5.1-rc.1}"
+# Keep the pin on its own line and literal: the release check greps for it when
+# it proposes a bump.
+CHDB_ENGINE_PIN=v26.5.1-rc.1
+
+# CHDB_ENGINE_VERSION overrides the pin, which is how the release check runs the
+# suite against an engine this repository has not adopted yet. It is a different
+# thing from CHDB_LIB_VERSION below, which names the npm subpackage.
+LATEST_RELEASE="${CHDB_ENGINE_VERSION:-$CHDB_ENGINE_PIN}"
 
 # Version published for the @chdb/lib-<platform> native subpackages on npm.
 # DECOUPLED from LATEST_RELEASE on purpose: chdb-core has no 26.5.2/26.5.3


### PR DESCRIPTION
The test job builds against the engine pinned in `update_libchdb.sh`, so it stays
green through anything chdb-core changes after that pin. The addon's C++ does get
a compile error out of a changed signature, but only against the header it was
handed; a struct that changes layout without changing its declaration produces no
error at all. Either way nobody finds out until the pin moves, which can be
months after the change landed.

chdb-core will dispatch here when it publishes a release. This runs the suite
against that engine on all four platforms, opens an issue with the verdict and
closes it again when green. A red result does not mean the pinned engine broke —
`update_libchdb.sh` is untouched — it means adopting the new one needs addon work
first.

One Node version rather than three: what is under test is the C ABI, and that
does not vary by Node version. Platform does, so all four stay.

`CHDB_ENGINE_VERSION` is deliberately not `CHDB_LIB_VERSION`, which already means
the npm subpackage version and is read from `LIBCHDB_NPM_VERSION`.

Nothing here runs until it is on main; `repository_dispatch` only ever executes
the default branch's copy of a workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CI workflow to test and pin each new chdb-core release
> - Adds [engine-release-check.yml](.github/workflows/engine-release-check.yml), a GitHub Actions workflow triggered by `repository_dispatch` (type `chdb-core-release`) or manual dispatch with an `engine_version` input.
> - Runs the full test suite across four OSes against the specified engine version, then opens a PR updating `CHDB_ENGINE_PIN` in [update_libchdb.sh](https://github.com/chdb-io/chdb-node/pull/76/files#diff-6f35e23173ec48cae47760551bfa867846783d6a777bcf30354d7dd8e2e11ecb) if tests pass and the tested commit matches the default branch tip.
> - Always posts a GitHub issue summarising the test result, bump PR status, and run URL; closes the issue immediately if fully green.
> - Adds `CHDB_ENGINE_PIN` as an explicit named variable in `update_libchdb.sh`, with `LATEST_RELEASE` falling back to it when `CHDB_ENGINE_VERSION` is not set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cf9988.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->