### PR TITLE
Link the addon for the platforms people actually install it on

### DIFF
--- a/.github/workflows/chdb-node-test.yml
+++ b/.github/workflows/chdb-node-test.yml
@@ -118,6 +118,13 @@ jobs:
           cache: npm
       - run: sudo apt-get update && sudo apt-get install -y patchelf binutils
       - run: npm install --ignore-scripts && npm run libchdb && npm run build
+      - name: Re-link the addon against an old glibc
+        # Same step the publish workflow runs, for the same reason: a binary
+        # linked on ubuntu-24.04 records that runner's symbol versions and will
+        # not load on anything older. Doing it here means a pull request that
+        # raises the floor goes red now, instead of at tag time when the npm
+        # version is already unrecallable.
+        run: bash scripts/build-addon-portable.sh
       - name: Pack main + platform subpackage
         run: |
           # Stamp the subpackage with the SAME version main pins in
@@ -154,3 +161,9 @@ jobs:
           # passes on the build runner even when the binary is unshippable.
           rm -f "$GITHUB_WORKSPACE/libchdb.so"
           node smoke-e2e.mjs
+      - name: The same install has to run on Debian bookworm
+        # The symbol assert reads the binary; this runs it. bookworm is older
+        # than every GitHub runner image and is the base of the node:22 /
+        # node:20 / node:lts images, so it is where users first meet a binary
+        # that demands a newer libstdc++ or glibc than they have.
+        run: docker run --rm -v /tmp/cleanroom:/w -w /w node:22-bookworm node smoke-e2e.mjs

--- a/.github/workflows/prebuild-publish.yml
+++ b/.github/workflows/prebuild-publish.yml
@@ -12,8 +12,12 @@ name: prebuild-publish
 #      installed location, and the subpath exports. (This is the gate that #50 needed:
 #      a binary with the build machine's absolute rpath passed the in-tree build test
 #      but failed on every clean host.)
-#   4. promote — only after verify is green on every leg, move 'latest' to the new
-#      version. If verify fails, users on 'latest' never see the broken release.
+#   3b. verify-old-distro — the same installed-package tests inside Debian bookworm,
+#      which is older than any GitHub runner image and is what `node:22` actually
+#      gives people. Catches a binary that only loads on a modern runtime.
+#   4. promote — only after both verify jobs are green on every leg, move 'latest'
+#      to the new version. If either fails, users on 'latest' never see the
+#      broken release.
 #
 # Gated on update_libchdb.sh pointing at a libchdb release that includes the required
 # C ABI (chdb_query_with_params, chdb_query_arrow).
@@ -48,6 +52,15 @@ jobs:
       - run: npm install --ignore-scripts
       - run: npm run libchdb
       - run: npm run build
+      - name: Re-link the addon against an old glibc so it loads off the runner
+        # The runner's GCC and glibc decide which symbol versions end up in the
+        # binary, and this one is newer than most machines that will install it:
+        # a straight ubuntu-24.04 build only loads on ubuntu-24.04-era systems
+        # and dies at require() on Debian bookworm, the base of the node:22 /
+        # node:20 / node:lts images. Nothing about the source can lower that
+        # floor, so the link happens in a container that is old enough.
+        if: runner.os == 'Linux'
+        run: bash scripts/build-addon-portable.sh
       - name: Drop the installed @chdb/lib-* so tests exercise the just-built addon
         # The loader prefers an installed @chdb/lib-<platform> subpackage over the
         # local build (src/loader.ts). npm install pulls the PREVIOUSLY published
@@ -205,8 +218,43 @@ jobs:
           node -e "console.log('verifying installed chdb', require('chdb/package.json').version, 'on', process.version, process.platform, process.arch)"
           npx vitest run test
 
