### PR TITLE
Hold the subpackage publish to the naming rule, and keep candidates off latest

### DIFF
--- a/.github/workflows/prebuild-publish.yml
+++ b/.github/workflows/prebuild-publish.yml
@@ -59,6 +59,14 @@ jobs:
         shell: bash
         run: rm -rf node_modules/@chdb/lib-*
       - run: npm run test:all
+      - name: The subpackage version has to name the engine it carries
+        # Run here and not only in pull request CI, because CI is not the last
+        # gate: this workflow fires on a tag, and a tag can be pushed to a commit
+        # no pull request ever checked. An npm version cannot be republished, so a
+        # subpackage published under a version that does not match its engine is
+        # permanent.
+        run: node scripts/check-version-scheme.mjs
+
       - name: Derive subpackage version from update_libchdb.sh
         run: |
           echo "CHDB_LIB_VERSION=$(grep -E '^LIBCHDB_NPM_VERSION=' update_libchdb.sh | cut -d= -f2)" >> "$GITHUB_ENV"
@@ -69,11 +77,27 @@ jobs:
         run: |
           NAME=$(node -p "require('./package.json').name")
           VER=$(node -p "require('./package.json').version")
+
+          # Which dist-tag this lands on, decided by what the version says about
+          # the engine inside it. A subpackage built from a chdb-core release
+          # candidate must not become what `npm install @chdb/lib-<platform>` or
+          # `npm view` reports, or a candidate engine turns into the default one.
+          #
+          # Keyed on -rc. rather than on "is a prerelease", because every version
+          # this scheme produces is a prerelease to semver — 26.7.0-stable.1 has a
+          # prerelease part too. Deciding by the hyphen would keep the stable
+          # subpackages off latest forever.
+          case "$VER" in
+          *-rc.*) DIST_TAG=rc ;;
+          *) DIST_TAG=latest ;;
+          esac
+          echo "publishing $NAME@$VER to the '$DIST_TAG' dist-tag"
+
           if npm view "$NAME@$VER" version >/dev/null 2>&1; then
             echo "$NAME@$VER already published; skipping (lets a re-run finish a partially-published release)."
             exit 0
           fi
-          if out=$(npm publish --access public 2>&1); then
+          if out=$(npm publish --access public --tag "$DIST_TAG" 2>&1); then
             echo "$out"
           else
             echo "$out"

--- a/.github/workflows/prebuild-publish.yml
+++ b/.github/workflows/prebuild-publish.yml
@@ -93,16 +93,40 @@ jobs:
           esac
           echo "publishing $NAME@$VER to the '$DIST_TAG' dist-tag"
 
+          # Publishing is skipped when the version is already there, but the
+          # dist-tag is not: --tag only applies to a publish that happens, so a
+          # version published before this job knew about dist-tags keeps whatever
+          # it was given then. A subpackage published with no --tag took 'latest'
+          # — that is the state this is here to correct, and skipping past it
+          # would leave a candidate engine as the default one indefinitely.
+          #
+          # Not paired with removing 'latest' when publishing a candidate. A
+          # package with no 'latest' cannot be installed by name at all, which is
+          # worse than the problem; a candidate simply does not touch it. If
+          # 'latest' is wrong, the stable release that follows sets it right.
+          reconcile_dist_tag() {
+            if [ "$(npm view "$NAME@$DIST_TAG" version 2>/dev/null)" = "$VER" ]; then
+              echo "'$DIST_TAG' already points at $VER"
+              return 0
+            fi
+            echo "moving '$DIST_TAG' to $VER"
+            npm dist-tag add "$NAME@$VER" "$DIST_TAG"
+          }
+
           if npm view "$NAME@$VER" version >/dev/null 2>&1; then
             echo "$NAME@$VER already published; skipping (lets a re-run finish a partially-published release)."
+            reconcile_dist_tag
             exit 0
           fi
           if out=$(npm publish --access public --tag "$DIST_TAG" 2>&1); then
             echo "$out"
           else
             echo "$out"
+            # Same reasoning as the skip above: the version is on the registry and
+            # this publish applied no tag to it, so the tag still has to be set.
             echo "$out" | grep -qiE "cannot publish over|previously published|EPUBLISHCONFLICT|403" \
               && echo "$NAME@$VER already on the registry (publish conflict); treating as success." \
+              && reconcile_dist_tag \
               || exit 1
           fi
         env:


### PR DESCRIPTION
Two gaps between what the naming rule says and what publishing actually does.
Follow-up to #82, which added the rule; this makes it hold at the one step that
cannot be undone.

## The check did not run where it matters

`scripts/check-version-scheme.mjs` ran only in pull request CI. This workflow
fires on a tag, and a tag can be pushed to a commit no pull request ever checked —
so the rule covered everything except publishing. An npm version cannot be
republished, so a subpackage whose version does not name the engine inside it is
permanent. It now runs in the publish job, before anything is built or sent.

## A release candidate could take `latest`

The subpackage was published with no `--tag`, which means `latest` whatever the
version said. A subpackage carrying a chdb-core release candidate would become
what `npm install @chdb/lib-<platform>` and `npm view` report — a candidate engine
turned into the default one.

Users installing `chdb` were never exposed: the main package pins all four
exactly, and an exact pin does not consult dist-tags. Anyone looking at the
subpackage directly would have been told the wrong thing.

Candidates now go to an `rc` dist-tag, stable ones to `latest`:

```
26.7.0-stable.1  26.7.0-stable.2  26.7.2-stable.1  26.5.3   ->  --tag latest
26.7.0-rc.1.1    26.7.2-rc.1.1                              ->  --tag rc
```

**Keyed on `-rc.`, not on "is a prerelease".** Every version this scheme produces
is a prerelease as far as semver is concerned — `semver.prerelease("26.7.0-stable.1")`
is `["stable", 1]` — so deciding by the hyphen would keep the stable subpackages
off `latest` forever.

The main package already did the right thing and is untouched: prereleases to
`next`, stable to a holding tag promoted to `latest` only after `verify` passes on
every platform and Node version.

## What this leaves

Default installs see stable engines only. Reaching a candidate engine takes
`chdb@next`, or naming an `@chdb/lib-*` version explicitly. Not enforced here, and
deliberately so: a main package pinning a candidate engine is *not* required to be
a prerelease itself.

cc @auxten @wudidapaopao


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce version naming rules and assign correct dist-tags for subpackage publishing
> - Adds a pre-publish step that runs `node scripts/check-version-scheme.mjs` to validate subpackage version names before publishing.
> - Derives the npm dist-tag from the version string: versions matching `*-rc.*` use the `rc` tag, all others use `latest`, keeping release candidates off the `latest` tag.
> - Adds a `reconcile_dist_tag` function in [prebuild-publish.yml](.github/workflows/prebuild-publish.yml) that corrects the dist-tag via `npm dist-tag add` if a version was already published or a publish conflict occurs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f9d22c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->