### PR TITLE
Rewrite the addon's libchdb path whatever the engine calls it

### DIFF
--- a/fix_loader_path.sh
+++ b/fix_loader_path.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 cd "$(dirname "$0")"
+set -o pipefail
 
 # Point the addon at the libchdb.so that ships beside it, instead of whatever the
 # linker recorded.
@@ -24,11 +25,19 @@ if [[ $(uname -s) == "Darwin" ]]; then
 
     otool -L "$ADDON"
 
-    if otool -L "$ADDON" | grep 'libchdb\.so' | grep -qv "$TARGET"; then
-        echo "fix_loader_path.sh: the libchdb dependency in $ADDON is not $TARGET." >&2
-        echo "The engine's install_name is probably a spelling this script does not" >&2
-        echo "know yet; add it to the loop above. dlopen would fail at runtime." >&2
-        otool -L "$ADDON" | grep 'libchdb\.so' >&2
+    # Assert what the dependency IS, rather than grepping for what it is not. That
+    # covers otool failing on a missing or unreadable addon (no output), an addon
+    # with no libchdb dependency at all, more than one of them, and a path that
+    # merely resembles the target — a `grep "$TARGET"` would accept
+    # @loader_path/ab/cd/libchdb.so, since the dots are wildcards.
+    dep=$(otool -L "$ADDON" | awk '/libchdb\.so/ { print $1 }')
+    if [ "$dep" != "$TARGET" ]; then
+        echo "fix_loader_path.sh: expected $ADDON to depend on exactly" >&2
+        echo "  $TARGET" >&2
+        echo "and it depends on:" >&2
+        echo "  ${dep:-<nothing, or otool failed>}" >&2
+        echo "If that is a new install_name spelling from the engine, add it to the" >&2
+        echo "loop above. Left alone, dlopen fails at runtime." >&2
         exit 1
     fi
 fi

--- a/fix_loader_path.sh
+++ b/fix_loader_path.sh
@@ -2,7 +2,33 @@
 
 cd "$(dirname "$0")"
 
+# Point the addon at the libchdb.so that ships beside it, instead of whatever the
+# linker recorded.
+#
+# Which name the linker records comes from the engine's install_name, and that is
+# not stable: chdb-core shipped `libchdb.so` through v26.5.x and `@rpath/libchdb.so`
+# from v26.7.0. `install_name_tool -change` silently succeeds when the old name
+# matches nothing, so a script that knew only one spelling left the addon pointing
+# at `@rpath/libchdb.so` with no LC_RPATH to resolve it — and the failure surfaced
+# far away, as ERR_DLOPEN_FAILED when the loader tried to require the addon.
+#
+# Hence: rewrite every spelling we have seen, then verify. A dependency this script
+# cannot resolve is a build failure, not something to discover at runtime.
 if [[ $(uname -s) == "Darwin" ]]; then
-    install_name_tool -change libchdb.so @loader_path/../../libchdb.so build/Release/chdb_node.node
-    otool -L build/Release/chdb_node.node
+    ADDON=build/Release/chdb_node.node
+    TARGET=@loader_path/../../libchdb.so
+
+    for old in libchdb.so @rpath/libchdb.so; do
+        install_name_tool -change "$old" "$TARGET" "$ADDON" 2>/dev/null || true
+    done
+
+    otool -L "$ADDON"
+
+    if otool -L "$ADDON" | grep 'libchdb\.so' | grep -qv "$TARGET"; then
+        echo "fix_loader_path.sh: the libchdb dependency in $ADDON is not $TARGET." >&2
+        echo "The engine's install_name is probably a spelling this script does not" >&2
+        echo "know yet; add it to the loop above. dlopen would fail at runtime." >&2
+        otool -L "$ADDON" | grep 'libchdb\.so' >&2
+        exit 1
+    fi
 fi


### PR DESCRIPTION
Closes #79.

The engine release check found this on its first run: chdb-node cannot load its own
addon against chdb-core v26.7.0 on macOS. Both arm64 and x86_64 fail with
`ERR_DLOPEN_FAILED`; both Linux shards pass.

`install_name_tool -change` matches the dependency by its exact recorded name, and
that name comes from the engine's `install_name`, which changed:

```
v26.5.x    libchdb.so
v26.7.0    @rpath/libchdb.so
```

The script only knew the first spelling. `-change` succeeds and does nothing when
the old name does not match, so the addon kept `@rpath/libchdb.so` — which it has
no `LC_RPATH` to resolve — and dlopen failed at `require()` time. The build itself
stayed green, and the `otool -L` output the script already prints showed the
unrewritten path to anyone who happened to read it.

Both spellings are rewritten now, and the result is verified instead of assumed: a
dependency this script cannot resolve fails the build and names what it found. The
next `install_name` change should stop the build with a clear message rather than
produce an addon that cannot load.

## What was checked

On macOS, by rewriting a built addon's dependency to `@rpath/libchdb.so` to
reproduce the no-op:

- the old script leaves it untouched — the CI failure, locally
- the new script restores `@loader_path/../../libchdb.so`
- a second run is idempotent
- an unknown third spelling (`@executable_path/libchdb.so`) exits 1 with the
  dependency printed

A full local rebuild against v26.7.0 was not possible — node-gyp 9.3.1 does not run
under Node 26 on this machine — so CI is the first end-to-end build of the addon
against that engine. The v3 suite does pass against v26.7.0's engine with the
existing addon (41 files, 476 tests), so nothing else about that version troubles
the binding; the loader path was the whole of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite both known `libchdb` install name spellings in the macOS addon build script
> - [fix_loader_path.sh](https://github.com/chdb-io/chdb-node/pull/80/files#diff-582aa6e6366717e21cf7d5a27aaff1fe39cf99228594750adc1be8f75c3b788a) now loops over both `libchdb.so` and `@rpath/libchdb.so` when calling `install_name_tool`, so the rewrite succeeds regardless of which spelling the build toolchain records.
> - Adds an assertion that the final recorded dependency exactly matches `@loader_path/../../libchdb.so`, exiting with status 1 and a diagnostic message if not.
> - Adds `set -o pipefail` and quotes variables throughout for robustness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a87342.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->