+  verify-old-distro:
+    # Every leg of `verify` runs on a GitHub runner image, and all four of them
+    # carry a glibc and libstdc++ newer than what users have — which is why an
+    # addon needing GLIBCXX_3.4.32 passed the whole matrix and then failed on
+    # `docker run node:22 npm i chdb`. This job is the counterexample: Debian
+    # bookworm, the base of the node:22 / node:20 / node:lts images, is the
+    # oldest runtime in common use, so if the published binary loads here the
+    # symbol floor is genuinely low. Two Linux legs against twelve — the
+    # cheapest kind of leg there is, and they run alongside the rest.
+    needs: main
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
+    container: node:22-bookworm
+    steps:
+      - uses: actions/checkout@v4   # only to obtain the installed-package tests
+      - name: Install the PUBLISHED chdb inside bookworm and run the installed-package tests
+        shell: bash
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          echo "distro: $(. /etc/os-release; echo "$PRETTY_NAME"), glibc $(ldd --version | head -1 | grep -oE '[0-9]+\.[0-9]+$')"
+          work="$(mktemp -d)"
+          cp -R "$GITHUB_WORKSPACE/test/pack" "$work/test"
+          cd "$work"
+          npm init -y >/dev/null
+          ok=
+          for i in 1 2 3 4 5 6; do
+            if npm install "chdb@$VER" vitest@2 >/tmp/i.log 2>&1; then ok=1; break; fi
+            echo "install attempt $i failed (registry propagation?); retry in 15s"; sleep 15
+          done
+          [ -n "$ok" ] || { echo "could not install chdb@$VER"; tail -20 /tmp/i.log; exit 1; }
+          npx vitest run test
+
   promote:
-    needs: verify
+    needs: [verify, verify-old-distro]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v4

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,6 +26,22 @@
           # an old-glibc container (scripts/build-addon-portable.sh), and
           # scripts/assert-runtime-baseline.sh checks what comes out.
           "ldflags": [ "-static-libstdc++", "-static-libgcc" ]
+        }],
+        ["OS=='mac'", {
+          # The same failure mode as the Linux branch above, by a different
+          # mechanism: without this, the deployment target is whatever the build
+          # machine's SDK defaults to, and it becomes a hard floor — a binary
+          # built on a macos-15 runner refuses to load on anything older. The
+          # published subpackages happen to sit at 11.0 today, which is right,
+          # but only because no runner has moved yet.
+          #
+          # 11.0 rather than lower: libchdb.so is itself built for 11.0 on arm64,
+          # and Node's own macOS binaries require 11.0 from Node 20 on, so
+          # nothing that can run this can be older. scripts/assert-runtime-baseline.sh
+          # checks the result.
+          "xcode_settings": {
+            "MACOSX_DEPLOYMENT_TARGET": "11.0"
+          }
         }]
       ]
     }

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,24 @@
       "libraries": [ "<(module_root_dir)/libchdb.so" ],
       "cflags!": [ "-fno-exceptions" ],
       "cflags_cc!": [ "-fno-exceptions" ],
-      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ]
+      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
+      "conditions": [
+        ["OS=='linux'", {
+          # Carry the C++ runtime inside the addon. Linked dynamically it demands
+          # whatever libstdc++ the build machine had — GCC 13 emits
+          # GLIBCXX_3.4.32, absent on Debian bookworm (the base of the node:22 /
+          # node:20 / node:lts images), Ubuntu 22.04 and Amazon Linux 2023, where
+          # the install succeeds and require() then dies with ERR_DLOPEN_FAILED.
+          # libchdb.so links no libstdc++ at all, so the addon is the only thing
+          # that drags one in.
+          #
+          # Half the story: a static libstdc++ taken from a modern host brings
+          # newer libc symbols along with it, so the release build also links in
+          # an old-glibc container (scripts/build-addon-portable.sh), and
+          # scripts/assert-runtime-baseline.sh checks what comes out.
+          "ldflags": [ "-static-libstdc++", "-static-libgcc" ]
+        }]
+      ]
     }
   ]
 }

--- a/scripts/assert-runtime-baseline.sh
+++ b/scripts/assert-runtime-baseline.sh
@@ -30,20 +30,42 @@
 #      the addon in an old-glibc container (scripts/build-addon-portable.sh) —
 #      a build on the ubuntu-24.04 runner lands at 2.38 and fails here.
 #
-# macOS has no ELF symbol versioning; the check is skipped there.
+#   3. On macOS, no deployment target above 11.0. A Mach-O records the oldest OS
+#      it will load on and that number comes from the build machine's SDK, so the
+#      same bug arrives by a different mechanism: a binary built on a newer runner
+#      quietly stops loading on older macOS. 11.0 because libchdb.so is itself
+#      built for 11.0 on arm64 and Node's own macOS builds require 11.0 from Node
+#      20 on, so nothing that can run this is older. The published subpackages sit
+#      at 11.0 today only because no runner has moved yet — binding.gyp now says
+#      it and this checks it.
 #
 # Usage: assert-runtime-baseline.sh <path-to-chdb_node.node>
 set -euo pipefail
 
 MAX_GLIBC=2.28
