### PR TITLE
Stop the re-link step dying on its own diagnostic output

### DIFF
--- a/scripts/build-addon-portable.sh
+++ b/scripts/build-addon-portable.sh
@@ -47,7 +47,7 @@ for c in docker podman; do command -v "$c" >/dev/null && { RUNTIME="$c"; break; 
 # node-gyp puts them outside the repository by default. Read the path out of the
 # Makefile rather than guessing where node-gyp cached them, and mount it at the
 # same location so the recorded -I flags still resolve.
-HDR=$(grep -ohE -- '-I[^ ]*/include/node' build/*.mk 2>/dev/null | head -1 | sed 's/^-I//' || true)
+HDR=$(grep -ohE -- '-I[^ ]*/include/node' build/*.mk 2>/dev/null | sed -n '1s/^-I//p' || true)
 [ -n "$HDR" ] || { echo "build-addon-portable: no node header include found in build/*.mk" >&2; exit 1; }
 HDR_ROOT=$(cd "$HDR/../../.." && pwd)
 
@@ -63,8 +63,11 @@ echo "build-addon-portable: re-linking in $BUILDER_IMAGE via $RUNTIME"
   "$BUILDER_IMAGE" bash -euo pipefail -c '
     dnf -y --setopt=retries=5 install "${TOOLSET}-gcc-c++" make >/dev/null
     export PATH="/opt/rh/${TOOLSET}/root/usr/bin:$PATH"
-    g++ --version | head -1
-    ldd --version | head -1
+    # No pipe: under pipefail, a reader that closes after one line sends
+    # SIGPIPE upstream and the whole script dies with 141. It is a race, so it
+    # passed locally and killed the runner.
+    v=$(g++ --version); echo "${v%%$'\n'*}"
+    v=$(ldd --version); echo "${v%%$'\n'*}"
     # Force a real recompile: make would otherwise consider the object the host
     # produced up to date and only the link step would change hosts.
     rm -rf build/Release/obj.target build/Release/chdb_node.node

--- a/scripts/build-addon-portable.sh
+++ b/scripts/build-addon-portable.sh
@@ -63,11 +63,11 @@ echo "build-addon-portable: re-linking in $BUILDER_IMAGE via $RUNTIME"
   "$BUILDER_IMAGE" bash -euo pipefail -c '
     dnf -y --setopt=retries=5 install "${TOOLSET}-gcc-c++" make >/dev/null
     export PATH="/opt/rh/${TOOLSET}/root/usr/bin:$PATH"
-    # No pipe: under pipefail, a reader that closes after one line sends
-    # SIGPIPE upstream and the whole script dies with 141. It is a race, so it
-    # passed locally and killed the runner.
-    v=$(g++ --version); echo "${v%%$'\n'*}"
-    v=$(ldd --version); echo "${v%%$'\n'*}"
+    # Printed whole rather than piped through head: under pipefail a reader that
+    # closes after one line SIGPIPEs the writer and takes the script with it, and
+    # no single quotes can appear here either — this whole command is one.
+    g++ --version
+    ldd --version
     # Force a real recompile: make would otherwise consider the object the host
     # produced up to date and only the link step would change hosts.
     rm -rf build/Release/obj.target build/Release/chdb_node.node


### PR DESCRIPTION
`main` went red on the merge of #87. The re-link step dies on its own diagnostic
output:

```
build-addon-portable: re-linking in docker.io/library/almalinux:8 via docker
g++ (GCC) 13.3.1 20240611 (Red Hat 13.3.1-2)
ldd (GNU libc) 2.28
##[error]Process completed with exit code 141
```

141 is 128 + SIGPIPE. Inside `bash -euo pipefail -c`, `g++ --version | head -1`
lets head exit after the first line; the compiler gets SIGPIPE writing the second;
pipefail makes the pipeline 141 and `set -e` takes the script with it. The re-link
never ran.

It is a race, which is why it passed everywhere it was tried before merging — the
output is four lines and usually reaches the pipe buffer before head closes it.
Deterministically, with a producer large enough to lose:

```
bash -euo pipefail -c 'seq 1 2000000 | head -1'   -> 141
bash -euo pipefail -c 'bash --version | head -1'  -> 0     # small output, wins the race
```

Both version lines now capture and trim rather than pipe, so there is no reader to
close early. The other `| head -1`, reading the node header path out of the
generated makefiles, becomes `sed -n '1s/^-I//p'`; it was already guarded by
`|| true`, so it could only have gone wrong quietly.

## Verified

The mechanism above, that the script still parses, and that on Darwin it is still a
no-op with `assert-runtime-baseline.sh` passing on a freshly built addon
(`minos 11.0`).

**Not** verified end to end: the re-link needs a container runtime and cannot be
exercised from inside one, so the full Linux path is left to CI — which is the job
that caught this in the first place.

cc @auxten @wudidapaopao


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `set -o pipefail` SIGPIPE failure in re-link step of `build-addon-portable.sh`
> The re-link step was failing because piping `g++ --version` and `ldd --version` through `head -1` could trigger SIGPIPE under `set -o pipefail`. The fix removes those pipes and prints the full version outputs instead. Also replaces a `grep|head|sed` pipeline for extracting the node header path with a single `sed -n '1s/^-I//p'` expression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c520ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->