+MAX_MACOS=11.0
 
 NODE_FILE="${1:?usage: assert-runtime-baseline.sh <chdb_node.node>}"
 [ -f "$NODE_FILE" ] || { echo "assert-runtime-baseline: no such file: $NODE_FILE" >&2; exit 1; }
 
 fail() { echo "assert-runtime-baseline: FAIL — $1" >&2; exit 1; }
 
+if [ "$(uname -s)" = "Darwin" ]; then
+  command -v otool >/dev/null || fail "otool not found (needs the Xcode command line tools)"
+
+  minos=$(otool -l "$NODE_FILE" | awk '/LC_BUILD_VERSION/ { seen = 1 } seen && $1 == "minos" { print $2; exit }')
+  [ -n "$minos" ] || fail "$NODE_FILE has no LC_BUILD_VERSION, so it declares no floor to check"
+
+  if [ "$(printf '%s\n%s\n' "$MAX_MACOS" "$minos" | sort -V | tail -1)" != "$MAX_MACOS" ]; then
+    fail $'the addon refuses to load below macOS '"$minos"', and the baseline is '"$MAX_MACOS"$'.\nThe deployment target came from the build machine rather than from binding.gyp.\nCheck that MACOSX_DEPLOYMENT_TARGET is still set there and that the build used it.'
+  fi
+
+  echo "assert-runtime-baseline: OK — $(basename "$NODE_FILE") loads on macOS $minos and up (baseline $MAX_MACOS)"
+  exit 0
+fi
+
 if [ "$(uname -s)" != "Linux" ]; then
-  echo "assert-runtime-baseline: skipped on $(uname -s) (ELF symbol versioning is Linux-only)"
+  echo "assert-runtime-baseline: skipped on $(uname -s) — nothing known about its runtime floors"
   exit 0
 fi
 

--- a/scripts/assert-runtime-baseline.sh
+++ b/scripts/assert-runtime-baseline.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Assert a packaged native addon does not demand a newer C/C++ runtime than the
+# oldest platform chdb claims to run on.
+#
+# The failure it catches: an addon linked on a modern build machine records the
+# symbol versions that machine's GCC and glibc emitted, and the dynamic loader
+# refuses the binary anywhere older. It installs fine — the breakage lands at
+# require() time, as ERR_DLOPEN_FAILED, on a machine no CI job ever visits:
+#
+#   libstdc++.so.6: version `GLIBCXX_3.4.32' not found   (GCC 13, dynamic libstdc++)
+#   libc.so.6: version `GLIBC_2.38' not found            (static libstdc++, glibc 2.39 host)
+#
+# Debian bookworm — the base of the node:22 / node:20 / node:lts images — offers
+# GLIBCXX_3.4.30 and GLIBC_2.36, so both of those kill it. Building and testing
+# on ubuntu-24.04 alone cannot see this: every leg has the same modern runtime.
+#
+# The two rules:
+#
+#   1. No GLIBCXX_/CXXABI_ requirement at all. libchdb.so links no libstdc++
+#      whatsoever, so the addon is the only thing that can drag one in; carrying
+#      the C++ runtime statically (binding.gyp) removes the whole failure class
+#      rather than moving the version floor around.
+#
+#   2. No glibc symbol newer than 2.28. That is the floor Node's own official
+#      Linux builds require, so an addon that stays at or under it loads
+#      anywhere Node itself runs — RHEL/Alma/Rocky 8 (2.28), Ubuntu 20.04
+#      (2.31), Amazon Linux 2023 (2.34), Ubuntu 22.04 (2.35), Debian bookworm
+#      (2.36). libchdb.so needs nothing above 2.17, so the engine never forces
+#      the number up; only the addon's build host can. Reaching it means linking
+#      the addon in an old-glibc container (scripts/build-addon-portable.sh) —
+#      a build on the ubuntu-24.04 runner lands at 2.38 and fails here.
+#
+# macOS has no ELF symbol versioning; the check is skipped there.
+#
+# Usage: assert-runtime-baseline.sh <path-to-chdb_node.node>
+set -euo pipefail
+
+MAX_GLIBC=2.28
+
+NODE_FILE="${1:?usage: assert-runtime-baseline.sh <chdb_node.node>}"
+[ -f "$NODE_FILE" ] || { echo "assert-runtime-baseline: no such file: $NODE_FILE" >&2; exit 1; }
+
+fail() { echo "assert-runtime-baseline: FAIL — $1" >&2; exit 1; }
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "assert-runtime-baseline: skipped on $(uname -s) (ELF symbol versioning is Linux-only)"
+  exit 0
+fi
+
+command -v readelf >/dev/null || fail "readelf not found (install binutils)"
+
+# .gnu.version_r is the authoritative list of versioned symbols the loader has to
+# satisfy — one entry per version node actually referenced.
+needs=$(readelf --version-info --wide "$NODE_FILE" | sed -nE 's/.*Name: ([A-Za-z_]+_[0-9][0-9.]*).*/\1/p' | sort -u)
+
+cxx=$(printf '%s\n' "$needs" | grep -E '^(GLIBCXX|CXXABI)_' || true)
+if [ -n "$cxx" ]; then
+  fail $'the addon links the C++ runtime dynamically; build it with -static-libstdc++.\nversions demanded:\n'"$cxx"
+fi
+
+glibc=$(printf '%s\n' "$needs" | grep -E '^GLIBC_' | sed 's/^GLIBC_//' | sort -V || true)
+worst=$(printf '%s\n' "$glibc" | tail -1)
+if [ -n "$worst" ] && [ "$(printf '%s\n%s\n' "$MAX_GLIBC" "$worst" | sort -V | tail -1)" != "$MAX_GLIBC" ]; then
+  fail $'needs glibc '"$worst"' but the baseline is '"$MAX_GLIBC"$'.\nBuilt on a host whose glibc is too new — link it in an old-glibc container\n(scripts/build-addon-portable.sh). Versions demanded:\n'"$(printf 'GLIBC_%s\n' $glibc)"
+fi
+
+echo "assert-runtime-baseline: OK — $(basename "$NODE_FILE") needs no libstdc++ and nothing above GLIBC_${worst:-none} (baseline $MAX_GLIBC)"

--- a/scripts/build-addon-portable.sh
+++ b/scripts/build-addon-portable.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Re-link the Linux addon inside an old-glibc container so the published binary
+# loads on distributions older than the build runner.
+#
+# Why this exists: the addon is compiled on ubuntu-24.04 (GCC 13, glibc 2.39) and
+# the linker records that runtime's symbol versions in the binary. Users install
+# it on Debian bookworm — the base of the node:22 / node:20 / node:lts images —
+# and require() dies with `GLIBCXX_3.4.32 not found`. Linking the C++ runtime
+# statically (binding.gyp) removes the libstdc++ dependency but not the problem:
+# the static libstdc++ on a 2.39 host pulls in __isoc23_strtoul, so the binary
+# then demands GLIBC_2.38 and bookworm (2.36) still refuses it. The glibc floor
+# is a property of the machine that links, and nothing in the source can lower
+# it — so link somewhere old.
+#
+# AlmaLinux 8 is glibc 2.28, which is also the floor Node's own official Linux
+# builds require: the addon ends up loadable anywhere Node itself runs. Its
+# gcc-toolset compilers target that glibc while still being new enough for the
+# C++ the addon and node-addon-api use.
+#
+# Only the link step moves. node-gyp has already run on the host, so the
+# generated Makefile, the downloaded node headers and node_modules are reused
+# as-is; the container mounts them at their original absolute paths and runs
+# make. That keeps node, npm and python out of the container entirely.
+#
+# Run after `npm run build`, before packaging. No-op on macOS.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BUILDER_IMAGE="${CHDB_BUILDER_IMAGE:-docker.io/library/almalinux:8}"
+TOOLSET="${CHDB_GCC_TOOLSET:-gcc-toolset-13}"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "build-addon-portable: skipped on $(uname -s) (Linux-only)"
+  exit 0
+fi
+
+[ -f build/Release/chdb_node.node ] || {
+  echo "build-addon-portable: build/Release/chdb_node.node is missing — run 'npm run build' first" >&2
+  exit 1
+}
+
+RUNTIME=""
+for c in docker podman; do command -v "$c" >/dev/null && { RUNTIME="$c"; break; }; done
+[ -n "$RUNTIME" ] || { echo "build-addon-portable: neither docker nor podman is available" >&2; exit 1; }
+
+# The generated Makefile points at the node headers by absolute path, and
+# node-gyp puts them outside the repository by default. Read the path out of the
+# Makefile rather than guessing where node-gyp cached them, and mount it at the
+# same location so the recorded -I flags still resolve.
+HDR=$(grep -ohE -- '-I[^ ]*/include/node' build/*.mk 2>/dev/null | head -1 | sed 's/^-I//' || true)
+[ -n "$HDR" ] || { echo "build-addon-portable: no node header include found in build/*.mk" >&2; exit 1; }
+HDR_ROOT=$(cd "$HDR/../../.." && pwd)
+
+MOUNTS=(-v "$PWD:$PWD")
+case "$HDR_ROOT/" in
+  "$PWD"/*) ;;                                   # already inside the repo mount
+  *) MOUNTS+=(-v "$HDR_ROOT:$HDR_ROOT") ;;
+esac
+
+echo "build-addon-portable: re-linking in $BUILDER_IMAGE via $RUNTIME"
+"$RUNTIME" run --rm "${MOUNTS[@]}" -w "$PWD" \
+  -e "TOOLSET=$TOOLSET" -e "OWNER=$(id -u):$(id -g)" \
+  "$BUILDER_IMAGE" bash -euo pipefail -c '
+    dnf -y --setopt=retries=5 install "${TOOLSET}-gcc-c++" make >/dev/null
+    export PATH="/opt/rh/${TOOLSET}/root/usr/bin:$PATH"
+    g++ --version | head -1
+    ldd --version | head -1
+    # Force a real recompile: make would otherwise consider the object the host
+    # produced up to date and only the link step would change hosts.
+    rm -rf build/Release/obj.target build/Release/chdb_node.node
+    make -C build BUILDTYPE=Release
+    # Hand the artifacts back to the invoking user; a rootless runtime already
+    # maps them there and rejects the call, which is not a build failure.
+    chown -R "$OWNER" build 2>/dev/null || true
+  '
+
+bash scripts/assert-runtime-baseline.sh build/Release/chdb_node.node

--- a/scripts/build-platform-pkg.sh
+++ b/scripts/build-platform-pkg.sh
@@ -53,6 +53,13 @@ fi
 # even on the build runner where a stale absolute path still resolves.
 bash scripts/assert-relocatable.sh "$PKG/chdb_node.node"
 
+# Guard against shipping a binary that only loads on distributions as new as the
+# build machine: assert it demands no libstdc++ and no glibc symbol above the
+# supported floor. Kept apart from the relocatability assert because it fails for
+# an unrelated reason and is fixed elsewhere — a stale path is a packaging bug,
+# a symbol version is a choice of build host (scripts/build-addon-portable.sh).
+bash scripts/assert-runtime-baseline.sh "$PKG/chdb_node.node"
+
 echo "module.exports = require('./chdb_node.node');" > "$PKG/index.js"
 
 LIBC_FIELD=""


### PR DESCRIPTION
`chdb@3.2.0` — the current `latest` — installs cleanly and then dies at
`require()` on Debian bookworm, which is the base of the `node:22`, `node:20` and
`node:lts` images. Also on Amazon Linux 2023 (the Lambda Node base) and Ubuntu
22.04 LTS.

```
ChdbBinaryVersionMismatchError: failed to load native binding from @chdb/lib-linux-arm64-gnu:
  /lib/aarch64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found
  code: 'ERR_DLOPEN_FAILED'
```

## Why, and why the obvious fix is not enough

The addon needs `GLIBCXX_3.4.32` (GCC 13); bookworm offers 3.4.30. `libchdb.so`
links no libstdc++ at all and needs nothing above `GLIBC_2.17`, so the addon is
the only thing dragging a modern runtime in.

`-static-libstdc++` alone does not fix it. The static libstdc++ on ubuntu-24.04 is
itself compiled against glibc 2.39 headers and brings `__isoc23_strtoul` along, so
the binary just fails differently:

| build | highest requirement | bookworm |
| --- | --- | --- |
| today (dynamic libstdc++) | `GLIBCXX_3.4.32` | ✗ |
| static libstdc++ only | `GLIBC_2.38` | ✗ |
| static + linked on AlmaLinux 8 | `GLIBC_2.25` | ✓ |

A binary's floor belongs to the machine that linked it. No source change can lower
it — the link has to happen somewhere old enough.

## What this does

- `binding.gyp` — static libstdc++/libgcc on Linux; `MACOSX_DEPLOYMENT_TARGET` on
  macOS.
- `scripts/build-addon-portable.sh` — re-links the addon inside `almalinux:8`.
  Only the link step moves: node-gyp already ran on the host, and the container
  gets the generated Makefile, the cached node headers and `node_modules` mounted
  at their original paths, so it needs no node, npm or python.
- `scripts/assert-runtime-baseline.sh` — asserts the artifact, not the test run.
  No `GLIBCXX_`/`CXXABI_` at all, no `GLIBC_` above 2.28, and on macOS no
  deployment target above 11.0.
- Called from `build-platform-pkg.sh`, so it covers the publish path automatically
  on all four platforms.
- `verify-old-distro` (bookworm × x64/arm64) gates `promote` alongside `verify`.

## The baselines are anchored, not guessed

**glibc 2.28** is what Node's own official Linux builds require, so an addon at or
under it loads anywhere Node itself runs — Alma/Rocky 8 (2.28), Ubuntu 20.04
(2.31), AL2023 (2.34), Ubuntu 22.04 (2.35), bookworm (2.36). `libchdb.so` needs
2.17, so the engine never pushes the number up; only the build host can.

**macOS 11.0** is what `libchdb.so` itself is built for on arm64, and what Node's
macOS builds require from Node 20 on.

## Why assert the artifact rather than test on distros

Testing on bookworm proves bookworm works. Asserting `GLIBC_ ≤ 2.28` proves every
glibc ≥ 2.28 works. Environments are a sample; the floor is the property.

This is what `auditwheel` does for Python wheels against `manylinux_2_28`. npm has
no equivalent, so this is a small hand-rolled one.

Nothing in the source decides this — the floor belongs to whichever machine did the
link. So it comes back whenever the build environment moves: a runner image
upgrade, a newer GCC, a re-link step dropped in a refactor. A test on one
distribution cannot see that coming, and the artifact assertion fails the moment it
happens, before anything is published.

## Verified

All native linux/arm64 under podman, no qemu.

```
BOOKWORM — before                    LOAD: FAIL  GLIBCXX_3.4.32 not found
BOOKWORM — static libstdc++ only     LOAD: FAIL  GLIBC_2.38 not found
BOOKWORM — static + old-glibc link   LOAD: OK
                                     SYNC: 1,"26.7.2.1"
                                     ASYNC: 499999500000
                                     CONN: 10,45
                                     ERRPATH: threw as expected
```

The same binary passes on AlmaLinux 8 (2.28) and Ubuntu 24.04 (2.39). The smoke
test is more than `dlopen`: a synchronous query, an async worker, a persistent
connection creating a MergeTree table and reading it back, and an engine error
surfacing as a JS exception.

macOS, on this laptop: a local build lands at `minos 13.5` and the assertion
rejects it; with `MACOSX_DEPLOYMENT_TARGET` set, the rebuild lands at 11.0 and
passes. Both published darwin subpackages (11.0) pass, read cross-architecture.

The full chain was re-run against the committed files: runner-style build →
assertion rejects (exit 1) → re-link → assertion passes → packaged subpackage
loads on bookworm.

## Not addressed

**musl / Alpine.** Left as is, deliberately. It is not a lower floor but a
different libc, so supporting it means a whole extra build target (duckdb does
publish `-musl` subpackages). It already fails legibly: the subpackages declare
`libc: ["glibc"]`, so npm skips them and the loader says
`no native binding for linux-arm64. Expected optional dependency @chdb/lib-linux-arm64-gnu`
— a platform question, not a mystery. That is the right way to not support
something.

**CPU baseline.** Nothing asserts what instruction set `libchdb.so` needs. Same
class, chdb-core's side.

## Residual risk

`almalinux:8` installs `gcc-toolset-13` at run time, so a mirror hiccup can redden
the publish job (`--setopt=retries=5` is set). Removing that means a prebuilt
`quay.io/pypa/manylinux_2_28_*` image instead, which was not verified here for
lack of local disk.

`26.7.0-stable.1` is not published yet, so `LIBCHDB_NPM_VERSION` needs no counter
bump — the next tag ships the fixed binary as the first 26.7.x subpackage.

cc @auxten @wudidapaopao
