### PR TITLE
Add chdb/durable, chdb/durable/s3 and chdb/libchdb: the pure-TypeScript Durable V1 control plane

### DIFF
--- a/.github/workflows/chdb-node-test.yml
+++ b/.github/workflows/chdb-node-test.yml
@@ -8,9 +8,11 @@ on:
     branches: ["main"]
     paths-ignore: ["**/*.md"]
 
-# update_libchdb.sh pins the published chdb-core v26.5.0 libchdb, which ships
-# chdb_query_with_params (#73) and chdb_query_arrow (#15) across all four target
-# platforms, so the full v2 + v3 suite is expected green here.
+# update_libchdb.sh pins a published chdb-core libchdb across all four target
+# platforms, so the full v2 + v3 suite is expected green here. The pin is
+# currently the v26.7.2-rc.2 pre-release, which is the first to export the
+# Durable V1 ABI (chdb_backup_database_n / chdb_restore_database_n /
+# chdb_classify_query_n).
 
 # Harden the registry fetch so a transient reset (e.g. ECONNRESET during
 # install) retries instead of reddening the job. Combined with the per-job
@@ -34,6 +36,74 @@ jobs:
         with:
           node-version: 22.x
       - run: node scripts/check-version-scheme.mjs
+
+  # The durable control plane is pure TypeScript with no engine dependency, so it
+  # gets its own job instead of riding the matrix: no libchdb download, no addon
+  # build, seconds to run. Keeping it off the matrix also keeps one of its own
+  # assertions honest — it checks that importing chdb/durable loads nothing
+  # native, and the v3 job has the addon in the process before its first test.
+  durable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - run: npm install --ignore-scripts
+      - name: Protocol, state machine and fault matrix
+        run: npm run test:durable
+
+  # Provider conformance for the S3 backend. Separate from the job above so a
+  # flaky container cannot redden the engine-free suite, and because this is the
+  # only automated check that conditional create and compare-and-swap work
+  # against a real object store rather than a filesystem. MinIO needs no
+  # credentials, so it runs on every PR; AWS S3 and R2 stay manual.
+  durable-s3:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - run: npm install --ignore-scripts
+      - name: Start MinIO
+        # Not a `services:` container: GitHub offers no way to pass a command to
+        # one, and this image needs `server /data` to start at all.
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+            quay.io/minio/minio:latest server /data
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              echo "MinIO ready after ${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "MinIO did not become healthy" >&2
+          docker logs minio >&2
+          exit 1
+      - name: Create the test bucket
+        run: |
+          node -e "
+            const { S3Client, CreateBucketCommand } = require('@aws-sdk/client-s3')
+            const c = new S3Client({ region: 'us-east-1', endpoint: 'http://127.0.0.1:9000',
+              forcePathStyle: true,
+              credentials: { accessKeyId: 'minioadmin', secretAccessKey: 'minioadmin' } })
+            c.send(new CreateBucketCommand({ Bucket: 'durable-test' }))
+              .then(() => console.log('bucket created'))
+              .catch(e => { console.error(e.name); process.exit(1) })
+          "
+      - name: S3 provider conformance
+        env:
+          CHDB_DURABLE_S3_BUCKET: durable-test
+          CHDB_DURABLE_S3_ENDPOINT: http://127.0.0.1:9000
+          CHDB_DURABLE_S3_REGION: us-east-1
+          CHDB_DURABLE_S3_FORCE_PATH_STYLE: "true"
+          AWS_ACCESS_KEY_ID: minioadmin
+          AWS_SECRET_ACCESS_KEY: minioadmin
+        run: npm run test:durable:s3
 
   test:
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,11 @@ Run SQL you have, or anything ClickHouse-specific?   -> raw SQL  (query / sql``)
 Build queries programmatically, type-safe + bound?   -> fluent   (selectFrom / insertInto)  [src/layer3/AGENTS.md]
 Read/JOIN external sources (S3/Postgres/…)?          -> connect({ url })                     [src/layer3/AGENTS.md]
 Migrating from @clickhouse/client (drop-in)?         -> chdb/connection                      [src/connection/AGENTS.md]
+Need the database to survive losing the machine?     -> chdb/durable   (experimental)        [docs/design/durable-control-plane.md]
 ```
 
-All four sit on the same engine. Default to raw SQL for one-off analytics; use the fluent
+The first four sit on the same engine; `chdb/durable` sits *above* it and loads no native
+code of its own — the caller injects the engine. Default to raw SQL for one-off analytics; use the fluent
 builder when an app or LLM assembles queries from parts (it binds every value server-side).
 
 ## Minimal examples

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ somewhere later.
 | Arrow **scan** (`registerArrowTable`, Arrow input) | ⏳ follow-up |
 | Arrow zero-copy (M2, `{ zeroCopy: true }`) | ⏳ follow-up |
 | chDB ↔ `@clickhouse/client` integration (`chdb/connection`, **experimental**) | ✅ |
+| Durable V1 control plane (`chdb/durable`, **experimental**) | ✅ pure TS; native adapter pending |
+| Remote object storage for durable (`chdb/durable/s3`) | ✅ verified on AWS S3 and MinIO; R2 untested |
 
 ### chDB ↔ `@clickhouse/client` integration (`chdb/connection`, experimental)
 
@@ -158,11 +160,77 @@ for the full design, the `Connection` interface, the `.chdb` extension
 namespace, the `tests/clickhouse-js/skip_list.json` parity blacklist,
 and the sync policy with `@clickhouse/client`.
 
+### Remote-authoritative durability (`chdb/durable`, experimental)
+
+> **Status**: implements chDB Durable V1 as specified in
+> `CHDB_DURABLE_V1_CONTRACT.md` in the
+> [chdb](https://github.com/chdb-io/chdb) repository, which is the source of
+> truth for the protocol. The pure-TypeScript control plane is complete; a
+> default engine adapter over the native addon is still to come, so today the
+> caller supplies the engine.
+>
+> Requires an engine exporting the durable ABI — currently `26.7.2-rc.2`.
+> Compatibility is a floor rather than an equality: an object records
+> `min_reader` and `backup_format`, and any engine at or above that floor opens
+> it. An object written by `26.7.2-rc.2` stays readable on `26.7.3` and later.
+
+`chdb/durable` makes an embedded chDB database recoverable on a *different*
+machine: a full checkpoint plus a statement WAL in object storage, with a
+single `head.json` updated by compare-and-swap under a fenced writer lease.
+
+Importing it loads **no native code** — not the addon, not `libchdb`. The
+engine arrives as an `EngineAdapter` the caller provides, which is what lets a
+Bun process that already owns its own `dlopen(libchdb)` reuse the state machine
+without a second engine in the process. The companion `chdb/libchdb` subpath
+resolves where the library *is* without opening it.
+
+Recovery on another machine needs the object to live somewhere neither machine
+owns, so `chdb/durable/s3` provides an S3-compatible backend — AWS S3,
+Cloudflare R2 and MinIO through one implementation. It sits behind its own
+subpath, and `@aws-sdk/client-s3` is an optional peer dependency, so callers
+who only use the local backend never install it.
+
+```ts
+import { DurableNamespace } from 'chdb/durable'
+import 'chdb/durable/s3'   // registers the s3:// scheme
+
+const ns = new DurableNamespace('s3://my-bucket/durable?region=eu-west-1', { engineFactory })
+const obj = await ns.open('orders', { database: 'default' })
+
+const ticket = await obj.execute("INSERT INTO events VALUES (1, 'a')")
+await obj.flushThrough(ticket)   // durability barrier; execute() alone is not one
+await obj.checkpoint()
+await obj.close()                // rejects if the final flush or lease release failed
+```
+
+Writes go through ClickHouse's own parser, not a regex: `execute()` takes
+exactly one `MUTATING` statement that core can prove writes only inside this
+object's database and embeds no credential, and `query()` takes exactly one
+`READ_ONLY` statement. Method names are not the gate.
+
+`obj.stats` gives a consistent snapshot for a status endpoint or log line —
+lease generation, committed sequence, pending statements and bytes, last flush
+and checkpoint times — with no credentials or SQL in it. `onRestoreProgress`
+reports each phase of a recovery, so a slow restore is distinguishable from a
+stuck one.
+
+The conditional writes S3 needs are real preconditions on `PutObject`
+(`If-None-Match: *` and `If-Match: <etag>`), never a HEAD followed by a PUT.
+A provider counts as supported once it has passed
+`test/durable/s3-backend.test.ts`, which is parameterised for exactly that.
+AWS S3 and MinIO have; Cloudflare R2 has not been run yet.
+
+See [docs/design/durable-control-plane.md](docs/design/durable-control-plane.md)
+for the object layout, the lease and fencing rules, the ambiguous-commit
+reconcile, both backends' compare-and-swap, and what V1 deliberately leaves
+out.
+
 ### Design docs
 
 - [Layered API design](docs/design/architecture.md): the Layer 1 / Layer 2 / Layer 3 architecture, package shape, and intended user-facing surfaces.
 - [Layer 1 native binding reviewer guide](docs/design/layer1-native-binding.md): the PR #43 design and implementation map, organized by commit and review feedback.
 - [chDB ↔ `@clickhouse/client` integration (experimental)](docs/design/pluggable-connection.md): the `chdb/connection` surface, the `Connection` interface chdb-node implements, the `.chdb` extension namespace, and the parity-test sync policy.
+- [Durable V1 control plane (experimental)](docs/design/durable-control-plane.md): the `chdb/durable` and `chdb/libchdb` subpaths, the `EngineAdapter` seam, lease/fencing/reconcile behaviour, and the V1 boundary.
 
 ### Runtimes
 

--- a/docs/design/durable-control-plane.md
+++ b/docs/design/durable-control-plane.md
@@ -178,6 +178,19 @@ is swallowed, because reporting must not be able to fail a good recovery.
 
 ### Backends: local is for testing, S3 is for the point
 
+Which also settles what the local backend is worth hardening against. It
+defends two things, because both are real whatever the scope: keys taken out of
+`head.json`, which is untrusted input fetched from object storage and could
+name `..` or an absolute path; and losing data it has already reported as
+written, which is a correctness bug rather than a security one, and disqualifies
+a conformance baseline.
+
+It does not defend against a hostile local filesystem. Guarding against, say, a
+symlink planted inside the object prefix buys no privilege boundary — whoever
+can plant it can rewrite the objects directly — and check-then-use cannot be
+made atomic without `openat`, which Node does not expose. Anything wanting that
+property should not be on this backend.
+
 A local directory cannot be a remote authority. When the machine holding it is
 gone, so is the object — so the local backend is what conformance and
 development run on, not what makes a database recoverable somewhere else.

--- a/docs/design/durable-control-plane.md
+++ b/docs/design/durable-control-plane.md
@@ -1,0 +1,547 @@
+# `chdb/durable` — Durable V1 control plane
+
+`chdb/durable` is a pure-TypeScript implementation of the chDB Durable V1
+protocol. It turns an embedded chDB database into an object in remote storage
+that a *different machine* can recover: a full checkpoint, a statement WAL on
+top of it, and a single `head.json` updated by compare-and-swap under a fenced
+writer lease.
+
+The protocol itself is specified in `CHDB_DURABLE_V1_CONTRACT.md` in the
+[chdb](https://github.com/chdb-io/chdb) repository. **That document is the
+source of truth, not this implementation.** Semantics change there first, then
+here.
+
+## What ships
+
+Two subpaths, neither of which loads native code:
+
+| Subpath | What it is |
+| --- | --- |
+| `chdb/durable` | The control plane: object layout, `head.json`, manifest, lease, CAS, fencing, WAL, checkpoint orchestration, error categories, local backend |
+| `chdb/durable/s3` | S3-compatible backend — AWS S3, Cloudflare R2, MinIO. Registers the `s3` scheme on import |
+| `chdb/libchdb` | A path resolver. Says where `libchdb.so` is; does not open it |
+
+The S3 backend sits behind its own subpath so that `chdb/durable` never pulls
+in the AWS SDK. A caller using only the local backend should not have to
+install several megabytes of it, and `@aws-sdk/client-s3` is an *optional* peer
+dependency for the same reason.
+
+## The engine is injected, and that is the point
+
+`chdb/durable` never touches a native library. The engine arrives as an
+`EngineAdapter` the caller supplies:
+
+```ts
+interface EngineAdapter {
+  start(options: { dataPath: string; backupsAllowedPath: string }): Promise<void>
+  version(): Promise<string>
+  createDatabase(database: string): Promise<void>
+  useDatabase(database: string): Promise<void>
+  analyze(sql: string, targetDatabase: string): Promise<QueryAnalysis>
+  query(sql: string, format: string): Promise<string>
+  run(sql: string): Promise<void>
+  backupDatabase(database: string, filePath: string): Promise<void>
+  restoreDatabase(database: string, filePath: string): Promise<void>
+  close(): Promise<void>
+}
+```
+
+This is not abstraction for its own sake. The first downstream user of the
+package reaches `libchdb` through its own Bun FFI bindings, and chdb-core binds
+**one data path per process** — so a control plane that transitively loaded
+`chdb_node.node` would put a second engine in a process that can only have one.
+`test/durable/subpath.test.ts` asserts the no-native-load property in a child
+process with `process.dlopen` replaced by a throw, which is the only version of
+that check that cannot pass by accident.
+
+The five methods that matter map onto the C ABI directly. Two of them are the
+reason the seam exists at all:
+
+- **`analyze` is `chdb_classify_query_n`.** No prefix lists, no regular
+  expressions, in any binding. Only ClickHouse's own parser can say how many
+  executable statements a text holds, see through `INSERT ... FORMAT` inline
+  data, or resolve an unqualified table name against the session database.
+- **`backupDatabase` / `restoreDatabase` take an identifier and a path.** Core
+  builds the AST and does the quoting. A binding that concatenated
+  `BACKUP DATABASE ` + name would be one adversarial database name away from
+  injection, in four languages independently.
+
+`backupDatabase` has no incremental-base parameter even though the C ABI accepts
+one: an incremental archive records the absolute path of its base, and that path
+does not exist on the machine doing the restore. V1 checkpoints are always full.
+
+## Usage
+
+```ts
+import { DurableNamespace } from 'chdb/durable'
+
+const ns = new DurableNamespace('file:///var/lib/chdb-durable', {
+  engineFactory: () => new MyEngineAdapter(),
+})
+
+const obj = await ns.open('orders', { database: 'default' })
+
+// A read. Refused unless core proves it is exactly one READ_ONLY statement.
+const rows = await obj.query('SELECT count() FROM events', { format: 'JSONEachRow' })
+
+// A write. Runs locally, then joins the WAL buffer. NOT yet durable.
+const ticket = await obj.execute("INSERT INTO events VALUES (1, 'a')")
+
+// Durability barrier. After this resolves, losing the machine loses nothing.
+await obj.flushThrough(ticket)
+
+await obj.checkpoint()   // full backup replaces the base, WAL list is cleared
+await obj.close()        // drains, flushes, releases the lease — and rejects if any of that failed
+```
+
+### `execute()` succeeding is not durability
+
+`execute()` returning means the statement ran against the local database and
+was appended to the in-memory WAL buffer. That is all. Durability is `flush()`,
+or `flushThrough(ticket)` for one specific statement.
+
+A service that answers a client before flushing has chosen to lose that write on
+a crash. That can be the right trade — it should just be a choice, not a
+surprise. `flushThrough` exists so a caller that expands one request into
+several statements can hold the whole request open behind a single watermark:
+concurrent waiters coalesce onto one head commit, because the first through the
+operation queue publishes a segment covering all of them and the rest find their
+watermark already met.
+
+### Entry-point gates
+
+Method names are not the gate; the analysis is. `query("INSERT …")` and
+`execute("SELECT …")` are both refused, by core, not by inspecting the string.
+
+| | `query()` | `execute()` |
+| --- | --- | --- |
+| statement count | exactly 1 | exactly 1 |
+| class | `READ_ONLY` | `MUTATING` |
+| writes confined to this database | — | required |
+| changes database lifecycle | — | refused |
+| carries a credential | allowed | refused |
+
+A read-only statement may carry a secret because it never reaches the WAL. A
+mutation may not, because the WAL outlives the statement — so the credential
+would outlive it too. `MUTATING_GLOBAL` (global UDFs, named collections, access
+entities, `system` writes) is refused outright in V1: a checkpoint is
+`BACKUP DATABASE`, which cannot carry state that lives outside every database,
+so logging it would mean losing it silently at the next checkpoint.
+
+`UNKNOWN` fails closed.
+
+## Design notes
+
+### The buffer is bounded where a refusal is still cheap
+
+`execute()` checks two limits before running the statement: the frozen 64 MiB
+per-statement ceiling, and whether this statement would take the unflushed
+buffer past the 128 MiB a WAL segment can hold.
+
+Checking at flush instead would be too late in a way that is hard to get out
+of. A statement that has executed cannot be un-executed, so once the buffer is
+larger than a segment, every flush fails while encoding and the local database
+has already moved on. `checkpoint()` can still rescue it — it archives the
+database rather than the buffer — but the caller has to know that, and nothing
+would have told it.
+
+What makes that worth guarding rather than documenting is how reachable it is
+from one transient failure. A flush that fails leaves the buffer intact, by
+design; a caller that keeps writing walks straight into a buffer no flush can
+encode. So a single network blip escalates into a state needing manual
+intervention. Refusing at `execute()` turns that into an ordinary recoverable
+error: nothing ran, and `pendingBytes` lets a caller apply its own backpressure
+long before the ceiling.
+
+The budget has to agree with the encoder exactly, so `walLineBytes` and
+`encodeWalSegment` are pinned to each other by a test rather than left to stay
+in step by inspection.
+
+### Observability
+
+`stats` returns a consistent point-in-time snapshot — generation, lease expiry,
+committed sequence, base key, WAL segment count, executed and committed
+statement counts, pending statements and bytes, and the times of the last
+successful flush and checkpoint. It is taken as one object rather than field by
+field because reading a generation and a sequence number through separate
+getters can straddle a commit and describe a state that never existed.
+
+It carries no credentials and no SQL, so it is safe to log verbatim; a test
+asserts that.
+
+Recovery reports progress through `onRestoreProgress`: creating the database or
+restoring the base, then each WAL segment as it replays, then ready with a
+statement count. Restoring a large object is not instantaneous, and "starting"
+with no further detail is indistinguishable from "stuck" — which is the pair an
+operator most needs to tell apart. The callback is best-effort: a throw from it
+is swallowed, because reporting must not be able to fail a good recovery.
+
+### Backends: local is for testing, S3 is for the point
+
+A local directory cannot be a remote authority. When the machine holding it is
+gone, so is the object — so the local backend is what conformance and
+development run on, not what makes a database recoverable somewhere else.
+
+`chdb/durable/s3` is the one that does. One implementation serves three
+providers, since the differences are endpoint and addressing:
+
+```text
+AWS     s3://my-bucket/durable?region=eu-west-1
+R2      s3://my-bucket/durable?region=auto&endpoint=https://<id>.r2.cloudflarestorage.com
+MinIO   s3://my-bucket/durable?region=us-east-1&endpoint=http://127.0.0.1:9000&forcePathStyle=true
+```
+
+Credentials are deliberately not in the URL. They come from the environment or
+the standard credential chain, because a namespace URL is the sort of thing
+that ends up in a config file, a log line and an issue comment.
+
+The conditional operations map onto preconditions on `PutObject`:
+
+| Backend method | HTTP |
+| --- | --- |
+| `putBytesIfAbsent` / `putFileIfAbsent` | `PUT` + `If-None-Match: *` |
+| `replaceIfMatch` | `PUT` + `If-Match: <etag>` |
+| 412, or 409 `ConditionalRequestConflict` | a CAS outcome, not a transport error |
+| timeout, reset connection, 5xx | `'ambiguous'`, resolved upstream by re-reading |
+
+**The SDK's own retries are safe, for a specific reason.** A retry can turn a
+request that did land into a precondition failure: the first `PutObject`
+succeeds, the response is lost, the retry finds the object there and gets a
+412. So this backend can report `already-exists` for an object it wrote itself.
+That is fine because nothing upstream concludes anything from a status code —
+`already-exists` sends the object layer to re-read that unique key and compare
+length and SHA-256, `not-replaced` sends it to re-read the head and look for
+its own intent under its own lease. A design that trusted the status code would
+need retries disabled; this one does not.
+
+**One assumption the ETag forces, worth naming.** An S3 ETag is a content hash
+for single-part uploads, so writing byte-identical content does not advance it,
+and the token used for that write stays valid — a second racer holding it also
+wins. This was measured against MinIO, not assumed. Durable is safe from it
+because every head write changes the bytes: lease acquisition moves the
+generation, heartbeat moves `expires_at`, flush and checkpoint move
+`manifest.seq`. That is a real dependency rather than a happy accident, which
+is why `test/durable/s3-backend.test.ts` pins the behaviour — anything that
+made a head write byte-idempotent would break CAS on any content-hash provider.
+
+### Two mutexes, not one
+
+`execute`, `query`, `flush`, `checkpoint` and `close` serialize on an
+**operation** mutex. A single head compare-and-swap serializes on a separate
+**head** mutex, and heartbeat only ever takes that one.
+
+With one mutex, checkpointing a large database would block heartbeat for the
+whole backup and upload, and the writer would fence itself out of an object it
+was legitimately in the middle of checkpointing. With the split, heartbeat keeps
+landing during a long backup, and the checkpoint's own final commit takes the
+head mutex afterwards and therefore sees the ETag heartbeat just produced.
+
+### Nothing is reported as committed without proof
+
+Every conditional operation can answer `'ambiguous'`, because a request whose
+response was lost is not a failure. The state machine resolves that by looking
+at what is actually there:
+
+- an immutable upload is settled by re-reading its unique key and comparing
+  size and SHA-256 — matching bytes are a commit, different bytes are
+  `corrupt`, an absent object means retry;
+- a head CAS is settled by re-reading the head — the intent visible with
+  ownership intact is a commit, ownership lost is `lease_fenced`, neither is a
+  retry inside the deadline;
+- nothing provable by the deadline is `commit_ambiguous`.
+
+Reporting a lost response as success is the one failure a caller cannot defend
+against, so it is the one thing this never does.
+
+### A writer that cannot confirm its lease stops writing
+
+Not on the next error — at the moment its locally believed validity window
+lapses. `assertWriter()` checks that on every write, and a lapsed window fences
+the handle permanently. The alternative is two processes each convinced they are
+the only writer.
+
+Takeover of an *expired* lease waits out a clock-skew allowance on top of the
+recorded expiry, because the two writers' clocks are not the same clock. Taking
+an *unexpired* lease requires an explicit `force`, and costs the previous
+writer's unflushed local work.
+
+Defaults, all configurable per namespace or per open:
+
+| Setting | Default | Rule |
+| --- | --- | --- |
+| `leaseTtlMs` | 30 000 | validity after a successful head write |
+| `heartbeatIntervalMs` | 10 000 | must be ≤ TTL/3 |
+| `clockSkewAllowanceMs` | 5 000 | added to a recorded expiry before takeover |
+| `commitDeadlineMs` | 30 000 | per commit, across retries and reconcile |
+| `maxCommitAttempts` | 5 | inside that deadline |
+
+### Unknown fields survive a write-back
+
+A writer that rebuilt `head.json` from scratch on every write would delete every
+field it did not recognise, which makes the whole named-feature mechanism a lie:
+a future revision's state would survive exactly until an older writer touched
+the object. So the parsed raw JSON is carried alongside the typed view and known
+fields are patched onto a clone of it — at the top level and inside `protocol`,
+`engine`, `lease` and `manifest`.
+
+Preserving unknown fields is not the same as being lenient about known ones.
+Wrong types are `corrupt`, not coerced.
+
+Features are named rather than versioned because a monotonic minimum version
+requires features to be linearly ordered, and with several bindings developed in
+parallel they are not: a client can implement B without A, and under a version
+floor it would be locked out of an object that only ever used B. Unknown
+*reader* feature refuses the open; unknown *writer* feature still allows a
+read-only open and refuses only the lease.
+
+### The local backend's compare-and-swap is real
+
+POSIX has no CAS on file contents, and the usual workarounds are worse than the
+problem — a lock file turns a crash into a stuck object needing a staleness
+heuristic; read-compare-rename has the race it is meant to prevent. So the
+mutable key is a chain of immutable versions plus a symlink naming the current
+one:
+
+```text
+head.json               -> symlink to .head-versions/7.json
+.head-versions/7.json   immutable
+```
+
+The ETag is the version number. Replacing against `v7` means creating
+`.head-versions/8.json`, and `link(2)` lets exactly one racer do that — the
+`EEXIST` *is* the CAS failure. The symlink is then swapped in with an atomic
+`rename`. Immutable objects use the same `link(2)` primitive for
+create-if-absent.
+
+A fixture written by another binding has a plain `head.json`, which reads fine
+(the ETag is then a content digest) and is adopted into the chain on the first
+replace. A plain-file reader continues to see a correct `head.json` through the
+symlink.
+
+## Testing
+
+```sh
+npm run test:durable          # protocol + state machine + fault matrix (no engine)
+npm run test:durable:s3       # S3-compatible provider conformance (needs a bucket)
+npm run test:durable:e2e      # end-to-end against a real libchdb, under Bun
+npm run test:durable:stack    # the whole stack: Bun + libchdb + real object storage
+```
+
+The last one is the arrangement a downstream actually deploys, and the only
+place the other two suites' halves meet. Each of them covers one: a real engine
+over a local directory, or a real bucket under a fake engine. Both can pass
+while an assumption held by only one of them is wrong.
+
+```sh
+CHDB_LIBCHDB_PATH=/path/to/libchdb.so \
+CHDB_DURABLE_S3_BUCKET=my-bucket CHDB_DURABLE_S3_REGION=us-east-2 \
+  npm run test:durable:stack
+```
+
+Both Bun suites pass `--timeout`, because the default five seconds is fine for
+a local engine and not for a checkpoint round-tripping through real object
+storage.
+
+The unit suites run the **real** `LocalDurableBackend` — mocking it would mean
+the conditional-create and CAS paths, the only parts of a backend that can be
+subtly wrong, were never exercised. `FaultBackend` wraps it rather than
+replacing it, so a fault scenario runs the real code right up to the injected
+failure, including the modes that write for real and *then* lose the response.
+
+The engine in those suites is a fake, because the state machine's correctness
+does not depend on ClickHouse executing anything, and a real engine binds one
+data path per process.
+
+The end-to-end suite closes that gap. It runs under Bun because it reaches
+`libchdb` through `bun:ffi` — which is also the shape a downstream owning its
+own `dlopen` will use — and it is the only place the entry-point gates are
+checked against the real `chdb_classify_query_n`:
+
+```sh
+CHDB_LIBCHDB_PATH=/path/to/chdb-core/buildlib/libchdb.so npm run test:durable:e2e
+```
+
+`CHDB_LIBCHDB_PATH` is only needed when a platform package that predates the
+durable ABI is installed. The resolver prefers `@chdb/lib-*` over anything in
+the working tree, so a stale one shadows a local `chdb-core` build — and until
+the RC platform packages are published, the newest on npm is
+`26.7.0-stable.1`, which exports none of the durable symbols. Either override
+the path or `rm -rf node_modules/@chdb/lib-*`, which is what CI already does.
+Running against a shadowing build fails with a message naming the missing ABI
+rather than a bare `dlopen` TypeError.
+
+`test/durable/libchdb-ffi.ts` is the adapter it uses. It is deliberately not
+shipped: the published package's default adapter belongs on the native addon,
+and a Bun-only module in the dependency graph would be a trap for Node users.
+Downstreams that want this shape should own their copy — it is a symbol table
+and fifty lines of `dlopen`.
+
+### Conformance status
+
+Against the V1 conformance list, this binding's position:
+
+| Requirement | Status |
+| --- | --- |
+| Core ABI and query-classification matrix | covered by the end-to-end suite |
+| All three `backup_format` / `min_reader` gate outcomes | covered |
+| Format fixtures: empty, checkpoint-only, checkpoint-plus-WAL, quoted database | covered |
+| Missing/corrupt base and WAL, future protocol, unknown feature, incompatible engine | covered |
+| Single-writer races, fencing, heartbeat, failed and ambiguous commits | covered |
+| Unknown-field round trips, size limits, secret redaction, close failure | covered |
+| Full provider suite against a real object store | covered — AWS S3 and MinIO |
+| Restoring full backups from *earlier* core releases | not applicable yet — `v26.7.2-rc.2` is the first release with the Durable ABI, so there is no earlier archive to restore |
+| New-header/old-library and old-header/new-library ABI tests | not applicable yet — same reason; the promise starts here |
+| Every writer's fixture read by two other bindings | pending — needs Python and Go to reach V1 |
+
+The two "not applicable" rows become real on the second Durable-capable core
+release, and the fixtures written now are what they will be tested against.
+
+### Provider conformance
+
+The contract is explicit that a provider is supported because this suite passed
+against it, not because it advertises S3 compatibility (§7.5). So
+`test/durable/s3-backend.test.ts` is parameterised — point it anywhere:
+
+```sh
+docker run -d --name minio -p 9000:9000 \
+  -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+  quay.io/minio/minio:latest server /data
+
+CHDB_DURABLE_S3_BUCKET=durable-test \
+CHDB_DURABLE_S3_ENDPOINT=http://127.0.0.1:9000 \
+CHDB_DURABLE_S3_REGION=us-east-1 \
+CHDB_DURABLE_S3_FORCE_PATH_STYLE=true \
+AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
+  npm run test:durable:s3
+```
+
+Without a bucket configured it skips, so the rest of the suite stays runnable
+with no network. It writes everything under one unique prefix and deletes it
+afterwards — the protocol has no destroy, but a test that leaves objects in
+someone's bucket costs them money.
+
+Beyond the six backend methods, it runs the claim the feature actually makes: a
+durable object written on one "machine" — one namespace instance, one engine,
+one scratch tree — reopened on another that shares nothing but the bucket, for
+both a WAL-only object and a checkpointed one.
+
+Run against engine `26.7.2-rc.2`:
+
+| Provider | Status |
+| --- | --- |
+| AWS S3 (`us-east-2`) | 11/11 conformance, plus 4/4 full stack |
+| MinIO (`RELEASE.2025-09-07`) | 11/11 conformance, run repeatedly |
+| Cloudflare R2 | not run — the code path is the same, but the claim is not made until measured |
+
+The two that have run agree on every point, including the ETag behaviour above:
+`If-None-Match: *` and `If-Match` are atomic on both, an eight-way race leaves
+exactly one winner on both, and re-PUTting identical bytes advances the token on
+neither.
+
+## Not in V1
+
+Deliberately absent, each requiring its own proposal, feature name and fixtures
+before it arrives (contract §8):
+
+- preamble / global state — all `MUTATING_GLOBAL` fails closed today
+- incremental checkpoints
+- Parquet or data WAL
+- garbage collection and destroy — nothing here deletes an object (see below)
+- multiple writers, multiple databases per object, cross-object transactions
+- cross-engine-version restore — V1 pins `chdb_version()` exactly
+- multipart upload: a single `PutObject` caps an object at 5 GiB, and a larger
+  checkpoint fails with `limit_exceeded` rather than truncating. Note where that
+  failure lands — the size is known only after the archive exists, so the backup
+  has already been taken and the local disk already used when it is refused.
+  There is no earlier check to make; the engine does not predict archive size
+- GCS and Azure backends: register one with `registerBackendScheme()`
+
+### Engine compatibility is a floor, not an equality
+
+The protocol gates on two explicit fields rather than on which build wrote the
+object:
+
+```text
+backup_format > this engine's generation  ->  engine_incompatible
+running version < min_reader              ->  engine_incompatible
+otherwise                                 ->  open
+```
+
+`engine.version` records the producer, for diagnosis. It is deliberately not a
+gate — an exact match would refuse every later release, which is the opposite
+of what chdb-core promises: a newer release restores full backups made by an
+earlier one. An object written by `26.7.2-rc.2` opens on `26.7.2`, `26.7.3` and
+`26.8.1`.
+
+The two checks guard different failures and neither subsumes the other.
+`min_reader` catches a reader that is simply too old. `backup_format` is the
+escape hatch for the day the compatibility promise is withdrawn: version
+numbers keep rising whether or not old archives still restore, so a broken
+format needs its own signal — otherwise a reader compares a larger version,
+concludes it is fine, and finds out partway through RESTORE. Core increments
+the generation; a reader refuses anything above its own. Until the C ABI
+exposes it, `EngineAdapter.backupFormat()` is optional and everything is the V1
+baseline of 1.
+
+Versions are ordered by release precedence, never as strings. That is not
+pedantry: lexicographically `"26.10.0" < "26.7.0"` and `"26.7.2-rc.2" >
+"26.7.2"`, and either one would let a reader open an object it cannot restore.
+A version string that cannot be parsed is refused rather than guessed at.
+
+chDB ships only `X.Y.Z` and `X.Y.Z-rc.N`, and a patch number that had a release
+candidate never gets a stable of the same number — after `26.7.2-rc.2` the next
+stable is `26.7.3`. The comparison is semver-shaped rather than a match on those
+two exact forms, which makes it more permissive than the convention: a future
+`26.7.2-beta.1` would sort correctly instead of being rejected. Tightening it
+would fail closed in the wrong place — refusing an object that could have been
+opened safely.
+
+A writer raises the floor on every head write and never lowers it — `max` of
+what is stored and what this engine requires — so an older engine reaching a
+write cannot advertise the object as readable by a build that cannot restore
+its base.
+
+If RESTORE fails anyway on an archive the gate admitted, that is the promise
+being violated rather than an ordinary engine error, and it surfaces as
+`engine_incompatible` so the caller knows to upgrade rather than to retry.
+
+### Objects only grow
+
+This is the V1 cost most likely to surprise someone in production, so it is
+worth stating plainly rather than leaving as an absence.
+
+Every checkpoint publishes a new base and empties the WAL list. The previous
+base and the WAL segments it subsumed stop being referenced at that moment —
+and stay in the bucket forever, because nothing in V1 deletes anything. A busy
+object accumulates one orphaned archive per checkpoint indefinitely.
+
+The reflex fix does not work: **a plain age-based lifecycle rule will corrupt
+objects.** The current base can be arbitrarily old — an object written once and
+then only read keeps the same base for as long as it exists — so "delete objects
+older than N days" happily deletes the base a live manifest points at, and the
+next open fails with `corrupt`.
+
+Reclaiming safely means reading `head.json`, keeping every key it references,
+and deleting only the rest, with a grace period long enough to cover a reader
+that fetched a manifest just before a checkpoint replaced it. That is a real
+design — concurrent-reader safety and orphan windows are the hard parts, which
+is why the contract holds it back to V2 (§8.1 item 4) rather than bolting it
+onto checkpoint. Until then, plan for the growth or run that reclaim as an
+external tool.
+
+One more constraint is not the control plane's to hide: chdb-core binds one data
+path per process, so **one process holds one open durable object at a time**.
+Fan-out has to be sequential, or spread across worker processes.
+
+## Still to do on the chdb-node side
+
+The pure-JS layer is complete; the native side is not:
+
+1. Bind `chdb_backup_database_n`, `chdb_restore_database_n`,
+   `chdb_classify_query_n` and `chdb_version` in `lib/chdb_node.cpp`.
+2. Ship a default `EngineAdapter` over the addon's async API
+   (`src/durable/adapters/chdb-node.ts`), so `chdb/durable` works out of the box
+   for Node callers who are not bringing their own engine.
+3. Point `optionalDependencies` at `@chdb/lib-*` builds carrying the new ABI.
+4. Add the shared cross-binding fixtures from the chdb repository once they
+   exist, and read a Python-written object with them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chdb",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chdb",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -18,6 +18,7 @@
         "chdb-gen-types": "dist/layer3/codegen/cli.js"
       },
       "devDependencies": {
+        "@aws-sdk/client-s3": "^3.1125.0",
         "@hypequery/clickhouse": "^2.1.2",
         "@mastra/core": "^1.47.0",
         "@types/node": "^20.14.0",
@@ -34,12 +35,13 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@chdb/lib-darwin-arm64": "26.5.2",
-        "@chdb/lib-darwin-x64": "26.5.2",
-        "@chdb/lib-linux-arm64-gnu": "26.5.2",
-        "@chdb/lib-linux-x64-gnu": "26.5.2"
+        "@chdb/lib-darwin-arm64": "26.7.2-rc.2.1",
+        "@chdb/lib-darwin-x64": "26.7.2-rc.2.1",
+        "@chdb/lib-linux-arm64-gnu": "26.7.2-rc.2.1",
+        "@chdb/lib-linux-x64-gnu": "26.7.2-rc.2.1"
       },
       "peerDependencies": {
+        "@aws-sdk/client-s3": ">=3",
         "@clickhouse/client": ">=1.23.0",
         "@hypequery/clickhouse": ">=2.1.2",
         "@mastra/core": ">=0.10",
@@ -48,6 +50,9 @@
         "zod": ">=3"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/client-s3": {
+          "optional": true
+        },
         "@clickhouse/client": {
           "optional": true
         },
@@ -273,63 +278,331 @@
         "node": ">=22"
       }
     },
-    "node_modules/@chdb/lib-darwin-arm64": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@chdb/lib-darwin-arm64/-/lib-darwin-arm64-26.5.2.tgz",
-      "integrity": "sha512-dJGw6uLmBQegU0ddWsG2N9E+uSKCW0CJqYBZK5qlz+D9hXxGGnm7Ox8Uo/nQ870Q/1qKbrTF2Zp9BOEHokluhQ==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.29.tgz",
+      "integrity": "sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
-    "node_modules/@chdb/lib-darwin-x64": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@chdb/lib-darwin-x64/-/lib-darwin-x64-26.5.2.tgz",
-      "integrity": "sha512-uY1AHR2oZyEBG1fKT24JrYO/UK8fmKNXYA7pp3jfIuKTEetz2ssIrImRJb8zMRIMWQkFcso8CwpIYrmQ0PleSg==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1125.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1125.0.tgz",
+      "integrity": "sha512-l0npObtjYgqDfUHiifnWGFuAuMVq5r4AVf4C+jY+thJ/2iAr/eHqAjBR4clbmXxSoJ5w3+ZFGRPyci/CCkUoyg==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.29",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.82",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.75",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
-    "node_modules/@chdb/lib-linux-arm64-gnu": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@chdb/lib-linux-arm64-gnu/-/lib-linux-arm64-gnu-26.5.2.tgz",
-      "integrity": "sha512-BayHMFnyxGp3/na9Wz3jfhXk6SxY+Kxv3u7pVsZ67JViDkAhMdVTGAcGvNbv9HESrC65mk0r4yjhaz5HB9pEGg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
-    "node_modules/@chdb/lib-linux-x64-gnu": {
-      "version": "26.5.2",
-      "resolved": "https://registry.npmjs.org/@chdb/lib-linux-x64-gnu/-/lib-linux-x64-gnu-26.5.2.tgz",
-      "integrity": "sha512-yOUe6xu1HpkB21KFOn4MNx16SQtPnuVm5zYR3dFjIYtBf4tvapdJuHcHlKLSVgu1z5hGoI4oca/URFLSy9C4ow==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.82",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+      "integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.75.tgz",
+      "integrity": "sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@clickhouse/client": {
       "version": "1.23.0",
@@ -1540,6 +1813,93 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.0.tgz",
+      "integrity": "sha512-0mq1pHadfyXCYCqm2cNpbjNIT+fbaUpNxewZb/YNr2L0IrEVMOb8gM/Fl4K6XvHCW3uSNDFwPl/+iKm0bx9jYg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2166,6 +2526,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,21 @@
       "require": "./dist/connection/index.js",
       "default": "./dist/connection/index.js"
     },
+    "./durable": {
+      "types": "./dist/durable/index.d.ts",
+      "require": "./dist/durable/index.js",
+      "default": "./dist/durable/index.js"
+    },
+    "./durable/s3": {
+      "types": "./dist/durable/backends/s3.d.ts",
+      "require": "./dist/durable/backends/s3.js",
+      "default": "./dist/durable/backends/s3.js"
+    },
+    "./libchdb": {
+      "types": "./dist/libchdb/index.d.ts",
+      "require": "./dist/libchdb/index.js",
+      "default": "./dist/libchdb/index.js"
+    },
     "./agents": {
       "types": "./integrations/agents/index.d.mts",
       "import": "./integrations/agents/index.mjs"
@@ -52,7 +67,11 @@
     "build": "node-gyp configure build --verbose && npm run fixloaderpath && npm run build:ts",
     "build:ts": "rm -rf dist && tsc -p tsconfig.build.json",
     "prepack": "npm run build:ts",
-    "install": "node -e \"\""
+    "install": "node -e \"\"",
+    "test:durable": "npm run build:ts && vitest run --config vitest.durable.config.ts",
+    "test:durable:e2e": "bun test --timeout 120000 test/durable/libchdb-e2e.bun.test.ts",
+    "test:durable:s3": "vitest run --config vitest.durable.config.ts test/durable/s3-backend.test.ts",
+    "test:durable:stack": "bun test --timeout 300000 test/durable/full-stack.bun.test.ts"
   },
   "author": {
     "name": "chdb",
@@ -75,6 +94,7 @@
     "integrations"
   ],
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.1125.0",
     "@hypequery/clickhouse": "^2.1.2",
     "@mastra/core": "^1.47.0",
     "@types/node": "^20.14.0",
@@ -93,10 +113,10 @@
     "node-gyp-build": "^4.6.0"
   },
   "optionalDependencies": {
-    "@chdb/lib-darwin-arm64": "26.7.0-stable.1",
-    "@chdb/lib-darwin-x64": "26.7.0-stable.1",
-    "@chdb/lib-linux-arm64-gnu": "26.7.0-stable.1",
-    "@chdb/lib-linux-x64-gnu": "26.7.0-stable.1"
+    "@chdb/lib-darwin-arm64": "26.7.2-rc.2.1",
+    "@chdb/lib-darwin-x64": "26.7.2-rc.2.1",
+    "@chdb/lib-linux-arm64-gnu": "26.7.2-rc.2.1",
+    "@chdb/lib-linux-x64-gnu": "26.7.2-rc.2.1"
   },
   "peerDependencies": {
     "@clickhouse/client": ">=1.23.0",
@@ -104,7 +124,8 @@
     "@mastra/core": ">=0.10",
     "ai": ">=5",
     "apache-arrow": ">=14",
-    "zod": ">=3"
+    "zod": ">=3",
+    "@aws-sdk/client-s3": ">=3"
   },
   "peerDependenciesMeta": {
     "@clickhouse/client": {
@@ -123,6 +144,9 @@
       "optional": true
     },
     "@hypequery/clickhouse": {
+      "optional": true
+    },
+    "@aws-sdk/client-s3": {
       "optional": true
     }
   },

--- a/src/durable/backend.ts
+++ b/src/durable/backend.ts
@@ -1,0 +1,87 @@
+/**
+ * The object-storage contract every durable backend must satisfy
+ * (contract §5.1).
+ *
+ * The shape is small on purpose. Only two properties are load-bearing, and
+ * both are properties a provider either has or does not:
+ *
+ *  1. **Real conditional operations.** `putIfAbsent` must be an atomic
+ *     create and `replaceIfMatch` an atomic compare-and-swap. Simulating
+ *     either with a read followed by a write is not a weaker implementation,
+ *     it is a broken one: the window between the two is exactly where two
+ *     writers both conclude they are the only writer.
+ *  2. **Streaming.** A checkpoint is a full database archive. Requiring it to
+ *     pass through a JavaScript `Buffer` puts a ceiling on database size that
+ *     has nothing to do with the database. So checkpoints move as files and
+ *     streams; only the head and WAL segments — both bounded by the protocol —
+ *     move as bytes.
+ *
+ * A third property is expressed in the return types rather than the methods:
+ * every mutating call can answer `'ambiguous'`. A request whose response was
+ * lost is not a failure, and reporting it as one would make a caller retry a
+ * commit that already happened. The state machine resolves ambiguity by
+ * re-reading (§5.8), which is only possible if the backend admits it.
+ *
+ * `delete_prefix` is absent by design: V1 has no destroy and no GC, so nothing
+ * in the protocol has the authority to remove an object (contract §8.1 item 4).
+ */
+
+import type { Readable } from 'stream'
+
+/** Outcome of a conditional create. */
+export type PutOutcome =
+  | 'created'
+  /** The key already exists. For a unique key this means *we* created it earlier. */
+  | 'already-exists'
+  /** The request may or may not have landed; the caller must re-read to find out. */
+  | 'ambiguous'
+
+/** Outcome of a conditional replace. */
+export type ReplaceOutcome =
+  | { status: 'replaced'; etag: string }
+  /** The stored ETag no longer matches: someone else wrote first. */
+  | { status: 'not-replaced' }
+  | { status: 'ambiguous' }
+
+export interface GetWithEtag {
+  bytes: Uint8Array
+  /** Opaque CAS token. Never parsed; never assumed to be a content digest. */
+  etag: string
+}
+
+export interface DurableBackend {
+  /**
+   * Human-readable location of the object prefix, for logs and errors. Must
+   * never contain credentials.
+   */
+  readonly describe: string
+
+  /** Read a whole object. `undefined` when the key does not exist. */
+  getBytes(key: string): Promise<Uint8Array | undefined>
+
+  /** Read a whole object with its CAS token. */
+  getBytesWithEtag(key: string): Promise<GetWithEtag | undefined>
+
+  /**
+   * Open a byte stream for a potentially large object. `undefined` when the
+   * key does not exist. Used for checkpoint download so the archive never has
+   * to be resident.
+   */
+  openReadStream(key: string): Promise<Readable | undefined>
+
+  /** Atomically create from bytes. Never overwrites. */
+  putBytesIfAbsent(key: string, bytes: Uint8Array): Promise<PutOutcome>
+
+  /** Atomically create by uploading a local file. Never overwrites. */
+  putFileIfAbsent(key: string, localPath: string): Promise<PutOutcome>
+
+  /** Atomically replace only if the stored token still equals `etag`. */
+  replaceIfMatch(key: string, bytes: Uint8Array, etag: string): Promise<ReplaceOutcome>
+}
+
+/**
+ * Creates a backend bound to one object prefix. A namespace owns the factory
+ * and hands each object its own scoped backend, so no code below the namespace
+ * can address a key outside its object.
+ */
+export type BackendFactory = (objectPrefix: string) => Promise<DurableBackend> | DurableBackend

--- a/src/durable/backends/local.ts
+++ b/src/durable/backends/local.ts
@@ -250,28 +250,15 @@ export class LocalDurableBackend implements DurableBackend {
 
   async putFileIfAbsent(key: string, localPath: string): Promise<PutOutcome> {
     const dest = this.pathFor(key)
-    await mkdir(dirname(dest), { recursive: true })
     // Hard-linking the caller's file avoids copying a multi-gigabyte archive.
     // It is safe because the durable object writes each backup to a fresh
     // unique path and never touches it again; a caller that mutated the source
     // afterwards would be mutating a published object, which the protocol
     // forbids anyway.
     try {
-      await link(localPath, dest)
-      // The fast path needs the same barriers as the staged one, and needs
-      // them more: this is how a checkpoint is published, so losing it to a
-      // power cut leaves a head naming a base that is not there. The link
-      // shares the caller's inode, so the data has to be flushed through the
-      // source, and the new name lives in the destination directory.
-      await fsyncFile(localPath)
-      await fsyncDir(dirname(dest))
-      return 'created'
+      return await this.linkIntoPlace(localPath, dest)
     } catch (e) {
-      const code = errno(e)
-      if (code === 'EEXIST') return 'already-exists'
-      if (code !== 'EXDEV') {
-        throw new DurableBackendError(`durable: failed to publish ${key} to ${this.describe}`, { cause: e })
-      }
+      if (errno((e as { cause?: unknown }).cause ?? e) !== 'EXDEV') throw e
     }
     // Different filesystem: stage a copy next to the destination, then link.
     const tmp = await this.tmpPath()
@@ -439,10 +426,26 @@ export class LocalDurableBackend implements DurableBackend {
     }
   }
 
-  private async linkIntoPlace(tmp: string, dest: string): Promise<PutOutcome> {
+  /**
+   * The one way an object becomes visible under this root.
+   *
+   * Both durability barriers live here rather than at the call sites, and that
+   * placement is the point. Publishing needs the contents flushed *and* the
+   * directory entry flushed, and three separate paths reach this operation —
+   * bytes staged into a temp file, a same-filesystem hard link, and a
+   * cross-filesystem copy. Barriers added per path were missed twice, once on
+   * each of the latter two, and the second miss was on the path a checkpoint
+   * actually takes. A caller cannot forget what it does not perform.
+   *
+   * Re-flushing a source that is already durable costs a no-op syscall, which
+   * is the right price for not having to reason about which callers did it.
+   */
+  private async linkIntoPlace(source: string, dest: string): Promise<PutOutcome> {
     await mkdir(dirname(dest), { recursive: true })
+    await this.assertRealDirectory(dirname(dest))
+    await fsyncFile(source)
     try {
-      await link(tmp, dest)
+      await link(source, dest)
     } catch (e) {
       if (errno(e) === 'EEXIST') return 'already-exists'
       throw new DurableBackendError(`durable: failed to create ${dest}`, { cause: e })
@@ -452,5 +455,30 @@ export class LocalDurableBackend implements DurableBackend {
     // crash, or a head will reference bytes that no longer exist.
     await fsyncDir(dirname(dest))
     return 'created'
+  }
+
+  /**
+   * Refuse to operate through a directory that is a symlink.
+   *
+   * `pathFor` resolves lexically, which cannot see that `<root>/checkpoints`
+   * is a link to somewhere else entirely — a valid-looking key would then read
+   * or publish outside the object prefix with this process's privileges.
+   *
+   * This is defence in depth rather than a complete answer. Whoever can plant
+   * that link can usually write the object directly, and a check followed by a
+   * use is never perfectly atomic without `openat`, which Node does not
+   * expose. What it does buy is that a link planted once, in a shared parent
+   * such as a temp directory, does not silently redirect every later
+   * operation.
+   */
+  private async assertRealDirectory(dir: string): Promise<void> {
+    if (dir === this.root) return
+    const st = await lstat(dir).catch(() => undefined)
+    if (st?.isSymbolicLink()) {
+      throw new DurableBackendError(
+        `durable: refusing to use ${dir}, which is a symlink; an object prefix must contain ` +
+          `only real directories`,
+      )
+    }
   }
 }

--- a/src/durable/backends/local.ts
+++ b/src/durable/backends/local.ts
@@ -204,7 +204,12 @@ export class LocalDurableBackend implements DurableBackend {
     }
     const full = resolve(this.root, key)
     const rel = relative(this.root, full)
-    if (rel === '' || rel.startsWith('..') || isAbsolute(rel) || rel.split(sep).includes('..')) {
+    // Compare path *segments*, not a string prefix. `rel.startsWith('..')`
+    // also rejects an ordinary name that happens to begin with two dots —
+    // `..metadata` is a legal key, since the protocol forbids `.` and `..`
+    // only as whole components — and refusing it would make an object the
+    // format allows unreadable here while `isValidObjectKey` accepted it.
+    if (rel === '' || isAbsolute(rel) || rel.split(sep).includes('..')) {
       throw new DurableBackendError(`durable: key ${JSON.stringify(key)} escapes the object prefix`)
     }
     return full

--- a/src/durable/backends/local.ts
+++ b/src/durable/backends/local.ts
@@ -55,6 +55,32 @@
  * The version chain and scratch directory are dot-prefixed so they cannot
  * collide with a protocol key, and a reader that only understands plain files
  * still sees a correct `head.json` through the symlink.
+ *
+ * ## What this backend is for, and what that rules out
+ *
+ * Development and conformance. Recovery on another machine needs storage
+ * neither machine owns, which is `chdb/durable/s3`; a directory on one host
+ * cannot be a remote authority. That scope decides which hardening belongs
+ * here and which is noise.
+ *
+ * Two things it does defend, because they are real regardless of scope:
+ *
+ *  - **Keys out of `head.json`.** A head is fetched from object storage and is
+ *    therefore untrusted input. A key containing `..`, an absolute path or an
+ *    empty component would steer a read or a publish outside the object, so
+ *    {@link LocalDurableBackend.pathFor} refuses it. This has nothing to do
+ *    with who can reach the filesystem.
+ *  - **Losing data it said it had written.** Publishing without flushing is a
+ *    correctness bug, not a security one, and a conformance baseline that can
+ *    silently roll back is not a baseline.
+ *
+ * What it does not defend against is a hostile local filesystem — a symlink
+ * planted in the object prefix, say, to redirect a write. Whoever can do that
+ * can already rewrite the objects directly, so guarding it buys no privilege
+ * boundary, and check-then-use cannot be made atomic without `openat`, which
+ * Node does not expose. Adding the check would cost a syscall per publish to
+ * narrow a window that leads nowhere. A production deployment wanting that
+ * property should not be on this backend at all.
  */
 
 import { createReadStream } from 'fs'
@@ -442,7 +468,6 @@ export class LocalDurableBackend implements DurableBackend {
    */
   private async linkIntoPlace(source: string, dest: string): Promise<PutOutcome> {
     await mkdir(dirname(dest), { recursive: true })
-    await this.assertRealDirectory(dirname(dest))
     await fsyncFile(source)
     try {
       await link(source, dest)
@@ -457,28 +482,4 @@ export class LocalDurableBackend implements DurableBackend {
     return 'created'
   }
 
-  /**
-   * Refuse to operate through a directory that is a symlink.
-   *
-   * `pathFor` resolves lexically, which cannot see that `<root>/checkpoints`
-   * is a link to somewhere else entirely — a valid-looking key would then read
-   * or publish outside the object prefix with this process's privileges.
-   *
-   * This is defence in depth rather than a complete answer. Whoever can plant
-   * that link can usually write the object directly, and a check followed by a
-   * use is never perfectly atomic without `openat`, which Node does not
-   * expose. What it does buy is that a link planted once, in a shared parent
-   * such as a temp directory, does not silently redirect every later
-   * operation.
-   */
-  private async assertRealDirectory(dir: string): Promise<void> {
-    if (dir === this.root) return
-    const st = await lstat(dir).catch(() => undefined)
-    if (st?.isSymbolicLink()) {
-      throw new DurableBackendError(
-        `durable: refusing to use ${dir}, which is a symlink; an object prefix must contain ` +
-          `only real directories`,
-      )
-    }
-  }
 }

--- a/src/durable/backends/local.ts
+++ b/src/durable/backends/local.ts
@@ -58,7 +58,18 @@
  */
 
 import { createReadStream } from 'fs'
-import { copyFile, link, lstat, mkdir, readFile, readlink, rename, symlink, unlink, writeFile } from 'fs/promises'
+import {
+  copyFile,
+  link,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readlink,
+  rename,
+  symlink,
+  unlink,
+} from 'fs/promises'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'path'
 import type { Readable } from 'stream'
 import { randomUUID } from 'crypto'
@@ -67,7 +78,14 @@ import { sha256Hex } from '../digest'
 import { isValidObjectKey } from '../keys'
 import type { DurableBackend, GetWithEtag, PutOutcome, ReplaceOutcome } from '../backend'
 
-/** Where the mutable-key version chain lives, relative to the object prefix. */
+/**
+ * Where the mutable-key version chain lives, relative to the object prefix.
+ *
+ * One directory, because V1 has exactly one mutable key. Everything else in an
+ * object is immutable and never enters the chain — which is also why
+ * {@link LocalDurableBackend.currentVersion} must not consult this directory
+ * for a key that is not a chain: it is not per-key.
+ */
 const VERSIONS_DIR = '.head-versions'
 /** Scratch for partially written files, relative to the object prefix. */
 const TMP_DIR = '.tmp'
@@ -76,6 +94,47 @@ const VERSION_TARGET = /^\.head-versions\/(\d+)\.json$/
 
 function errno(e: unknown): string | undefined {
   return typeof e === 'object' && e !== null ? (e as NodeJS.ErrnoException).code : undefined
+}
+
+/**
+ * Write a file and make it survive power loss before returning.
+ *
+ * `writeFile` alone does not: it returns once the data reaches the page cache,
+ * so a crash can lose bytes the caller has already been told were written. For
+ * a version file that is about to be reported as a committed head, that is the
+ * difference between a durable object and one that quietly rolls back.
+ */
+async function writeFileDurably(path: string, bytes: Uint8Array): Promise<void> {
+  const handle = await open(path, 'w')
+  try {
+    await handle.writeFile(bytes)
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+/**
+ * Flush a directory entry, so a create or rename inside it survives too.
+ *
+ * Syncing a file persists its contents; the *name* lives in the parent
+ * directory and needs its own barrier. Best-effort on platforms that refuse to
+ * open a directory for this, where the guarantee is simply not available.
+ */
+async function fsyncDir(path: string): Promise<void> {
+  let handle
+  try {
+    handle = await open(path, 'r')
+  } catch {
+    return
+  }
+  try {
+    await handle.sync()
+  } catch {
+    /* not supported here; nothing further to do */
+  } finally {
+    await handle.close()
+  }
 }
 
 export interface LocalBackendOptions {
@@ -171,7 +230,7 @@ export class LocalDurableBackend implements DurableBackend {
   async putBytesIfAbsent(key: string, bytes: Uint8Array): Promise<PutOutcome> {
     const dest = this.pathFor(key)
     const tmp = await this.tmpPath()
-    await writeFile(tmp, bytes)
+    await writeFileDurably(tmp, bytes)
     try {
       return await this.linkIntoPlace(tmp, dest)
     } finally {
@@ -214,15 +273,18 @@ export class LocalDurableBackend implements DurableBackend {
 
     let nextVersion: number
     if (etag.startsWith('v')) {
-      const observed = await this.currentVersion(path)
       const claimed = Number(etag.slice(1))
       if (!Number.isSafeInteger(claimed) || claimed < 1) {
         throw new DurableBackendError(`durable: malformed local etag ${JSON.stringify(etag)}`)
       }
-      // A stale claim is decided by the exclusive create below, not here; this
-      // early exit only avoids pointless work when the chain has clearly moved
-      // on or vanished.
+      const observed = await this.currentVersion(path)
       if (observed === undefined) return { status: 'not-replaced' }
+      // The token must name the version that is current, not merely one that
+      // exists. Leaving this to the exclusive create below is not equivalent:
+      // a token above the current version would create a version nobody has
+      // read, skip the one in between, and publish it — a compare-and-swap
+      // succeeding against a value that was never there.
+      if (observed !== claimed) return { status: 'not-replaced' }
       nextVersion = claimed + 1
     } else if (etag.startsWith('f')) {
       const current = await readFile(path).catch((e) => {
@@ -237,22 +299,37 @@ export class LocalDurableBackend implements DurableBackend {
 
     const versionPath = join(versionsDir, `${nextVersion}.json`)
     const tmp = await this.tmpPath()
-    await writeFile(tmp, bytes)
+    await writeFileDurably(tmp, bytes)
     let claimed: PutOutcome
     try {
       claimed = await this.linkIntoPlace(tmp, versionPath)
     } finally {
       await unlink(tmp).catch(() => {})
     }
-    if (claimed !== 'created') return { status: 'not-replaced' }
+
+    if (claimed !== 'created') {
+      // Someone already won this version number. That someone may have been an
+      // earlier attempt of ours whose response was lost, so the bytes decide:
+      // identical content means our write is the one that landed, different
+      // content means a racer won it. Either way the pointer is advanced,
+      // because the version is published whether or not its author survived
+      // long enough to say so.
+      const existing = await readFile(versionPath).catch((e) => {
+        throw new DurableBackendError(
+          `durable: version ${nextVersion} of ${key} exists but cannot be read`,
+          { cause: e },
+        )
+      })
+      await this.publishPointer(path, nextVersion)
+      return Buffer.from(bytes).equals(existing)
+        ? { status: 'replaced', etag: `v${nextVersion}` }
+        : { status: 'not-replaced' }
+    }
 
     // The version is published; swapping the pointer is what makes it current.
-    const tmpLink = await this.tmpPath()
     try {
-      await symlink(`${VERSIONS_DIR}/${nextVersion}.json`, tmpLink)
-      await rename(tmpLink, path)
+      await this.publishPointer(path, nextVersion)
     } catch (e) {
-      await unlink(tmpLink).catch(() => {})
       throw new DurableBackendError(
         `durable: created version ${nextVersion} of ${key} but failed to publish the pointer`,
         { cause: e },
@@ -268,34 +345,95 @@ export class LocalDurableBackend implements DurableBackend {
     return version === undefined ? path : join(this.root, VERSIONS_DIR, `${version}.json`)
   }
 
-  /** Current chain version for a path, or `undefined` if it is not a chain. */
+  /**
+   * Current chain version for a path, or `undefined` if it is not a chain.
+   *
+   * The pointer is a hint, not the authority. Creating a version and swapping
+   * the symlink are two syscalls, and a process that dies between them leaves
+   * a version nothing points at. Trusting the symlink alone would wedge the
+   * object permanently: every later writer would hold the pointed-at token,
+   * fail to create the version above it because the orphan is already there,
+   * and report `not-replaced` forever.
+   *
+   * So the authority is the highest version that actually exists, found by
+   * stepping forward from the pointer. That costs one `stat` in the normal
+   * case, where nothing is above it, and it is bounded because each step
+   * requires a version file that some writer won an exclusive create for.
+   *
+   * The pointer is repaired opportunistically. Failing to repair it is
+   * harmless — the next reader recomputes the same answer.
+   */
   private async currentVersion(path: string): Promise<number | undefined> {
-    let target: string
+    let start: number
     try {
-      target = await readlink(path)
+      const target = await readlink(path)
+      const m = VERSION_TARGET.exec(target)
+      if (!m) {
+        throw new DurableBackendError(
+          `durable: ${path} is a symlink to ${JSON.stringify(target)}, which this backend did not write`,
+        )
+      }
+      start = Number(m[1])
     } catch (e) {
+      if (e instanceof DurableBackendError) throw e
       const code = errno(e)
-      // EINVAL: a plain file. ENOENT: nothing there yet. Both mean "no chain".
-      if (code === 'EINVAL' || code === 'ENOENT' || code === 'ENOTDIR') return undefined
-      throw new DurableBackendError(`durable: failed to inspect ${path}`, { cause: e })
+      // EINVAL: a plain file. ENOENT: nothing there yet. Either way there is
+      // no chain for this key, and there must be no look-ahead: this method
+      // serves every key, and the version directory belongs to the one mutable
+      // key. Probing it for a WAL segment or a checkpoint would resolve that
+      // key's read to the head's bytes.
+      //
+      // An adoption that created version 1 and died before the swap needs no
+      // special case here. The plain file still reads, its digest is still the
+      // ETag, and the next replaceIfMatch meets the existing version 1 through
+      // the conditional-create path below, which compares content and
+      // publishes the pointer.
+      if (code !== 'EINVAL' && code !== 'ENOENT' && code !== 'ENOTDIR') {
+        throw new DurableBackendError(`durable: failed to inspect ${path}`, { cause: e })
+      }
+      return undefined
     }
-    const m = VERSION_TARGET.exec(target)
-    if (!m) {
-      throw new DurableBackendError(
-        `durable: ${path} is a symlink to ${JSON.stringify(target)}, which this backend did not write`,
-      )
+
+    let latest = start
+    while (await this.versionExists(latest + 1)) latest++
+    if (latest !== start) await this.publishPointer(path, latest).catch(() => {})
+    return latest
+  }
+
+  private async versionExists(version: number): Promise<boolean> {
+    try {
+      await lstat(join(this.root, VERSIONS_DIR, `${version}.json`))
+      return true
+    } catch {
+      return false
     }
-    return Number(m[1])
+  }
+
+  /** Point the mutable key at a version. Atomic, and idempotent across racers. */
+  private async publishPointer(path: string, version: number): Promise<void> {
+    const tmpLink = await this.tmpPath()
+    try {
+      await symlink(`${VERSIONS_DIR}/${version}.json`, tmpLink)
+      await rename(tmpLink, path)
+      await fsyncDir(dirname(path))
+    } catch (e) {
+      await unlink(tmpLink).catch(() => {})
+      throw e
+    }
   }
 
   private async linkIntoPlace(tmp: string, dest: string): Promise<PutOutcome> {
     await mkdir(dirname(dest), { recursive: true })
     try {
       await link(tmp, dest)
-      return 'created'
     } catch (e) {
       if (errno(e) === 'EEXIST') return 'already-exists'
       throw new DurableBackendError(`durable: failed to create ${dest}`, { cause: e })
     }
+    // The name is what makes the object visible, and the name lives in the
+    // directory. An object reported as published has to still be there after a
+    // crash, or a head will reference bytes that no longer exist.
+    await fsyncDir(dirname(dest))
+    return 'created'
   }
 }

--- a/src/durable/backends/local.ts
+++ b/src/durable/backends/local.ts
@@ -435,12 +435,26 @@ export class LocalDurableBackend implements DurableBackend {
     return latest
   }
 
+  /**
+   * Whether a version has been published.
+   *
+   * Only `ENOENT` means no. Anything else — `EIO`, `EACCES` — means the answer
+   * is unknown, and this answer decides which version is current: swallowing
+   * the error would hand back the version below the failure as though the
+   * chain ended there, and every operation after it would run against a state
+   * that is not the object's. An unreadable directory is a backend failure,
+   * not an empty one.
+   */
   private async versionExists(version: number): Promise<boolean> {
     try {
       await lstat(join(this.root, VERSIONS_DIR, `${version}.json`))
       return true
-    } catch {
-      return false
+    } catch (e) {
+      if (errno(e) === 'ENOENT') return false
+      throw new DurableBackendError(
+        `durable: failed to determine whether version ${version} exists in ${this.describe}`,
+        { cause: e },
+      )
     }
   }
 

--- a/src/durable/backends/local.ts
+++ b/src/durable/backends/local.ts
@@ -72,7 +72,10 @@
  *    with who can reach the filesystem.
  *  - **Losing data it said it had written.** Publishing without flushing is a
  *    correctness bug, not a security one, and a conformance baseline that can
- *    silently roll back is not a baseline.
+ *    silently roll back is not a baseline. The promise has to hold all the way
+ *    down: flushing a file and its immediate parent is worthless if the parent
+ *    is itself a fresh, unflushed entry in a directory above, so a publish that
+ *    creates directories flushes the chain it created.
  *
  * What it does not defend against is a hostile local filesystem — a symlink
  * planted in the object prefix, say, to redirect a write. Whoever can do that
@@ -486,7 +489,7 @@ export class LocalDurableBackend implements DurableBackend {
    * is the right price for not having to reason about which callers did it.
    */
   private async linkIntoPlace(source: string, dest: string): Promise<PutOutcome> {
-    await mkdir(dirname(dest), { recursive: true })
+    const firstCreated = await mkdir(dirname(dest), { recursive: true })
     await fsyncFile(source)
     try {
       await link(source, dest)
@@ -498,6 +501,22 @@ export class LocalDurableBackend implements DurableBackend {
     // directory. An object reported as published has to still be there after a
     // crash, or a head will reference bytes that no longer exist.
     await fsyncDir(dirname(dest))
+    // And when that directory is itself new, its own entry is just as
+    // unflushed — losing it would take the object with it, which would make
+    // the guarantee above false for exactly the first publish into a prefix.
+    // `mkdir` reports the topmost directory it created, so the walk happens
+    // once in an object's life and costs nothing on every publish after it.
+    if (firstCreated !== undefined) {
+      let dir = dirname(dest)
+      while (dir !== firstCreated && dir !== dirname(dir)) {
+        dir = dirname(dir)
+        await fsyncDir(dir)
+      }
+      // The topmost new directory is an entry in a directory this backend did
+      // not create, so that one is flushed too — otherwise the whole chain can
+      // still disappear.
+      await fsyncDir(dirname(firstCreated))
+    }
     return 'created'
   }
 

--- a/src/durable/backends/local.ts
+++ b/src/durable/backends/local.ts
@@ -114,6 +114,16 @@ async function writeFileDurably(path: string, bytes: Uint8Array): Promise<void> 
   }
 }
 
+/** Flush a file's contents, addressed by path rather than by an open handle. */
+async function fsyncFile(path: string): Promise<void> {
+  const handle = await open(path, 'r')
+  try {
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
 /**
  * Flush a directory entry, so a create or rename inside it survives too.
  *
@@ -248,6 +258,13 @@ export class LocalDurableBackend implements DurableBackend {
     // forbids anyway.
     try {
       await link(localPath, dest)
+      // The fast path needs the same barriers as the staged one, and needs
+      // them more: this is how a checkpoint is published, so losing it to a
+      // power cut leaves a head naming a base that is not there. The link
+      // shares the caller's inode, so the data has to be flushed through the
+      // source, and the new name lives in the destination directory.
+      await fsyncFile(localPath)
+      await fsyncDir(dirname(dest))
       return 'created'
     } catch (e) {
       const code = errno(e)

--- a/src/durable/backends/local.ts
+++ b/src/durable/backends/local.ts
@@ -1,0 +1,301 @@
+/**
+ * Local-filesystem durable backend.
+ *
+ * This is the backend every conformance run uses, and the one a developer
+ * gets from a `file://` namespace URL. That makes its conditional operations
+ * load-bearing rather than a convenience: if they were approximations, every
+ * scenario that passes here would prove nothing about the ones that run
+ * against a real object store.
+ *
+ * ## Conditional create
+ *
+ * `link(2)` is the primitive. It fails with `EEXIST` atomically, so writing to
+ * a unique scratch file and then linking it into place is a true create-if-
+ * absent — with the full contents already in the file at the moment the name
+ * appears. `rename` would have been simpler and wrong: it clobbers.
+ *
+ * ## Conditional replace
+ *
+ * POSIX has no compare-and-swap on file contents, and the usual workarounds
+ * are worse than the problem. A lock file turns a crash into a stuck object
+ * that needs a staleness heuristic to recover; read-compare-rename has the
+ * race it is meant to prevent.
+ *
+ * So the mutable key is stored as a chain of immutable versions with a symlink
+ * naming the current one:
+ *
+ * ```text
+ *   head.json                -> symlink to .head-versions/7.json
+ *   .head-versions/7.json    immutable
+ *   .head-versions/6.json    immutable
+ * ```
+ *
+ * The ETag is the version number. Replacing against ETag `v7` means creating
+ * `.head-versions/8.json`, and `link(2)` lets exactly one racer do that — so
+ * the `EEXIST` *is* the CAS failure. The symlink is then swapped in with an
+ * atomic `rename`. A writer that wins the create and dies before the rename
+ * has still legitimately won: a racer reading version 7 will fail to create 8
+ * and correctly report `not-replaced`.
+ *
+ * Version numbers only ever move forward, because creating version N+1
+ * requires having read version N, which requires the symlink to already point
+ * at it.
+ *
+ * ## Reading what another binding wrote
+ *
+ * A fixture produced elsewhere has a plain `head.json` file and no version
+ * chain. That reads fine — the ETag is then a content digest — and the first
+ * `replaceIfMatch` adopts it into the chain: verify the plain file still
+ * hashes to the ETag, create `.head-versions/1.json` exclusively, swap the
+ * symlink. Adoption is atomic against other adopters, since only one can win
+ * the create. It assumes no *foreign* process is rewriting the plain file at
+ * the same moment, which is the same single-writer assumption the protocol
+ * already makes.
+ *
+ * The version chain and scratch directory are dot-prefixed so they cannot
+ * collide with a protocol key, and a reader that only understands plain files
+ * still sees a correct `head.json` through the symlink.
+ */
+
+import { createReadStream } from 'fs'
+import { copyFile, link, lstat, mkdir, readFile, readlink, rename, symlink, unlink, writeFile } from 'fs/promises'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'path'
+import type { Readable } from 'stream'
+import { randomUUID } from 'crypto'
+import { DurableBackendError } from '../errors'
+import { sha256Hex } from '../digest'
+import { isValidObjectKey } from '../keys'
+import type { DurableBackend, GetWithEtag, PutOutcome, ReplaceOutcome } from '../backend'
+
+/** Where the mutable-key version chain lives, relative to the object prefix. */
+const VERSIONS_DIR = '.head-versions'
+/** Scratch for partially written files, relative to the object prefix. */
+const TMP_DIR = '.tmp'
+
+const VERSION_TARGET = /^\.head-versions\/(\d+)\.json$/
+
+function errno(e: unknown): string | undefined {
+  return typeof e === 'object' && e !== null ? (e as NodeJS.ErrnoException).code : undefined
+}
+
+export interface LocalBackendOptions {
+  /** Absolute directory holding one durable object. Created on demand. */
+  root: string
+}
+
+export class LocalDurableBackend implements DurableBackend {
+  readonly root: string
+  readonly describe: string
+
+  constructor(options: LocalBackendOptions) {
+    if (!isAbsolute(options.root)) {
+      throw new RangeError(`durable: local backend root must be absolute, got ${options.root}`)
+    }
+    this.root = resolve(options.root)
+    this.describe = `file://${this.root}`
+  }
+
+  /**
+   * Resolve a protocol key to a path inside the object prefix. The key has
+   * already been validated on the way out of the head, but this re-checks and
+   * then confirms the resolved path really is under the root — a key is the
+   * one piece of a head that turns into a filesystem path, so the traversal
+   * check belongs at the point where that happens, not only at the point where
+   * it was parsed.
+   */
+  private pathFor(key: string): string {
+    if (!isValidObjectKey(key)) {
+      throw new DurableBackendError(`durable: refusing to resolve invalid key ${JSON.stringify(key)}`)
+    }
+    const full = resolve(this.root, key)
+    const rel = relative(this.root, full)
+    if (rel === '' || rel.startsWith('..') || isAbsolute(rel) || rel.split(sep).includes('..')) {
+      throw new DurableBackendError(`durable: key ${JSON.stringify(key)} escapes the object prefix`)
+    }
+    return full
+  }
+
+  private async tmpPath(): Promise<string> {
+    const dir = join(this.root, TMP_DIR)
+    await mkdir(dir, { recursive: true })
+    return join(dir, `${Date.now().toString(36)}-${randomUUID()}`)
+  }
+
+  async getBytes(key: string): Promise<Uint8Array | undefined> {
+    const target = await this.resolveReadPath(key)
+    if (target === undefined) return undefined
+    try {
+      return await readFile(target)
+    } catch (e) {
+      if (errno(e) === 'ENOENT') return undefined
+      throw new DurableBackendError(`durable: failed to read ${key} from ${this.describe}`, { cause: e })
+    }
+  }
+
+  async getBytesWithEtag(key: string): Promise<GetWithEtag | undefined> {
+    const path = this.pathFor(key)
+    const version = await this.currentVersion(path)
+    if (version !== undefined) {
+      const bytes = await readFile(join(this.root, VERSIONS_DIR, `${version}.json`)).catch((e) => {
+        // The symlink names a version that is not there. Nothing in this
+        // backend removes a version, so the object has been tampered with.
+        throw new DurableBackendError(
+          `durable: ${key} points at version ${version}, which is missing from ${this.describe}`,
+          { cause: e },
+        )
+      })
+      return { bytes, etag: `v${version}` }
+    }
+    let bytes: Buffer
+    try {
+      bytes = await readFile(path)
+    } catch (e) {
+      if (errno(e) === 'ENOENT') return undefined
+      throw new DurableBackendError(`durable: failed to read ${key} from ${this.describe}`, { cause: e })
+    }
+    return { bytes, etag: `f${sha256Hex(bytes)}` }
+  }
+
+  async openReadStream(key: string): Promise<Readable | undefined> {
+    const target = await this.resolveReadPath(key)
+    if (target === undefined) return undefined
+    try {
+      await lstat(target)
+    } catch (e) {
+      if (errno(e) === 'ENOENT') return undefined
+      throw new DurableBackendError(`durable: failed to stat ${key} in ${this.describe}`, { cause: e })
+    }
+    return createReadStream(target)
+  }
+
+  async putBytesIfAbsent(key: string, bytes: Uint8Array): Promise<PutOutcome> {
+    const dest = this.pathFor(key)
+    const tmp = await this.tmpPath()
+    await writeFile(tmp, bytes)
+    try {
+      return await this.linkIntoPlace(tmp, dest)
+    } finally {
+      await unlink(tmp).catch(() => {})
+    }
+  }
+
+  async putFileIfAbsent(key: string, localPath: string): Promise<PutOutcome> {
+    const dest = this.pathFor(key)
+    await mkdir(dirname(dest), { recursive: true })
+    // Hard-linking the caller's file avoids copying a multi-gigabyte archive.
+    // It is safe because the durable object writes each backup to a fresh
+    // unique path and never touches it again; a caller that mutated the source
+    // afterwards would be mutating a published object, which the protocol
+    // forbids anyway.
+    try {
+      await link(localPath, dest)
+      return 'created'
+    } catch (e) {
+      const code = errno(e)
+      if (code === 'EEXIST') return 'already-exists'
+      if (code !== 'EXDEV') {
+        throw new DurableBackendError(`durable: failed to publish ${key} to ${this.describe}`, { cause: e })
+      }
+    }
+    // Different filesystem: stage a copy next to the destination, then link.
+    const tmp = await this.tmpPath()
+    try {
+      await copyFile(localPath, tmp)
+      return await this.linkIntoPlace(tmp, dest)
+    } finally {
+      await unlink(tmp).catch(() => {})
+    }
+  }
+
+  async replaceIfMatch(key: string, bytes: Uint8Array, etag: string): Promise<ReplaceOutcome> {
+    const path = this.pathFor(key)
+    const versionsDir = join(this.root, VERSIONS_DIR)
+    await mkdir(versionsDir, { recursive: true })
+
+    let nextVersion: number
+    if (etag.startsWith('v')) {
+      const observed = await this.currentVersion(path)
+      const claimed = Number(etag.slice(1))
+      if (!Number.isSafeInteger(claimed) || claimed < 1) {
+        throw new DurableBackendError(`durable: malformed local etag ${JSON.stringify(etag)}`)
+      }
+      // A stale claim is decided by the exclusive create below, not here; this
+      // early exit only avoids pointless work when the chain has clearly moved
+      // on or vanished.
+      if (observed === undefined) return { status: 'not-replaced' }
+      nextVersion = claimed + 1
+    } else if (etag.startsWith('f')) {
+      const current = await readFile(path).catch((e) => {
+        if (errno(e) === 'ENOENT') return undefined
+        throw new DurableBackendError(`durable: failed to read ${key} from ${this.describe}`, { cause: e })
+      })
+      if (current === undefined || `f${sha256Hex(current)}` !== etag) return { status: 'not-replaced' }
+      nextVersion = 1
+    } else {
+      throw new DurableBackendError(`durable: malformed local etag ${JSON.stringify(etag)}`)
+    }
+
+    const versionPath = join(versionsDir, `${nextVersion}.json`)
+    const tmp = await this.tmpPath()
+    await writeFile(tmp, bytes)
+    let claimed: PutOutcome
+    try {
+      claimed = await this.linkIntoPlace(tmp, versionPath)
+    } finally {
+      await unlink(tmp).catch(() => {})
+    }
+    if (claimed !== 'created') return { status: 'not-replaced' }
+
+    // The version is published; swapping the pointer is what makes it current.
+    const tmpLink = await this.tmpPath()
+    try {
+      await symlink(`${VERSIONS_DIR}/${nextVersion}.json`, tmpLink)
+      await rename(tmpLink, path)
+    } catch (e) {
+      await unlink(tmpLink).catch(() => {})
+      throw new DurableBackendError(
+        `durable: created version ${nextVersion} of ${key} but failed to publish the pointer`,
+        { cause: e },
+      )
+    }
+    return { status: 'replaced', etag: `v${nextVersion}` }
+  }
+
+  /** Path to read `key` from: the pointed-at version, or the key itself. */
+  private async resolveReadPath(key: string): Promise<string | undefined> {
+    const path = this.pathFor(key)
+    const version = await this.currentVersion(path)
+    return version === undefined ? path : join(this.root, VERSIONS_DIR, `${version}.json`)
+  }
+
+  /** Current chain version for a path, or `undefined` if it is not a chain. */
+  private async currentVersion(path: string): Promise<number | undefined> {
+    let target: string
+    try {
+      target = await readlink(path)
+    } catch (e) {
+      const code = errno(e)
+      // EINVAL: a plain file. ENOENT: nothing there yet. Both mean "no chain".
+      if (code === 'EINVAL' || code === 'ENOENT' || code === 'ENOTDIR') return undefined
+      throw new DurableBackendError(`durable: failed to inspect ${path}`, { cause: e })
+    }
+    const m = VERSION_TARGET.exec(target)
+    if (!m) {
+      throw new DurableBackendError(
+        `durable: ${path} is a symlink to ${JSON.stringify(target)}, which this backend did not write`,
+      )
+    }
+    return Number(m[1])
+  }
+
+  private async linkIntoPlace(tmp: string, dest: string): Promise<PutOutcome> {
+    await mkdir(dirname(dest), { recursive: true })
+    try {
+      await link(tmp, dest)
+      return 'created'
+    } catch (e) {
+      if (errno(e) === 'EEXIST') return 'already-exists'
+      throw new DurableBackendError(`durable: failed to create ${dest}`, { cause: e })
+    }
+  }
+}

--- a/src/durable/backends/s3.ts
+++ b/src/durable/backends/s3.ts
@@ -1,0 +1,352 @@
+/**
+ * S3-compatible durable backend — AWS S3, Cloudflare R2, MinIO.
+ *
+ * This is the backend that makes the whole thing mean something. A local
+ * directory cannot be a remote authority: when the machine holding it is gone,
+ * so is the object. Recovering a database on a *different* machine needs the
+ * head, the checkpoints and the WAL to live somewhere neither machine owns.
+ *
+ * It lives behind its own subpath (`chdb/durable/s3`) and registers the `s3`
+ * scheme as an import side effect, so `chdb/durable` on its own never pulls in
+ * the AWS SDK. A caller that only uses the local backend should not have to
+ * install several megabytes of it.
+ *
+ * ## Conditional writes are the whole contract
+ *
+ * The protocol needs a real atomic create and a real atomic compare-and-swap;
+ * simulating either with a HEAD followed by a PUT is not a weaker version, it
+ * is the bug the protocol exists to prevent. S3 provides both as preconditions
+ * on `PutObject`:
+ *
+ * ```text
+ *   putIfAbsent    ->  PUT with If-None-Match: *
+ *   replaceIfMatch ->  PUT with If-Match: <etag>
+ * ```
+ *
+ * A precondition failure is a CAS outcome, not a transport error, and it is
+ * reported as one. Everything the state machine does with `already-exists` and
+ * `not-replaced` depends on that distinction being made here rather than
+ * upstream.
+ *
+ * ## Why the SDK's own retries are safe
+ *
+ * The SDK retries on its own, and a retry can turn a request that *did* land
+ * into a precondition failure: the first `PutObject` succeeds, the response is
+ * lost, the retry finds the object already there and gets a 412. So this
+ * backend can report `already-exists` for an object it wrote itself, and
+ * `not-replaced` for a CAS that actually committed.
+ *
+ * That is fine, and it is fine for a specific reason: nothing upstream decides
+ * anything from the return code alone. An `already-exists` sends the object
+ * layer to re-read that unique key and compare length and SHA-256; a
+ * `not-replaced` sends it to re-read the head and look for its own intent with
+ * its own lease still on it. Both resolve to the truth. A design that trusted
+ * the status code would need retries disabled; this one does not.
+ *
+ * ## ETags stay opaque, and carry one assumption worth naming
+ *
+ * An S3 ETag is quoted, and it is only an MD5 for single-part uploads — not on
+ * R2, not for multipart, not necessarily forever. It is stored and handed back
+ * exactly as received and never parsed, which is what the contract requires.
+ *
+ * Being a content hash has a consequence that a version counter would not
+ * have: writing *byte-identical* content does not advance the ETag, so the
+ * token used for that write stays valid afterwards and a second racer holding
+ * it can also win. Measured, not assumed — on both MinIO and AWS S3,
+ * re-PUTting the same bytes under `If-Match` leaves the ETag unchanged.
+ *
+ * Durable is safe from this because every head write changes the bytes: a
+ * lease acquisition moves the generation, a heartbeat moves `expires_at`, and
+ * a flush or checkpoint moves `manifest.seq`. That is a real dependency rather
+ * than a coincidence, so it is written down here: anything that makes a head
+ * write idempotent at the byte level would break compare-and-swap on any
+ * content-hash-ETag provider.
+ *
+ * ## V1 limits
+ *
+ * Single `PutObject` only, so an object caps at 5 GiB and a larger checkpoint
+ * fails with `limit_exceeded` rather than silently truncating. Multipart upload
+ * is the fix and is not here yet.
+ */
+
+import { createReadStream } from 'fs'
+import { stat } from 'fs/promises'
+import type { Readable } from 'stream'
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  type S3ClientConfig,
+} from '@aws-sdk/client-s3'
+
+import type { DurableBackend, GetWithEtag, PutOutcome, ReplaceOutcome } from '../backend'
+import { DurableBackendError, DurableLimitExceededError } from '../errors'
+import { isValidObjectKey } from '../keys'
+import { registerBackendScheme } from '../namespace'
+
+/** Ceiling for a single PutObject. Beyond this a checkpoint needs multipart. */
+export const MAX_SINGLE_PUT_BYTES = 5 * 1024 * 1024 * 1024
+
+export interface S3BackendOptions {
+  bucket: string
+  /** Key prefix for this object, without a leading slash. May be empty. */
+  prefix?: string
+  /** Pre-built client. Takes precedence over `clientConfig`. */
+  client?: S3Client
+  /** Passed to `new S3Client`. Credentials come from the default chain unless set. */
+  clientConfig?: S3ClientConfig
+}
+
+interface AwsErrorish {
+  name?: string
+  Code?: string
+  $metadata?: { httpStatusCode?: number }
+  code?: string
+  message?: string
+}
+
+function asAwsError(e: unknown): AwsErrorish {
+  return (typeof e === 'object' && e !== null ? e : {}) as AwsErrorish
+}
+
+function statusOf(e: unknown): number | undefined {
+  return asAwsError(e).$metadata?.httpStatusCode
+}
+
+/**
+ * A precondition failed. S3 answers 412 for `If-Match` and for an
+ * `If-None-Match: *` against an object that already exists; a race between two
+ * conditional writes can also surface as 409 `ConditionalRequestConflict`.
+ * Both mean the same thing to the protocol: someone else got there first.
+ */
+function isPreconditionFailure(e: unknown): boolean {
+  const err = asAwsError(e)
+  const status = statusOf(e)
+  if (status === 412 || status === 409) return true
+  return err.name === 'PreconditionFailed' || err.name === 'ConditionalRequestConflict'
+}
+
+function isNotFound(e: unknown): boolean {
+  const err = asAwsError(e)
+  const status = statusOf(e)
+  return status === 404 || err.name === 'NoSuchKey' || err.name === 'NotFound'
+}
+
+/**
+ * Could the request have been committed?
+ *
+ * The distinction is the difference between a retry and a `commit_ambiguous`.
+ * A timeout or a reset connection may have reached the service; a refused
+ * connection or an unresolvable host did not. Guessing "did not" when it did
+ * is how a caller ends up publishing twice, so anything genuinely in doubt
+ * counts as in doubt.
+ */
+function isAmbiguous(e: unknown): boolean {
+  const err = asAwsError(e)
+  const status = statusOf(e)
+  if (status !== undefined && status >= 500) return true
+  const code = err.code ?? err.name ?? ''
+  return (
+    code === 'TimeoutError' ||
+    code === 'RequestTimeout' ||
+    code === 'RequestTimeTooSkewed' ||
+    code === 'AbortError' ||
+    code === 'ECONNRESET' ||
+    code === 'EPIPE' ||
+    code === 'ETIMEDOUT' ||
+    code === 'ECONNABORTED'
+  )
+}
+
+/**
+ * Wrap a provider failure without leaking anything sensitive. Only the error's
+ * name and status are carried into the message; the original hangs off
+ * `.cause` for a caller that wants it, and credentials never appear in either.
+ */
+function backendError(what: string, describe: string, e: unknown): DurableBackendError {
+  const err = asAwsError(e)
+  const status = statusOf(e)
+  const detail = [err.name ?? err.code, status !== undefined ? `HTTP ${status}` : undefined]
+    .filter(Boolean)
+    .join(', ')
+  return new DurableBackendError(
+    `durable: ${what} failed against ${describe}${detail ? ` (${detail})` : ''}`,
+    { cause: e },
+  )
+}
+
+export class S3DurableBackend implements DurableBackend {
+  readonly describe: string
+  private readonly client: S3Client
+  private readonly bucket: string
+  private readonly prefix: string
+
+  constructor(options: S3BackendOptions) {
+    if (!options.bucket) throw new RangeError('durable: S3 backend requires a bucket')
+    this.bucket = options.bucket
+    this.prefix = options.prefix ? options.prefix.replace(/^\/+|\/+$/g, '') : ''
+    this.client = options.client ?? new S3Client(options.clientConfig ?? {})
+    // Never the endpoint's credentials, and never a presigned anything: this
+    // string ends up in error messages and logs.
+    this.describe = `s3://${this.bucket}/${this.prefix}`
+  }
+
+  private keyFor(key: string): string {
+    if (!isValidObjectKey(key)) {
+      throw new DurableBackendError(`durable: refusing to resolve invalid key ${JSON.stringify(key)}`)
+    }
+    return this.prefix ? `${this.prefix}/${key}` : key
+  }
+
+  async getBytes(key: string): Promise<Uint8Array | undefined> {
+    const got = await this.getBytesWithEtag(key)
+    return got?.bytes
+  }
+
+  async getBytesWithEtag(key: string): Promise<GetWithEtag | undefined> {
+    try {
+      const out = await this.client.send(
+        new GetObjectCommand({ Bucket: this.bucket, Key: this.keyFor(key) }),
+      )
+      if (!out.Body) return undefined
+      const bytes = await out.Body.transformToByteArray()
+      // An absent ETag would leave nothing to compare-and-swap against, so it
+      // is a hard failure rather than an empty token that silently never
+      // matches.
+      if (!out.ETag) {
+        throw new DurableBackendError(
+          `durable: ${key} came back from ${this.describe} without an ETag; ` +
+            `this provider cannot support compare-and-swap`,
+        )
+      }
+      return { bytes, etag: out.ETag }
+    } catch (e) {
+      if (isNotFound(e)) return undefined
+      if (e instanceof DurableBackendError) throw e
+      throw backendError(`reading ${key}`, this.describe, e)
+    }
+  }
+
+  async openReadStream(key: string): Promise<Readable | undefined> {
+    try {
+      const out = await this.client.send(
+        new GetObjectCommand({ Bucket: this.bucket, Key: this.keyFor(key) }),
+      )
+      if (!out.Body) return undefined
+      // Under Node the SDK hands back a Readable; the union also covers the
+      // web stream and Blob shapes that only appear in other runtimes.
+      return out.Body as unknown as Readable
+    } catch (e) {
+      if (isNotFound(e)) return undefined
+      throw backendError(`opening ${key}`, this.describe, e)
+    }
+  }
+
+  async putBytesIfAbsent(key: string, bytes: Uint8Array): Promise<PutOutcome> {
+    this.assertWithinSinglePut(key, bytes.byteLength)
+    return this.conditionalPut(key, {
+      Body: bytes,
+      ContentLength: bytes.byteLength,
+      IfNoneMatch: '*',
+    })
+  }
+
+  async putFileIfAbsent(key: string, localPath: string): Promise<PutOutcome> {
+    const size = (await stat(localPath)).size
+    this.assertWithinSinglePut(key, size)
+    // ContentLength is not optional here: with a stream body and no length the
+    // SDK cannot produce the signature S3 wants, and the upload fails at the
+    // edge rather than here.
+    return this.conditionalPut(key, {
+      Body: createReadStream(localPath),
+      ContentLength: size,
+      IfNoneMatch: '*',
+    })
+  }
+
+  async replaceIfMatch(key: string, bytes: Uint8Array, etag: string): Promise<ReplaceOutcome> {
+    this.assertWithinSinglePut(key, bytes.byteLength)
+    try {
+      const out = await this.client.send(
+        new PutObjectCommand({
+          Bucket: this.bucket,
+          Key: this.keyFor(key),
+          Body: bytes,
+          ContentLength: bytes.byteLength,
+          IfMatch: etag,
+        }),
+      )
+      if (!out.ETag) {
+        // The write landed but the new token is unknown, so the next CAS has
+        // nothing to present. Re-reading is the honest way out.
+        return { status: 'ambiguous' }
+      }
+      return { status: 'replaced', etag: out.ETag }
+    } catch (e) {
+      if (isPreconditionFailure(e)) return { status: 'not-replaced' }
+      if (isAmbiguous(e)) return { status: 'ambiguous' }
+      throw backendError(`replacing ${key}`, this.describe, e)
+    }
+  }
+
+  private async conditionalPut(
+    key: string,
+    input: Omit<ConstructorParameters<typeof PutObjectCommand>[0], 'Bucket' | 'Key'>,
+  ): Promise<PutOutcome> {
+    try {
+      await this.client.send(
+        new PutObjectCommand({ ...input, Bucket: this.bucket, Key: this.keyFor(key) }),
+      )
+      return 'created'
+    } catch (e) {
+      if (isPreconditionFailure(e)) return 'already-exists'
+      if (isAmbiguous(e)) return 'ambiguous'
+      throw backendError(`creating ${key}`, this.describe, e)
+    }
+  }
+
+  private assertWithinSinglePut(key: string, size: number): void {
+    if (size > MAX_SINGLE_PUT_BYTES) {
+      throw new DurableLimitExceededError(
+        `durable: ${key} is ${size} bytes, over the ${MAX_SINGLE_PUT_BYTES}-byte ceiling for a ` +
+          `single PutObject; multipart upload is not implemented yet, so checkpoint more often ` +
+          `or reduce the database`,
+        { limit: MAX_SINGLE_PUT_BYTES, actual: size },
+      )
+    }
+  }
+}
+
+/**
+ * `s3://<bucket>/<prefix>?region=&endpoint=&forcePathStyle=`
+ *
+ * The query parameters are what make one implementation serve three providers:
+ *
+ * ```text
+ *   AWS     s3://my-bucket/durable?region=eu-west-1
+ *   R2      s3://my-bucket/durable?region=auto&endpoint=https://<id>.r2.cloudflarestorage.com
+ *   MinIO   s3://my-bucket/durable?region=us-east-1&endpoint=http://127.0.0.1:9000&forcePathStyle=true
+ * ```
+ *
+ * Credentials are deliberately not among them. They come from the environment
+ * or the standard credential chain, because a namespace URL is the sort of
+ * thing that gets logged, put in a config file and pasted into an issue.
+ */
+registerBackendScheme('s3', (url, objectId) => {
+  const bucket = url.hostname
+  if (!bucket) throw new RangeError(`durable: s3 namespace URL needs a bucket: ${url.href}`)
+
+  const basePrefix = url.pathname.replace(/^\/+|\/+$/g, '')
+  const prefix = basePrefix ? `${basePrefix}/${objectId}` : objectId
+
+  const region = url.searchParams.get('region') ?? undefined
+  const endpoint = url.searchParams.get('endpoint') ?? undefined
+  const forcePathStyle = url.searchParams.get('forcePathStyle') === 'true'
+
+  const clientConfig: S3ClientConfig = {}
+  if (region) clientConfig.region = region
+  if (endpoint) clientConfig.endpoint = endpoint
+  if (forcePathStyle) clientConfig.forcePathStyle = true
+
+  return new S3DurableBackend({ bucket, prefix, clientConfig })
+})

--- a/src/durable/digest.ts
+++ b/src/durable/digest.ts
@@ -1,0 +1,102 @@
+/**
+ * Length and SHA-256 verification (contract §4.5).
+ *
+ * The contract requires both to be checked before a base is restored or a WAL
+ * segment is parsed, and it requires checkpoint transfer not to hold the whole
+ * archive in memory. So the streaming helper here does the two jobs in one
+ * pass: it hashes and counts while it writes, then publishes the file to its
+ * final name only once both match. A caller therefore never sees a scratch
+ * path that holds unverified bytes.
+ */
+
+import { createHash } from 'crypto'
+import { createWriteStream } from 'fs'
+import { rename, unlink } from 'fs/promises'
+import { pipeline } from 'stream/promises'
+import type { Readable } from 'stream'
+import { Transform } from 'stream'
+import { DurableCorruptError } from './errors'
+import type { DurableObjectRef } from './types'
+
+export interface Digest {
+  size: number
+  sha256: string
+}
+
+/** Lowercase full SHA-256 hex of a buffer. */
+export function sha256Hex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+export function digestOf(bytes: Uint8Array): Digest {
+  return { size: bytes.byteLength, sha256: sha256Hex(bytes) }
+}
+
+/**
+ * Compare an observed digest against a reference. Returns the mismatch reason
+ * rather than throwing, because callers use it for two different things:
+ * refusing a corrupt object, and deciding whether an upload whose response was
+ * lost actually landed (§5.8) — where a mismatch is an answer, not a failure.
+ */
+export function digestMatches(ref: DurableObjectRef, observed: Digest): boolean {
+  return ref.size === observed.size && ref.sha256 === observed.sha256
+}
+
+export function assertDigest(ref: DurableObjectRef, observed: Digest, what: string): void {
+  if (ref.size !== observed.size) {
+    throw new DurableCorruptError(
+      `durable: ${what} (${ref.key}) has size ${observed.size}, head says ${ref.size}`,
+    )
+  }
+  if (ref.sha256 !== observed.sha256) {
+    throw new DurableCorruptError(
+      `durable: ${what} (${ref.key}) sha256 ${observed.sha256} does not match head ${ref.sha256}`,
+    )
+  }
+}
+
+/** A pass-through that accumulates length and SHA-256 as bytes flow past. */
+export function digestingStream(): Transform & { digest(): Digest } {
+  const hash = createHash('sha256')
+  let size = 0
+  const t = new Transform({
+    transform(chunk, _enc, cb) {
+      hash.update(chunk)
+      size += chunk.length
+      cb(null, chunk)
+    },
+  }) as Transform & { digest(): Digest }
+  t.digest = () => ({ size, sha256: hash.digest('hex') })
+  return t
+}
+
+/**
+ * Stream `source` into `tmpPath`, verify it against `ref`, then atomically
+ * publish it as `finalPath`. On any mismatch the scratch file is removed and
+ * `finalPath` is never created, so a failed verify cannot leave behind
+ * something a later step mistakes for a good archive.
+ */
+export async function streamToVerifiedFile(
+  source: Readable,
+  ref: DurableObjectRef,
+  tmpPath: string,
+  finalPath: string,
+  what: string,
+): Promise<Digest> {
+  const counter = digestingStream()
+  try {
+    await pipeline(source, counter, createWriteStream(tmpPath))
+  } catch (e) {
+    await unlink(tmpPath).catch(() => {})
+    throw e
+  }
+  const observed = counter.digest()
+  try {
+    assertDigest(ref, observed, what)
+  } catch (e) {
+    await unlink(tmpPath).catch(() => {})
+    throw e
+  }
+  await rename(tmpPath, finalPath)
+  return observed
+}

--- a/src/durable/engine-adapter.ts
+++ b/src/durable/engine-adapter.ts
@@ -1,0 +1,214 @@
+/**
+ * The engine seam (contract §3, roadmap §7.1).
+ *
+ * The durable control plane never touches a native library. Everything it
+ * needs from the engine goes through this interface, which is why the same
+ * state machine can drive chdb-node's addon, a Bun `dlopen` of `libchdb`, or a
+ * fake in a unit test without any of them knowing about the others.
+ *
+ * Two rules shape the interface, and both are contract requirements rather
+ * than taste:
+ *
+ *  1. **The binding never builds management SQL.** `backupDatabase`,
+ *     `restoreDatabase` and `createDatabase` take an identifier and a path;
+ *     quoting and AST construction happen in core. A binding that concatenated
+ *     `BACKUP DATABASE ` + name would be one clever database name away from
+ *     injection, in four languages independently.
+ *  2. **The binding never classifies SQL itself.** No prefix lists, no regular
+ *     expressions. `analyze` is ClickHouse's own parser answering questions
+ *     only it can answer — how many executable statements are in this text,
+ *     and does every persistent write land in the database we own. A regex
+ *     cannot see through `INSERT ... FORMAT` inline data, and it cannot
+ *     resolve an unqualified table name against the session's current
+ *     database.
+ *
+ * `backupDatabase` deliberately has no incremental-base parameter even though
+ * the C ABI accepts one. V1 checkpoints are always full: an incremental
+ * archive records the *path* of its base, and that path does not exist on the
+ * machine that restores it (contract §3.2).
+ */
+
+import { DurableClassificationRefusedError, DurableSecretRefusedError } from './errors'
+
+/**
+ * Statement classes, ascending by how restricted they are — so a batch
+ * classifies as the maximum over its members. Values match `chdb_query_class`
+ * in the C ABI and must not be renumbered.
+ */
+export enum QueryClass {
+  /** SELECT, SHOW, DESCRIBE, EXPLAIN: leaves no trace. */
+  ReadOnly = 0,
+  /** INSERT, CREATE, ALTER, DROP, …: changes a database, and a backup captures it. */
+  Mutating = 1,
+  /** Global UDFs, named collections, access entities, `system` writes: persistent
+   *  and replayable, but outside any database a checkpoint could capture. */
+  MutatingGlobal = 2,
+  /** USE, SET, SYSTEM, BACKUP, RESTORE, writes outside the engine entirely. */
+  Control = 3,
+  /** Did not parse, or parsed into something this engine does not classify. */
+  Unknown = 4,
+}
+
+/** What `chdb_classify_query_n` reports, as a JS value. */
+export interface QueryAnalysis {
+  /** Executable statements. `PARALLEL WITH` arms count separately. */
+  statementCount: number
+  queryClass: QueryClass
+  /** The text carries a credential. Never set when the class is Unknown. */
+  hasSecrets: boolean
+  /** Proven: every persistent write lands in the database the caller named. */
+  writesOnlyTargetDatabase: boolean
+  /** The statement creates, drops or renames a database rather than acting inside one. */
+  changesDatabaseLifecycle: boolean
+}
+
+export interface EngineStartOptions {
+  /** Fresh, empty, private data directory for this object's engine. */
+  dataPath: string
+  /** Absolute, already-created directory the engine may read and write archives in. */
+  backupsAllowedPath: string
+}
+
+/**
+ * What the durable object needs from an engine. Implementations own their
+ * native resources entirely; the control plane only calls these methods and
+ * `close`.
+ */
+export interface EngineAdapter {
+  /** Bring up a connection on a fresh scratch path. Called once, before anything else. */
+  start(options: EngineStartOptions): Promise<void>
+
+  /**
+   * Exact `chdb_version()`. Recorded in the head and matched on every open.
+   *
+   * Must be answerable before {@link start}: the open sequence checks engine
+   * compatibility before it takes a lease or creates a scratch directory, so
+   * a mismatch costs nothing. The underlying C symbol takes no connection, so
+   * this is a property of the loaded library rather than of a session.
+   */
+  version(): Promise<string>
+
+  /**
+   * Highest archive-format generation this engine can restore.
+   *
+   * Optional, and defaults to the V1 baseline of 1, because the C ABI has no
+   * accessor for it yet — every release so far is generation 1. Once core
+   * exposes one, an adapter reports it here and the reader gate starts
+   * refusing archives from a future generation instead of assuming.
+   */
+  backupFormat?(): Promise<number>
+
+  /** `CREATE DATABASE`, with core doing the quoting. */
+  createDatabase(database: string): Promise<void>
+
+  /**
+   * Pin the connection's current database. Called once after restore; the
+   * public surface can never change it, because `USE` classifies as Control.
+   */
+  useDatabase(database: string): Promise<void>
+
+  /** Analyse without executing, judged against `targetDatabase`. */
+  analyze(sql: string, targetDatabase: string): Promise<QueryAnalysis>
+
+  /** Run a read query and return its formatted result. */
+  query(sql: string, format: string): Promise<string>
+
+  /**
+   * Run a statement for effect. This is the *internal* path: it does no
+   * analysis and appends nothing to a WAL. Replay uses it, which is exactly
+   * why it must not be reachable from the public surface — a replayed
+   * statement that re-entered `execute()` would be logged a second time.
+   */
+  run(sql: string): Promise<void>
+
+  /** Full `BACKUP DATABASE` to a new absolute path that must not already exist. */
+  backupDatabase(database: string, filePath: string): Promise<void>
+
+  /** `RESTORE DATABASE` from an archive into a database that does not hold its tables. */
+  restoreDatabase(database: string, filePath: string): Promise<void>
+
+  /** Release the native connection. Must be safe to call after a failed start. */
+  close(): Promise<void>
+}
+
+/** Builds the engine for one durable object. */
+export type EngineFactory = () => EngineAdapter | Promise<EngineAdapter>
+
+const CLASS_NAMES: Record<QueryClass, string> = {
+  [QueryClass.ReadOnly]: 'READ_ONLY',
+  [QueryClass.Mutating]: 'MUTATING',
+  [QueryClass.MutatingGlobal]: 'MUTATING_GLOBAL',
+  [QueryClass.Control]: 'CONTROL',
+  [QueryClass.Unknown]: 'UNKNOWN',
+}
+
+export function queryClassName(c: QueryClass): string {
+  return CLASS_NAMES[c] ?? `class ${c}`
+}
+
+/**
+ * The frozen `query()` gate (contract §3.4).
+ *
+ * Note what is *not* here: a secret check. A read-only statement never reaches
+ * the WAL, so a credential inside it is not a durability problem — it is only
+ * a logging problem, which the binding handles by never echoing SQL.
+ */
+export function assertQueryAllowed(analysis: QueryAnalysis): void {
+  if (analysis.statementCount !== 1) {
+    throw new DurableClassificationRefusedError(
+      `durable: query() takes exactly one statement, core counted ${analysis.statementCount}`,
+    )
+  }
+  if (analysis.queryClass !== QueryClass.ReadOnly) {
+    throw new DurableClassificationRefusedError(
+      `durable: query() accepts only READ_ONLY statements, core classified this as ` +
+        `${queryClassName(analysis.queryClass)}`,
+    )
+  }
+}
+
+/**
+ * The frozen `execute()` gate (contract §3.4).
+ *
+ * The checks are ordered so the message names the most actionable fact first.
+ * The secret check is last and separate because it is the one failure the
+ * caller fixes by rewriting the statement rather than by using a different
+ * API — and because its message must describe the refusal without quoting the
+ * statement that triggered it.
+ */
+export function assertExecuteAllowed(analysis: QueryAnalysis, database: string): void {
+  if (analysis.statementCount !== 1) {
+    throw new DurableClassificationRefusedError(
+      `durable: execute() takes exactly one statement, core counted ${analysis.statementCount}. ` +
+        `A WAL record is one statement, so a batch has no replayable form in V1`,
+    )
+  }
+  if (analysis.queryClass !== QueryClass.Mutating) {
+    throw new DurableClassificationRefusedError(
+      `durable: execute() accepts only MUTATING statements, core classified this as ` +
+        `${queryClassName(analysis.queryClass)}` +
+        (analysis.queryClass === QueryClass.MutatingGlobal
+          ? '. Global state lives outside every database, so a checkpoint cannot carry it and V1 refuses it'
+          : ''),
+    )
+  }
+  if (analysis.changesDatabaseLifecycle) {
+    throw new DurableClassificationRefusedError(
+      `durable: execute() cannot create, drop or rename a database; the object owns ` +
+        `${JSON.stringify(database)} and its lifecycle is not a logged mutation`,
+    )
+  }
+  if (!analysis.writesOnlyTargetDatabase) {
+    throw new DurableClassificationRefusedError(
+      `durable: core could not prove every write lands in ${JSON.stringify(database)}. ` +
+        `A write to another database, to system, to a table function or to a file is not ` +
+        `captured by this object's checkpoint`,
+    )
+  }
+  if (analysis.hasSecrets) {
+    throw new DurableSecretRefusedError(
+      'durable: refusing to log a mutation that embeds a credential; the WAL outlives the ' +
+        'statement, so the credential would outlive it too',
+    )
+  }
+}

--- a/src/durable/errors.ts
+++ b/src/durable/errors.ts
@@ -1,0 +1,221 @@
+/**
+ * Durable V1 error model.
+ *
+ * The V1 contract freezes a set of error *categories* (contract §6) and
+ * requires them to be programmatically distinguishable. It deliberately does
+ * not freeze class names, so the categories live on `category` — a stable
+ * string discriminator every binding shares — while the class hierarchy is
+ * shaped the way the rest of this package shapes errors.
+ *
+ * Two rules the contract states explicitly and this file encodes:
+ *
+ *  1. A provider precondition failure (HTTP 412 and friends) is a CAS race
+ *     first. It is resolved against lease/manifest state into `lease_held`,
+ *     `lease_fenced` or a retry — never reported as a plain `backend` error.
+ *     `DurableBackendError` is for the failures that are genuinely the
+ *     provider's: network, auth, quota.
+ *  2. Messages must not carry secret-bearing SQL, provider credentials or
+ *     unredacted connection parameters. `secret_refused` in particular
+ *     describes the refusal without echoing the statement that caused it.
+ */
+
+import { ChdbError, type ChdbErrorOptions } from '../errors'
+
+/**
+ * The frozen category set (contract §6). Cross-binding conformance asserts on
+ * these strings, so they are the wire names, not prose.
+ */
+export type DurableErrorCategory =
+  | 'not_found'
+  | 'lease_held'
+  | 'lease_fenced'
+  | 'engine_incompatible'
+  | 'protocol_unsupported'
+  | 'corrupt'
+  | 'classification_refused'
+  | 'secret_refused'
+  | 'engine'
+  | 'backend'
+  | 'timeout'
+  | 'commit_ambiguous'
+  | 'limit_exceeded'
+  | 'closed'
+
+export abstract class DurableError extends ChdbError {
+  /** Frozen V1 category (contract §6). */
+  abstract readonly category: DurableErrorCategory
+  readonly code: string = 'CHDB_DURABLE'
+}
+
+/** Read-only open of an object that does not exist, or existing-only was required. */
+export class DurableNotFoundError extends DurableError {
+  readonly category = 'not_found'
+  override readonly code = 'CHDB_DURABLE_NOT_FOUND'
+}
+
+/** Another writer holds an unexpired lease. */
+export class DurableLeaseHeldError extends DurableError {
+  readonly category = 'lease_held'
+  override readonly code = 'CHDB_DURABLE_LEASE_HELD'
+
+  /** Owner recorded on the live lease — observability only, never authority. */
+  readonly owner?: string
+  /** Seconds until the observed lease expires; negative once inside skew allowance. */
+  readonly expiresInSeconds?: number
+
+  constructor(
+    message: string,
+    options?: ChdbErrorOptions & { owner?: string; expiresInSeconds?: number },
+  ) {
+    super(message, options)
+    if (options?.owner !== undefined) this.owner = options.owner
+    if (options?.expiresInSeconds !== undefined) this.expiresInSeconds = options.expiresInSeconds
+  }
+}
+
+/**
+ * This instance no longer owns the generation/ETag it was writing under —
+ * either a takeover happened, or heartbeat could not be confirmed inside the
+ * locally believed validity window and the writer fenced itself (contract
+ * §5.7). Both are unrecoverable for the object handle: it never writes again.
+ */
+export class DurableLeaseFencedError extends DurableError {
+  readonly category = 'lease_fenced'
+  override readonly code = 'CHDB_DURABLE_LEASE_FENCED'
+}
+
+/** The object records an engine version that is not exactly the running one. */
+export class DurableEngineIncompatibleError extends DurableError {
+  readonly category = 'engine_incompatible'
+  override readonly code = 'CHDB_DURABLE_ENGINE_INCOMPATIBLE'
+
+  readonly expected?: string
+  readonly actual?: string
+
+  constructor(message: string, options?: ChdbErrorOptions & { expected?: string; actual?: string }) {
+    super(message, options)
+    if (options?.expected !== undefined) this.expected = options.expected
+    if (options?.actual !== undefined) this.actual = options.actual
+  }
+}
+
+/** Protocol version above this baseline, or a feature name this build does not know. */
+export class DurableProtocolUnsupportedError extends DurableError {
+  readonly category = 'protocol_unsupported'
+  override readonly code = 'CHDB_DURABLE_PROTOCOL_UNSUPPORTED'
+
+  /** The unrecognised feature names, so the caller learns which ones blocked it. */
+  readonly features?: readonly string[]
+  readonly version?: number
+
+  constructor(
+    message: string,
+    options?: ChdbErrorOptions & { features?: readonly string[]; version?: number },
+  ) {
+    super(message, options)
+    if (options?.features !== undefined) this.features = options.features
+    if (options?.version !== undefined) this.version = options.version
+  }
+}
+
+/**
+ * Head failed schema validation, a referenced immutable object is missing, or
+ * its length/SHA-256 did not match. Never downgraded into "open an older
+ * state": a corrupt object stays closed (contract §4.5).
+ */
+export class DurableCorruptError extends DurableError {
+  readonly category = 'corrupt'
+  override readonly code = 'CHDB_DURABLE_CORRUPT'
+}
+
+/**
+ * Core query analysis refused the statement at a public entry point: wrong
+ * statement count, wrong class, or a write outside the object's database
+ * (contract §3.4). The message states which fact failed, never the SQL.
+ */
+export class DurableClassificationRefusedError extends DurableError {
+  readonly category = 'classification_refused'
+  override readonly code = 'CHDB_DURABLE_CLASSIFICATION_REFUSED'
+}
+
+/**
+ * A mutation carries a credential. It cannot be logged, and V1 has nowhere
+ * else to put it, so it is refused outright. Kept apart from
+ * `classification_refused` because the reason a caller must act on is
+ * different: rewrite the statement to not embed a secret.
+ */
+export class DurableSecretRefusedError extends DurableError {
+  readonly category = 'secret_refused'
+  override readonly code = 'CHDB_DURABLE_SECRET_REFUSED'
+}
+
+/** A core query, backup or restore failed. */
+export class DurableEngineError extends DurableError {
+  readonly category = 'engine'
+  override readonly code = 'CHDB_DURABLE_ENGINE'
+}
+
+/** Provider network, auth or non-conditional failure. Never a CAS conflict. */
+export class DurableBackendError extends DurableError {
+  readonly category = 'backend'
+  override readonly code = 'CHDB_DURABLE_BACKEND'
+}
+
+/** Deadline passed while the operation was provably still uncommitted. */
+export class DurableTimeoutError extends DurableError {
+  readonly category = 'timeout'
+  override readonly code = 'CHDB_DURABLE_TIMEOUT'
+}
+
+/**
+ * Reconcile could not prove whether the remote committed (contract §5.8).
+ * The one thing this must never do is report success: a caller that treats
+ * ambiguity as failure and retries is safe, one told "committed" is not.
+ */
+export class DurableCommitAmbiguousError extends DurableError {
+  readonly category = 'commit_ambiguous'
+  override readonly code = 'CHDB_DURABLE_COMMIT_AMBIGUOUS'
+
+  /** The unique key whose commit state could not be settled, for operator triage. */
+  readonly key?: string
+
+  constructor(message: string, options?: ChdbErrorOptions & { key?: string }) {
+    super(message, options)
+    if (options?.key !== undefined) this.key = options.key
+  }
+}
+
+/** SQL, WAL segment, head or provider object exceeded a declared V1 limit. */
+export class DurableLimitExceededError extends DurableError {
+  readonly category = 'limit_exceeded'
+  override readonly code = 'CHDB_DURABLE_LIMIT_EXCEEDED'
+
+  readonly limit?: number
+  readonly actual?: number
+
+  constructor(message: string, options?: ChdbErrorOptions & { limit?: number; actual?: number }) {
+    super(message, options)
+    if (options?.limit !== undefined) this.limit = options.limit
+    if (options?.actual !== undefined) this.actual = options.actual
+  }
+}
+
+/** Operation on an object whose close already completed. */
+export class DurableClosedError extends DurableError {
+  readonly category = 'closed'
+  override readonly code = 'CHDB_DURABLE_CLOSED'
+}
+
+/** Type guard for the whole durable hierarchy. */
+export function isDurableError(value: unknown): value is DurableError {
+  return value instanceof DurableError
+}
+
+/**
+ * Narrow by frozen category. Conformance suites and callers that branch on the
+ * contract's categories use this rather than `instanceof`, so an implementation
+ * is free to add subclasses without breaking them.
+ */
+export function isDurableErrorOf(value: unknown, category: DurableErrorCategory): boolean {
+  return isDurableError(value) && value.category === category
+}

--- a/src/durable/head.ts
+++ b/src/durable/head.ts
@@ -1,0 +1,265 @@
+/**
+ * `head.json` parsing, strict validation and unknown-field-preserving
+ * write-back (contract §4.2, §4.3, §4.5).
+ *
+ * The single most important thing this file does is *not* rebuild the head
+ * from scratch on every write. A writer that constructs a fresh object each
+ * time silently deletes every field it does not know about, which turns the
+ * whole named-feature mechanism into a lie: a future revision's state would
+ * survive exactly until an older writer touched the object. So the parsed raw
+ * JSON is carried alongside the typed view, and {@link serializeHead} patches
+ * the known fields onto a clone of it.
+ *
+ * The second thing is that "preserve unknown fields" is not "be lenient".
+ * Known fields are validated strictly — wrong types are `corrupt`, not
+ * best-effort coercions — because a head that does not mean what it says is
+ * more dangerous than one that fails to load.
+ */
+
+import { DurableCorruptError, DurableLimitExceededError } from './errors'
+import { assertObjectKey } from './keys'
+import {
+  BACKUP_FORMAT_BASELINE,
+  ENGINE_NAME,
+  LIMITS,
+  PROTOCOL_VERSION,
+  type DurableEngineIdentity,
+  type DurableHead,
+  type DurableLease,
+  type DurableManifest,
+  type DurableObjectRef,
+  type DurableProtocol,
+} from './types'
+
+const SHA256_HEX = /^[0-9a-f]{64}$/
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+function corrupt(what: string): never {
+  throw new DurableCorruptError(`durable: head.json ${what}`)
+}
+
+function safeInt(value: unknown, where: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    corrupt(`${where} must be a non-negative safe integer`)
+  }
+  return value
+}
+
+function nonEmptyString(value: unknown, where: string): string {
+  if (typeof value !== 'string' || value.length === 0) corrupt(`${where} must be a non-empty string`)
+  return value
+}
+
+function stringArray(value: unknown, where: string): string[] {
+  if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) {
+    corrupt(`${where} must be an array of strings`)
+  }
+  return value as string[]
+}
+
+function parseRef(value: unknown, where: string): DurableObjectRef {
+  if (!isPlainObject(value)) corrupt(`${where} must be an object`)
+  return {
+    key: assertObjectKey(value['key'], `head.json ${where}.key`),
+    size: safeInt(value['size'], `${where}.size`),
+    sha256: (() => {
+      const s = value['sha256']
+      if (typeof s !== 'string' || !SHA256_HEX.test(s)) {
+        corrupt(`${where}.sha256 must be 64 lowercase hex characters`)
+      }
+      return s
+    })(),
+  }
+}
+
+/**
+ * A missing `protocol` block reads as the V1 baseline with no features. That
+ * is the documented default rather than a rejection so that objects written
+ * before the block existed stay readable; every other shape of `protocol` is
+ * validated strictly.
+ */
+function parseProtocol(value: unknown): DurableProtocol {
+  if (value === undefined) {
+    return { version: PROTOCOL_VERSION, reader_features: [], writer_features: [] }
+  }
+  if (!isPlainObject(value)) corrupt('protocol must be an object')
+  return {
+    version: safeInt(value['version'] ?? PROTOCOL_VERSION, 'protocol.version'),
+    reader_features: stringArray(value['reader_features'] ?? [], 'protocol.reader_features'),
+    writer_features: stringArray(value['writer_features'] ?? [], 'protocol.writer_features'),
+  }
+}
+
+/**
+ * `engine` itself has no default — a head that records no engine cannot
+ * establish compatibility at all, so an absent block is a refusal rather than
+ * a wildcard.
+ *
+ * The two compatibility fields do have defaults, and both are chosen to be the
+ * conservative reading of an object written before they existed:
+ *
+ *  - `backup_format` defaults to the V1 baseline, which is what such an object
+ *    necessarily used.
+ *  - `min_reader` defaults to `version`. That reproduces the old exact-match
+ *    behaviour's lower bound: only a reader at or above the producer may open
+ *    it. Defaulting it to something older would retroactively widen an object's
+ *    audience on the strength of a field its writer never wrote.
+ */
+function parseEngine(value: unknown): DurableEngineIdentity {
+  if (!isPlainObject(value)) corrupt('engine must be an object')
+  const version = nonEmptyString(value['version'], 'engine.version')
+  return {
+    name: nonEmptyString(value['name'], 'engine.name'),
+    version,
+    backup_format: safeInt(value['backup_format'] ?? BACKUP_FORMAT_BASELINE, 'engine.backup_format'),
+    min_reader: nonEmptyString(value['min_reader'] ?? version, 'engine.min_reader'),
+  }
+}
+
+/**
+ * The lease is either fully held or fully released. A partial form — an owner
+ * with no expiry, an expiry with no instance — is rejected rather than
+ * normalised, because each half implies a different answer to "may I take
+ * this over", and guessing is how two writers end up believing they are the
+ * one writer.
+ */
+function parseLease(value: unknown): DurableLease {
+  if (!isPlainObject(value)) corrupt('lease must be an object')
+  const generation = safeInt(value['generation'], 'lease.generation')
+  const owner = value['owner'] ?? null
+  const instance = value['instance'] ?? null
+  const expiresAt = value['expires_at'] ?? null
+
+  const released = owner === null && instance === null && expiresAt === null
+  if (released) return { generation, owner: null, instance: null, expires_at: null }
+
+  if (typeof owner !== 'string' || typeof instance !== 'string' || typeof expiresAt !== 'number') {
+    corrupt(
+      'lease must be either fully released (owner, instance and expires_at all null) ' +
+        'or fully held (owner and instance strings, expires_at a number)',
+    )
+  }
+  if (!Number.isFinite(expiresAt)) corrupt('lease.expires_at must be finite')
+  return { generation, owner, instance, expires_at: expiresAt }
+}
+
+function parseManifest(value: unknown): DurableManifest {
+  if (!isPlainObject(value)) corrupt('manifest must be an object')
+  const base = value['base'] ?? null
+  const wal = value['wal'] ?? []
+  if (!Array.isArray(wal)) corrupt('manifest.wal must be an array')
+  return {
+    db: nonEmptyString(value['db'], 'manifest.db'),
+    base: base === null ? null : parseRef(base, 'manifest.base'),
+    wal: wal.map((ref, i) => parseRef(ref, `manifest.wal[${i}]`)),
+    seq: safeInt(value['seq'], 'manifest.seq'),
+  }
+}
+
+/** Parse and strictly validate head bytes, keeping the raw JSON for round-trip. */
+export function parseHead(bytes: Uint8Array): { head: DurableHead; raw: Record<string, unknown> } {
+  if (bytes.byteLength > LIMITS.MAX_HEAD_BYTES) {
+    throw new DurableLimitExceededError(
+      `durable: head.json is ${bytes.byteLength} bytes, over the V1 limit of ${LIMITS.MAX_HEAD_BYTES}`,
+      { limit: LIMITS.MAX_HEAD_BYTES, actual: bytes.byteLength },
+    )
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(Buffer.from(bytes).toString('utf8'))
+  } catch (e) {
+    throw new DurableCorruptError(`durable: head.json is not valid UTF-8 JSON`, { cause: e })
+  }
+  if (!isPlainObject(raw)) corrupt('must be a JSON object')
+  return {
+    head: {
+      protocol: parseProtocol(raw['protocol']),
+      engine: parseEngine(raw['engine']),
+      lease: parseLease(raw['lease']),
+      manifest: parseManifest(raw['manifest']),
+    },
+    raw,
+  }
+}
+
+/**
+ * Patch the known fields of `head` onto a clone of `raw`, so anything this
+ * build does not recognise — at the top level or inside protocol, engine,
+ * lease and manifest — is written back untouched.
+ *
+ * `manifest.base` and `manifest.wal` are replaced wholesale rather than
+ * merged: they are this build's own state, and a stale unknown key inside a
+ * reference we are rewriting would describe bytes that are no longer there.
+ */
+export function serializeHead(head: DurableHead, raw?: Record<string, unknown>): Uint8Array {
+  const base: Record<string, unknown> = raw ? structuredClone(raw) : {}
+
+  const mergeInto = (key: string, known: Record<string, unknown>): void => {
+    const existing = base[key]
+    base[key] = isPlainObject(existing) ? { ...existing, ...known } : known
+  }
+
+  mergeInto('protocol', {
+    version: head.protocol.version,
+    reader_features: [...head.protocol.reader_features],
+    writer_features: [...head.protocol.writer_features],
+  })
+  mergeInto('engine', {
+    name: head.engine.name,
+    version: head.engine.version,
+    backup_format: head.engine.backup_format,
+    min_reader: head.engine.min_reader,
+  })
+  mergeInto('lease', {
+    generation: head.lease.generation,
+    owner: head.lease.owner,
+    instance: head.lease.instance,
+    expires_at: head.lease.expires_at,
+  })
+  mergeInto('manifest', {
+    db: head.manifest.db,
+    base: head.manifest.base === null ? null : { ...head.manifest.base },
+    wal: head.manifest.wal.map((r) => ({ ...r })),
+    seq: head.manifest.seq,
+  })
+
+  const bytes = Buffer.from(JSON.stringify(base), 'utf8')
+  if (bytes.byteLength > LIMITS.MAX_HEAD_BYTES) {
+    throw new DurableLimitExceededError(
+      `durable: head.json would be ${bytes.byteLength} bytes, over the V1 limit of ` +
+        `${LIMITS.MAX_HEAD_BYTES}; checkpoint to truncate the WAL list`,
+      { limit: LIMITS.MAX_HEAD_BYTES, actual: bytes.byteLength },
+    )
+  }
+  return bytes
+}
+
+/**
+ * The head a cold object starts from: no base, no WAL, generation 1. The
+ * creating writer fills the lease in before publishing, because cold create and
+ * lease acquisition are one conditional write (contract §5.2) — publishing an
+ * unheld head first would leave a window where a second process could take a
+ * lease on a manifest nobody has restored into yet.
+ */
+export function coldHead(
+  db: string,
+  engineVersion: string,
+  backupFormat: number = BACKUP_FORMAT_BASELINE,
+): DurableHead {
+  return {
+    protocol: { version: PROTOCOL_VERSION, reader_features: [], writer_features: [] },
+    engine: {
+      name: ENGINE_NAME,
+      version: engineVersion,
+      backup_format: backupFormat,
+      // A fresh object can only be read by this engine or later: its base will
+      // be produced by this engine.
+      min_reader: engineVersion,
+    },
+    lease: { generation: 1, owner: null, instance: null, expires_at: null },
+    manifest: { db, base: null, wal: [], seq: 0 },
+  }
+}

--- a/src/durable/head.ts
+++ b/src/durable/head.ts
@@ -235,6 +235,15 @@ export function parseHead(bytes: Uint8Array): { head: DurableHead; raw: Record<s
  * reference we are rewriting would describe bytes that are no longer there.
  */
 export function serializeHead(head: DurableHead, raw?: Record<string, unknown>): Uint8Array {
+  // Refuse to emit a document this parser would reject. Writing one is worse
+  // than failing here: `head.json` is created with a conditional create and V1
+  // has no destroy, so an object published with, say, an empty `manifest.db`
+  // is corrupt on every subsequent open and cannot be removed.
+  if (head.manifest.db.length === 0) corrupt('manifest.db must be a non-empty string')
+  if (head.engine.version.length === 0) corrupt('engine.version must be a non-empty string')
+  if (head.engine.min_reader.length === 0) corrupt('engine.min_reader must be a non-empty string')
+  if (head.engine.name.length === 0) corrupt('engine.name must be a non-empty string')
+
   const base: Record<string, unknown> = raw ? structuredClone(raw) : {}
 
   const mergeInto = (key: string, known: Record<string, unknown>): void => {

--- a/src/durable/head.ts
+++ b/src/durable/head.ts
@@ -41,6 +41,20 @@ function corrupt(what: string): never {
   throw new DurableCorruptError(`durable: head.json ${what}`)
 }
 
+/**
+ * Read a field that must be present.
+ *
+ * `value['x'] ?? fallback` cannot tell an absent property from an explicit
+ * `null`, and for this document that distinction carries meaning: a released
+ * lease is *explicitly* three nulls, while a lease missing those keys is a
+ * truncated write. Treating the second as the first hands the object to a new
+ * writer on the strength of a corrupt head.
+ */
+function required(obj: Record<string, unknown>, key: string, where: string): unknown {
+  if (!(key in obj)) corrupt(`${where} is required`)
+  return obj[key]
+}
+
 function safeInt(value: unknown, where: string): number {
   if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
     corrupt(`${where} must be a non-negative safe integer`)
@@ -86,10 +100,20 @@ function parseProtocol(value: unknown): DurableProtocol {
     return { version: PROTOCOL_VERSION, reader_features: [], writer_features: [] }
   }
   if (!isPlainObject(value)) corrupt('protocol must be an object')
+  // An absent key takes the documented default; a key that is present takes
+  // its value, including an explicit null, which then fails validation. The
+  // defaults exist for older documents, not as a way to launder bad data.
+  const absent = (k: string): boolean => !(k in value)
   return {
-    version: safeInt(value['version'] ?? PROTOCOL_VERSION, 'protocol.version'),
-    reader_features: stringArray(value['reader_features'] ?? [], 'protocol.reader_features'),
-    writer_features: stringArray(value['writer_features'] ?? [], 'protocol.writer_features'),
+    version: safeInt(absent('version') ? PROTOCOL_VERSION : value['version'], 'protocol.version'),
+    reader_features: stringArray(
+      absent('reader_features') ? [] : value['reader_features'],
+      'protocol.reader_features',
+    ),
+    writer_features: stringArray(
+      absent('writer_features') ? [] : value['writer_features'],
+      'protocol.writer_features',
+    ),
   }
 }
 
@@ -110,12 +134,19 @@ function parseProtocol(value: unknown): DurableProtocol {
  */
 function parseEngine(value: unknown): DurableEngineIdentity {
   if (!isPlainObject(value)) corrupt('engine must be an object')
-  const version = nonEmptyString(value['version'], 'engine.version')
+  const version = nonEmptyString(required(value, 'version', 'engine.version'), 'engine.version')
+  const absent = (k: string): boolean => !(k in value)
   return {
-    name: nonEmptyString(value['name'], 'engine.name'),
+    name: nonEmptyString(required(value, 'name', 'engine.name'), 'engine.name'),
     version,
-    backup_format: safeInt(value['backup_format'] ?? BACKUP_FORMAT_BASELINE, 'engine.backup_format'),
-    min_reader: nonEmptyString(value['min_reader'] ?? version, 'engine.min_reader'),
+    backup_format: safeInt(
+      absent('backup_format') ? BACKUP_FORMAT_BASELINE : value['backup_format'],
+      'engine.backup_format',
+    ),
+    min_reader: nonEmptyString(
+      absent('min_reader') ? version : value['min_reader'],
+      'engine.min_reader',
+    ),
   }
 }
 
@@ -128,10 +159,11 @@ function parseEngine(value: unknown): DurableEngineIdentity {
  */
 function parseLease(value: unknown): DurableLease {
   if (!isPlainObject(value)) corrupt('lease must be an object')
-  const generation = safeInt(value['generation'], 'lease.generation')
-  const owner = value['owner'] ?? null
-  const instance = value['instance'] ?? null
-  const expiresAt = value['expires_at'] ?? null
+  const generation = safeInt(required(value, 'generation', 'lease.generation'), 'lease.generation')
+  // All three must be present. A half-written lease is corrupt, not free.
+  const owner = required(value, 'owner', 'lease.owner')
+  const instance = required(value, 'instance', 'lease.instance')
+  const expiresAt = required(value, 'expires_at', 'lease.expires_at')
 
   const released = owner === null && instance === null && expiresAt === null
   if (released) return { generation, owner: null, instance: null, expires_at: null }
@@ -148,14 +180,17 @@ function parseLease(value: unknown): DurableLease {
 
 function parseManifest(value: unknown): DurableManifest {
   if (!isPlainObject(value)) corrupt('manifest must be an object')
-  const base = value['base'] ?? null
-  const wal = value['wal'] ?? []
+  // `base` is the only one the protocol allows to be null; the rest are
+  // required and may not be null, so an absent or nulled `wal` is corrupt
+  // rather than an empty replay list.
+  const base = required(value, 'base', 'manifest.base')
+  const wal = required(value, 'wal', 'manifest.wal')
   if (!Array.isArray(wal)) corrupt('manifest.wal must be an array')
   return {
-    db: nonEmptyString(value['db'], 'manifest.db'),
+    db: nonEmptyString(required(value, 'db', 'manifest.db'), 'manifest.db'),
     base: base === null ? null : parseRef(base, 'manifest.base'),
     wal: wal.map((ref, i) => parseRef(ref, `manifest.wal[${i}]`)),
-    seq: safeInt(value['seq'], 'manifest.seq'),
+    seq: safeInt(required(value, 'seq', 'manifest.seq'), 'manifest.seq'),
   }
 }
 
@@ -169,7 +204,12 @@ export function parseHead(bytes: Uint8Array): { head: DurableHead; raw: Record<s
   }
   let raw: unknown
   try {
-    raw = JSON.parse(Buffer.from(bytes).toString('utf8'))
+    // Fatal decoding, not the lenient default. `Buffer.toString('utf8')`
+    // replaces malformed bytes with U+FFFD, which would let invalid data
+    // inside an *unknown* field parse cleanly and then be written back
+    // mangled — silently corrupting the one thing round-tripping exists to
+    // protect. The protocol says UTF-8; bytes that are not UTF-8 are corrupt.
+    raw = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes))
   } catch (e) {
     throw new DurableCorruptError(`durable: head.json is not valid UTF-8 JSON`, { cause: e })
   }

--- a/src/durable/index.ts
+++ b/src/durable/index.ts
@@ -1,0 +1,127 @@
+/**
+ * `chdb/durable` — the pure-TypeScript Durable V1 control plane.
+ *
+ * Importing this module loads no native code. Not the chdb-node addon, not
+ * `libchdb`, nothing that a second copy of an engine in the same process could
+ * collide with. That is a hard requirement rather than a nicety: the first
+ * downstream user of this package reaches `libchdb` through its own Bun FFI
+ * bindings, and a control plane that quietly pulled in a second native runtime
+ * would be unusable there.
+ *
+ * What arrives instead is an {@link EngineAdapter}: the caller supplies
+ * something that can analyse, run, back up and restore, and this package
+ * supplies everything above it — object layout, `head.json`, manifest, lease,
+ * CAS, fencing, WAL, checkpoint orchestration and the frozen error categories.
+ *
+ * The protocol these implement is specified in `CHDB_DURABLE_V1_CONTRACT.md`
+ * in the chdb repository, and that document — not this implementation — is the
+ * source of truth. Semantics change there first.
+ *
+ * ```js
+ * import { DurableNamespace } from 'chdb/durable'
+ *
+ * const ns = new DurableNamespace('file:///var/lib/chdb-durable', { engineFactory })
+ * const obj = await ns.open('orders')
+ *
+ * const ticket = await obj.execute("INSERT INTO events VALUES (1, 'a')")
+ * await obj.flushThrough(ticket)      // now it survives losing this machine
+ * const rows = await obj.query('SELECT count() FROM events')
+ * await obj.checkpoint()
+ * await obj.close()                   // rejects if the final flush failed
+ * ```
+ */
+
+export {
+  DurableNamespace,
+  registerBackendScheme,
+  type BackendSchemeFactory,
+  type DurableNamespaceOptions,
+} from './namespace'
+
+export {
+  DurableObject,
+  DEFAULT_TUNING,
+  type DurableObjectDeps,
+  type DurableOpenOptions,
+  type DurableStats,
+  type DurableTuning,
+  type RestoreProgress,
+  type QueryOptions,
+  type WriteTicket,
+} from './object'
+
+export {
+  QueryClass,
+  assertExecuteAllowed,
+  assertQueryAllowed,
+  queryClassName,
+  type EngineAdapter,
+  type EngineFactory,
+  type EngineStartOptions,
+  type QueryAnalysis,
+} from './engine-adapter'
+
+export type {
+  BackendFactory,
+  DurableBackend,
+  GetWithEtag,
+  PutOutcome,
+  ReplaceOutcome,
+} from './backend'
+
+export { LocalDurableBackend, type LocalBackendOptions } from './backends/local'
+
+export {
+  DurableError,
+  DurableBackendError,
+  DurableClassificationRefusedError,
+  DurableClosedError,
+  DurableCommitAmbiguousError,
+  DurableCorruptError,
+  DurableEngineError,
+  DurableEngineIncompatibleError,
+  DurableLeaseFencedError,
+  DurableLeaseHeldError,
+  DurableLimitExceededError,
+  DurableNotFoundError,
+  DurableProtocolUnsupportedError,
+  DurableSecretRefusedError,
+  DurableTimeoutError,
+  isDurableError,
+  isDurableErrorOf,
+  type DurableErrorCategory,
+} from './errors'
+
+export {
+  BACKUP_FORMAT_BASELINE,
+  ENGINE_NAME,
+  KNOWN_READER_FEATURES,
+  KNOWN_WRITER_FEATURES,
+  LIMITS,
+  PROTOCOL_VERSION,
+  type DurableEngineIdentity,
+  type DurableHead,
+  type DurableLease,
+  type DurableManifest,
+  type DurableObjectRef,
+  type DurableProtocol,
+  type HeadSnapshot,
+} from './types'
+
+export { coldHead, parseHead, serializeHead } from './head'
+export {
+  assertEngineCompatible,
+  assertReadable,
+  assertWritable,
+  type RunningEngine,
+} from './negotiate'
+export {
+  compareEngineVersions,
+  comparePrecedence,
+  maxEngineVersion,
+  parseEngineVersion,
+  type ParsedEngineVersion,
+} from './version'
+export { decodeWalSegment, encodeWalSegment } from './wal'
+export { HEAD_KEY, checkpointKey, isValidObjectKey, walKey } from './keys'
+export { digestOf, sha256Hex } from './digest'

--- a/src/durable/keys.ts
+++ b/src/durable/keys.ts
@@ -1,0 +1,93 @@
+/**
+ * Object key construction and validation (contract §4.1).
+ *
+ * Two separate jobs live here, and they are separate on purpose:
+ *
+ *  - *Minting* a key for something this writer is about to publish. Every
+ *    attempt gets a fresh key, including a retry of an attempt that may have
+ *    already landed. That is what makes an ambiguous upload resolvable rather
+ *    than destructive — a retry can never overwrite the bytes the first try
+ *    published (§5.8).
+ *  - *Validating* a key read out of someone else's head. A reference is a
+ *    relative key inside the object prefix, and nothing else. Rejecting `..`,
+ *    absolute paths and empty segments here is what stops a hostile or broken
+ *    head from steering a download outside the object — the local backend
+ *    resolves keys against a directory, so a traversal would be a real escape.
+ */
+
+import { randomUUID } from 'crypto'
+import { DurableCorruptError } from './errors'
+
+/** First 8 hex digits of a UUID4, per the frozen key shape. */
+export function uuid8(): string {
+  return randomUUID().replace(/-/g, '').slice(0, 8)
+}
+
+function decimal(n: number, what: string): string {
+  if (!Number.isSafeInteger(n) || n < 0) {
+    throw new RangeError(`durable: ${what} must be a non-negative safe integer, got ${n}`)
+  }
+  // No leading zeros: `String` on a safe integer never produces one.
+  return String(n)
+}
+
+/** `checkpoints/<generation>-<seq>-<uuid8>.tar.gz` */
+export function checkpointKey(generation: number, seq: number): string {
+  return `checkpoints/${decimal(generation, 'generation')}-${decimal(seq, 'seq')}-${uuid8()}.tar.gz`
+}
+
+/** `wal/<generation>-<seq>-<uuid8>.jsonl` */
+export function walKey(generation: number, seq: number): string {
+  return `wal/${decimal(generation, 'generation')}-${decimal(seq, 'seq')}-${uuid8()}.jsonl`
+}
+
+/** The one mutable key in an object. */
+export const HEAD_KEY = 'head.json'
+
+/**
+ * Accept only a relative, `/`-separated key with no empty, `.` or `..`
+ * segments. Backslashes are rejected too: on a POSIX filesystem a backslash is
+ * an ordinary character, so a key containing one would name a different file
+ * here than it does on a provider that normalises it.
+ */
+export function isValidObjectKey(key: unknown): key is string {
+  if (typeof key !== 'string' || key.length === 0) return false
+  if (key.startsWith('/') || key.includes('\\')) return false
+  if (key.includes('\0')) return false
+  for (const segment of key.split('/')) {
+    if (segment === '' || segment === '.' || segment === '..') return false
+  }
+  return true
+}
+
+/** Validate a key that came out of a head, or refuse the object as corrupt. */
+export function assertObjectKey(key: unknown, where: string): string {
+  if (!isValidObjectKey(key)) {
+    throw new DurableCorruptError(
+      `durable: ${where} is not a valid relative object key: ${JSON.stringify(key)}`,
+    )
+  }
+  return key
+}
+
+/**
+ * Join a namespace prefix and an object id into the object prefix. Both are
+ * validated as single path segments so an id cannot climb out of its
+ * namespace.
+ */
+export function objectPrefix(objectId: string): string {
+  if (
+    typeof objectId !== 'string' ||
+    objectId.length === 0 ||
+    objectId.includes('/') ||
+    objectId.includes('\\') ||
+    objectId.includes('\0') ||
+    objectId === '.' ||
+    objectId === '..'
+  ) {
+    throw new RangeError(
+      `durable: object id must be a single non-empty path segment, got ${JSON.stringify(objectId)}`,
+    )
+  }
+  return objectId
+}

--- a/src/durable/mutex.ts
+++ b/src/durable/mutex.ts
@@ -1,0 +1,88 @@
+/**
+ * Operation serialization (contract §5.3).
+ *
+ * The contract requires an explicit queue and forbids leaning on "the runtime
+ * is single-threaded" or "the native call happens to be synchronous" as the
+ * serialization argument. Both are true today and neither is a guarantee: the
+ * moment any step awaits provider I/O, another operation can interleave, and
+ * the state machine's invariants are exactly the things that break when it
+ * does.
+ *
+ * A durable object uses two of these rather than one, and the split is the
+ * interesting part.
+ *
+ *  - The **operation** mutex covers a whole logical operation: execute, query,
+ *    flush, checkpoint, close. Holding it for the duration of a checkpoint is
+ *    what stops new writes landing in a database that is being archived.
+ *  - The **head** mutex covers a single compare-and-swap against `head.json`.
+ *
+ * If one mutex covered both, a checkpoint of a large database would block
+ * heartbeat for the whole backup and upload, and the writer would fence itself
+ * out of an object it was in the middle of legitimately checkpointing. With
+ * the split, heartbeat only ever contends for the head mutex, which is held
+ * for a single conditional write — while the checkpoint's own final commit
+ * takes that same mutex and therefore sees the ETag heartbeat just produced.
+ */
+
+export class Mutex {
+  private tail: Promise<unknown> = Promise.resolve()
+  private sealedReason: (() => Error) | undefined
+  private depth = 0
+
+  /** True while an operation holds the mutex or is queued behind one. */
+  get busy(): boolean {
+    return this.depth > 0
+  }
+
+  /**
+   * Run `fn` with exclusive access. Rejections propagate to the caller and do
+   * not poison the queue — the next waiter runs regardless, because a failed
+   * flush must not wedge the close that has to report it.
+   */
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.sealedReason) throw this.sealedReason()
+    this.depth++
+    const prior = this.tail
+    let release!: () => void
+    this.tail = new Promise<void>((r) => {
+      release = r
+    })
+    await prior.catch(() => {})
+    try {
+      return await fn()
+    } finally {
+      this.depth--
+      release()
+    }
+  }
+
+  /**
+   * Stop accepting new work, then wait for what is already queued. Used by
+   * close: the drain has to happen before the durability barrier, and new
+   * callers have to be turned away rather than silently queued behind a
+   * close they will never come back from.
+   */
+  async sealAndDrain(reason: () => Error): Promise<void> {
+    this.sealedReason = reason
+    await this.tail.catch(() => {})
+  }
+
+  /**
+   * Run `fn` even though the mutex is sealed. Close itself needs this: it
+   * seals the queue against everyone else and then still has to do its own
+   * work in the same serialized position.
+   */
+  async runSealed<T>(fn: () => Promise<T>): Promise<T> {
+    const prior = this.tail
+    let release!: () => void
+    this.tail = new Promise<void>((r) => {
+      release = r
+    })
+    await prior.catch(() => {})
+    try {
+      return await fn()
+    } finally {
+      release()
+    }
+  }
+}

--- a/src/durable/namespace.ts
+++ b/src/durable/namespace.ts
@@ -1,0 +1,122 @@
+/**
+ * Namespaces: the entry point to the durable control plane.
+ *
+ * A namespace is a URL plus an engine factory. The URL says where objects
+ * live and, through its scheme, which backend implements the conditional
+ * operations; the factory says how to bring up an engine for whichever object
+ * is being opened.
+ *
+ * Backends are looked up in a registry rather than imported here on purpose.
+ * V1 ships with the local filesystem backend, and a cloud provider arrives as
+ * its own module that registers a scheme — so importing `chdb/durable` never
+ * drags in an object-storage SDK, and a provider can be added without this
+ * file changing.
+ *
+ * One constraint is not the namespace's to hide: chdb-core binds one data path
+ * per process, so one process can hold one open durable object at a time.
+ * `scan`-style fan-out therefore has to be sequential, or spread across worker
+ * processes. A registry here that pretended otherwise would just move the
+ * failure somewhere less obvious (contract §3.6).
+ */
+
+import { isAbsolute, join } from 'path'
+import { fileURLToPath } from 'url'
+import type { BackendFactory, DurableBackend } from './backend'
+import { LocalDurableBackend } from './backends/local'
+import type { EngineFactory } from './engine-adapter'
+import { objectPrefix } from './keys'
+import { DurableObject, type DurableOpenOptions, type DurableTuning } from './object'
+
+/** Builds a backend for one object, given the namespace URL and the object id. */
+export type BackendSchemeFactory = (url: URL, objectId: string) => Promise<DurableBackend> | DurableBackend
+
+const SCHEMES = new Map<string, BackendSchemeFactory>()
+
+/**
+ * Schemes this package ships but does not register until their module is
+ * imported. Getting "no backend for s3" when the S3 backend is right there is
+ * a confusing five minutes, so the error says which import is missing rather
+ * than only which schemes are present.
+ */
+const SHIPPED_BUT_UNIMPORTED: Readonly<Record<string, string>> = {
+  s3: 'chdb/durable/s3',
+}
+
+function hintFor(scheme: string): string {
+  const subpath = SHIPPED_BUT_UNIMPORTED[scheme]
+  return subpath
+    ? ` This package ships one — add \`import '${subpath}'\` to register it.`
+    : ' Register others with registerBackendScheme().'
+}
+
+/**
+ * Register a backend for a URL scheme, e.g. `s3`. Provider packages call this
+ * on import; the durable core stays free of their dependencies.
+ */
+export function registerBackendScheme(scheme: string, factory: BackendSchemeFactory): void {
+  SCHEMES.set(scheme.replace(/:$/, ''), factory)
+}
+
+registerBackendScheme('file', (url, objectId) => {
+  const root = fileURLToPath(url)
+  if (!isAbsolute(root)) {
+    throw new RangeError(`durable: file namespace must be an absolute path, got ${url.href}`)
+  }
+  return new LocalDurableBackend({ root: join(root, objectId) })
+})
+
+export interface DurableNamespaceOptions {
+  /** How to build the engine for an object being opened. Required. */
+  engineFactory: EngineFactory
+  /**
+   * Bypass scheme lookup and supply the backend directly. Conformance suites
+   * use this to wrap a real backend in fault injection.
+   */
+  backendFactory?: BackendFactory
+  /** Default writer name for objects opened from this namespace. */
+  owner?: string
+  /** Default parent directory for scratch trees. */
+  scratchRoot?: string
+  /** Default lease and commit tuning. */
+  tuning?: Partial<DurableTuning>
+}
+
+export class DurableNamespace {
+  readonly url: URL
+  private readonly options: DurableNamespaceOptions
+
+  constructor(url: string | URL, options: DurableNamespaceOptions) {
+    this.url = typeof url === 'string' ? new URL(url) : url
+    if (!options?.engineFactory) {
+      throw new TypeError('durable: DurableNamespace requires an engineFactory')
+    }
+    const scheme = this.url.protocol.replace(/:$/, '')
+    if (!options.backendFactory && !SCHEMES.has(scheme)) {
+      throw new RangeError(
+        `durable: no backend registered for scheme ${JSON.stringify(scheme)}. ` +
+          `Registered: ${[...SCHEMES.keys()].join(', ')}.${hintFor(scheme)}`,
+      )
+    }
+    this.options = options
+  }
+
+  /**
+   * Open one object. Writer by default; pass `readOnly` for a snapshot handle
+   * that takes no lease, or `force` to take an unexpired lease from a writer
+   * that is presumed dead.
+   */
+  async open(objectId: string, openOptions: DurableOpenOptions = {}): Promise<DurableObject> {
+    const id = objectPrefix(objectId)
+    const backend = this.options.backendFactory
+      ? await this.options.backendFactory(id)
+      : await (SCHEMES.get(this.url.protocol.replace(/:$/, '')) as BackendSchemeFactory)(this.url, id)
+
+    const merged: DurableOpenOptions = {
+      ...openOptions,
+      owner: openOptions.owner ?? this.options.owner,
+      scratchRoot: openOptions.scratchRoot ?? this.options.scratchRoot,
+      tuning: { ...this.options.tuning, ...openOptions.tuning },
+    }
+    return DurableObject.open({ id, backend, engineFactory: this.options.engineFactory }, merged)
+  }
+}

--- a/src/durable/negotiate.ts
+++ b/src/durable/negotiate.ts
@@ -1,0 +1,123 @@
+/**
+ * Version and feature negotiation (contract §4.3) and engine identity
+ * (§4.2).
+ *
+ * V1 uses named features rather than a monotonic minimum-version number. The
+ * reason is that a monotonic number requires features to be linearly ordered,
+ * and with several bindings developed in parallel they are not: a client can
+ * implement B without A, and under a version floor it would be locked out of
+ * an object that only ever used B. Delta Lake moved off version numbers onto
+ * table features for exactly this.
+ *
+ * The asymmetry between the two lists is the whole point. An unknown
+ * *reader* feature means bytes in this object cannot be interpreted, so the
+ * object does not open at all. An unknown *writer* feature means only that
+ * writing correctly requires something this build cannot do — reading is
+ * still sound, so a read-only open is allowed and only the lease is refused.
+ */
+
+import { DurableEngineIncompatibleError, DurableProtocolUnsupportedError } from './errors'
+import { compareEngineVersions } from './version'
+import {
+  ENGINE_NAME,
+  KNOWN_READER_FEATURES,
+  KNOWN_WRITER_FEATURES,
+  PROTOCOL_VERSION,
+  type DurableHead,
+} from './types'
+
+function unknown(features: readonly string[], known: readonly string[]): string[] {
+  return features.filter((f) => !known.includes(f))
+}
+
+/**
+ * Gate a read. Refuses a protocol version above this baseline, or any
+ * unrecognised reader feature, naming the offenders so the operator knows
+ * which build they need.
+ */
+export function assertReadable(head: DurableHead): void {
+  if (head.protocol.version > PROTOCOL_VERSION) {
+    throw new DurableProtocolUnsupportedError(
+      `durable: object uses protocol version ${head.protocol.version}, this build implements ${PROTOCOL_VERSION}`,
+      { version: head.protocol.version },
+    )
+  }
+  const missing = unknown(head.protocol.reader_features, KNOWN_READER_FEATURES)
+  if (missing.length > 0) {
+    throw new DurableProtocolUnsupportedError(
+      `durable: object requires reader features this build does not implement: ${missing.join(', ')}`,
+      { features: missing },
+    )
+  }
+}
+
+/**
+ * Gate taking the writer lease. Assumes {@link assertReadable} already passed;
+ * this only adds the writer-side feature check.
+ */
+export function assertWritable(head: DurableHead): void {
+  const missing = unknown(head.protocol.writer_features, KNOWN_WRITER_FEATURES)
+  if (missing.length > 0) {
+    throw new DurableProtocolUnsupportedError(
+      `durable: object requires writer features this build does not implement: ${missing.join(', ')}; ` +
+        `it can still be opened read-only`,
+      { features: missing },
+    )
+  }
+}
+
+/** What the running engine can offer, for the compatibility gate. */
+export interface RunningEngine {
+  /** `chdb_version()` of the engine in this process. */
+  version: string
+  /** Highest archive-format generation this engine can restore. */
+  backupFormat: number
+}
+
+/**
+ * The frozen engine gate:
+ *
+ * ```text
+ *   backup_format > reader baseline   -> engine_incompatible
+ *   running_version < min_reader      -> engine_incompatible
+ *   otherwise                         -> open
+ * ```
+ *
+ * Note what is deliberately absent: a comparison against `engine.version`.
+ * That field records which build produced the object, for diagnosis, and is
+ * explicitly not a gate. An exact match would refuse every later release,
+ * which is the opposite of what the compatibility promise says — a newer
+ * chdb-core restores full backups made by an earlier one.
+ *
+ * The two checks guard different failures and neither subsumes the other.
+ * `min_reader` catches a reader that is simply too old. `backup_format` is the
+ * escape hatch for the day the promise itself is withdrawn: version numbers
+ * keep increasing whether or not the format still works, so a broken format
+ * needs its own signal, or a reader would compare a larger version, conclude
+ * it is fine, and discover otherwise partway through RESTORE.
+ */
+export function assertEngineCompatible(head: DurableHead, running: RunningEngine): void {
+  if (head.engine.name !== ENGINE_NAME) {
+    throw new DurableEngineIncompatibleError(
+      `durable: object was written by engine ${JSON.stringify(head.engine.name)}, not ${ENGINE_NAME}`,
+      { expected: head.engine.name, actual: ENGINE_NAME },
+    )
+  }
+
+  if (head.engine.backup_format > running.backupFormat) {
+    throw new DurableEngineIncompatibleError(
+      `durable: object uses archive format generation ${head.engine.backup_format}, and this ` +
+        `engine restores up to ${running.backupFormat}. A newer chdb-core is required; the ` +
+        `format generation only moves when older archives can no longer be restored`,
+      { expected: String(head.engine.backup_format), actual: String(running.backupFormat) },
+    )
+  }
+
+  if (compareEngineVersions(running.version, head.engine.min_reader) < 0) {
+    throw new DurableEngineIncompatibleError(
+      `durable: object requires chdb ${head.engine.min_reader} or later to read, and this ` +
+        `process runs ${running.version} (written by ${head.engine.version})`,
+      { expected: head.engine.min_reader, actual: running.version },
+    )
+  }
+}

--- a/src/durable/object.ts
+++ b/src/durable/object.ts
@@ -569,10 +569,18 @@ export class DurableObject {
         })
       }
 
+      // Checked before anything is published: an empty name would produce a
+      // head that fails to parse, created with a conditional create that V1
+      // gives no way to undo. A bad argument should be a bad argument, not a
+      // permanently corrupt object.
+      const database = options.database ?? 'default'
+      if (database.length === 0) {
+        throw new RangeError('durable: options.database must be a non-empty string')
+      }
       leaseTaken = existing
         ? await acquireLease(deps.backend, existing, { instance, owner, tuning, force: options.force === true })
         : await createCold(deps.backend, {
-            database: options.database ?? 'default',
+            database,
             running,
             instance,
             owner,

--- a/src/durable/object.ts
+++ b/src/durable/object.ts
@@ -1,0 +1,1225 @@
+/**
+ * The Durable V1 object state machine (contract §5).
+ *
+ * Everything the protocol calls hard lives here: lease acquisition and
+ * fencing, the operation queue, WAL publication, checkpoint, and the
+ * reconcile that decides whether a request whose response vanished actually
+ * committed. None of it touches a native library — the engine arrives as an
+ * {@link EngineAdapter}, the object store as a {@link DurableBackend}.
+ *
+ * A few invariants are worth stating up front, because most of the code below
+ * exists to hold one of them:
+ *
+ *  - **`execute()` succeeding does not mean the write is durable.** It means
+ *    the statement ran locally and joined the buffer. Durability is `flush()`.
+ *    A product that answers a client before flushing is choosing to lose that
+ *    write on a crash, and it should choose that knowingly.
+ *  - **Nothing is ever reported as committed without proof.** Every commit
+ *    path can end in `commit_ambiguous`, which is an honest answer. Reporting
+ *    a lost response as success would be the one failure mode a caller cannot
+ *    defend against.
+ *  - **A writer that cannot confirm its lease stops writing.** Not on the next
+ *    error — at the moment its locally believed validity window lapses. The
+ *    alternative is two processes each convinced they are the only writer.
+ *  - **Local resources are always released.** A close that fails to flush
+ *    still closes the connection and removes the scratch directory, and still
+ *    reports the failure.
+ */
+
+import { mkdir, mkdtemp, rm, unlink } from 'fs/promises'
+import { createReadStream } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { pipeline } from 'stream/promises'
+
+import type { DurableBackend } from './backend'
+import { assertDigest, digestOf, digestingStream, streamToVerifiedFile, type Digest } from './digest'
+import {
+  assertExecuteAllowed,
+  assertQueryAllowed,
+  type EngineAdapter,
+  type EngineFactory,
+} from './engine-adapter'
+import {
+  DurableClassificationRefusedError,
+  DurableClosedError,
+  DurableCommitAmbiguousError,
+  DurableCorruptError,
+  DurableEngineError,
+  DurableEngineIncompatibleError,
+  DurableLeaseFencedError,
+  DurableLeaseHeldError,
+  DurableLimitExceededError,
+  DurableNotFoundError,
+  DurableTimeoutError,
+} from './errors'
+import { coldHead, parseHead, serializeHead } from './head'
+import { HEAD_KEY, checkpointKey, uuid8, walKey } from './keys'
+import { Mutex } from './mutex'
+import {
+  assertEngineCompatible,
+  assertReadable,
+  assertWritable,
+  type RunningEngine,
+} from './negotiate'
+import { maxEngineVersion } from './version'
+import {
+  assertStatementWithinLimit,
+  decodeWalSegment,
+  encodeWalSegment,
+  walLineBytes,
+} from './wal'
+import {
+  BACKUP_FORMAT_BASELINE,
+  LIMITS,
+  type DurableHead,
+  type DurableManifest,
+  type DurableObjectRef,
+} from './types'
+
+/**
+ * Lease and commit tuning. The contract lets a binding choose these but
+ * requires the defaults, their units and their rules to be documented — so
+ * they are, here, and the same values drive the conformance scenarios.
+ */
+export interface DurableTuning {
+  /** How long a lease is valid after a successful head write. Default 30s. */
+  leaseTtlMs: number
+  /**
+   * How often the writer renews. Must be at most a third of the TTL, so two
+   * consecutive heartbeat failures still leave a window to notice and fence.
+   * Default 10s.
+   */
+  heartbeatIntervalMs: number
+  /**
+   * How far past a recorded expiry another writer waits before treating a
+   * lease as abandoned. This is a bound on disagreement between two machines'
+   * clocks, not a grace period for a slow writer. Default 5s.
+   */
+  clockSkewAllowanceMs: number
+  /** How long a single commit may spend retrying and reconciling. Default 30s. */
+  commitDeadlineMs: number
+  /** Attempts inside that deadline before giving up. Default 5. */
+  maxCommitAttempts: number
+}
+
+export const DEFAULT_TUNING: DurableTuning = {
+  leaseTtlMs: 30_000,
+  heartbeatIntervalMs: 10_000,
+  clockSkewAllowanceMs: 5_000,
+  commitDeadlineMs: 30_000,
+  maxCommitAttempts: 5,
+}
+
+export interface DurableOpenOptions {
+  /** Open without a writer lease. Read-only opens see the manifest as of open. */
+  readOnly?: boolean
+  /**
+   * Take an unexpired lease from its current holder. An administrator action:
+   * the previous writer's unflushed local work is lost, and it learns this
+   * only when its next commit is fenced.
+   */
+  force?: boolean
+  /** Refuse to create the object if it does not exist. */
+  existingOnly?: boolean
+  /** Visible writer name recorded in the lease. Observability only. */
+  owner?: string
+  /** Database this object holds. Only used when creating a cold object. */
+  database?: string
+  /** Parent directory for the scratch tree. Defaults to the system temp dir. */
+  scratchRoot?: string
+  /**
+   * Called as the open restores base and replays WAL. Synchronous and
+   * best-effort: a throw from it is swallowed, because a reporting callback
+   * must not be able to fail an otherwise good recovery.
+   */
+  onRestoreProgress?: (progress: RestoreProgress) => void
+  tuning?: Partial<DurableTuning>
+}
+
+/**
+ * Progress through the restore an open performs, for a caller that has to show
+ * one. Recovering a large object is not instantaneous, and "starting" with no
+ * further detail is indistinguishable from "stuck" — which is the state an
+ * operator most needs to tell apart.
+ */
+export type RestoreProgress =
+  | { phase: 'creating-database'; database: string }
+  | { phase: 'restoring-base'; key: string; size: number }
+  | {
+      phase: 'replaying-wal'
+      /** 1-based index of the segment being replayed. */
+      segment: number
+      segments: number
+      /** Statements replayed so far, across all segments. */
+      statements: number
+      key: string
+    }
+  | { phase: 'ready'; statementsReplayed: number }
+
+/**
+ * A consistent snapshot of an object's runtime state. Contains no credentials
+ * and no SQL, so it is safe to log verbatim.
+ */
+export interface DurableStats {
+  objectId: string
+  database: string
+  readOnly: boolean
+  state: 'open' | 'closing' | 'closed'
+  /** True once this writer has lost, or given up on, its lease. */
+  fenced: boolean
+  generation: number
+  owner: string
+  instance: string
+  /** When this writer stops believing its lease. Absent for a read-only open. */
+  leaseExpiresAt: Date | undefined
+  /** `manifest.seq` as last committed. */
+  committedSeq: number
+  baseKey: string | undefined
+  walSegments: number
+  /** Statements executed through this handle since it opened. */
+  executedStatements: number
+  /** Of those, how many are in a committed WAL segment. */
+  committedStatements: number
+  pendingStatements: number
+  pendingBytes: number
+  lastFlushAt: Date | undefined
+  lastCheckpointAt: Date | undefined
+}
+
+export interface DurableObjectDeps {
+  id: string
+  backend: DurableBackend
+  engineFactory: EngineFactory
+}
+
+/**
+ * A watermark for one executed statement. `flushThrough` turns it into a
+ * durability barrier, which is what lets a caller that expands one request
+ * into several statements answer the request as a whole (roadmap §10.1)
+ * without the protocol having to know about requests.
+ */
+export interface WriteTicket {
+  /** Ordinal of the statement within this open session, starting at 1. */
+  readonly statement: number
+}
+
+export interface QueryOptions {
+  /** ClickHouse output format. Defaults to `JSONEachRow`. */
+  format?: string
+}
+
+interface Scratch {
+  root: string
+  data: string
+  backups: string
+  staging: string
+}
+
+function nowMs(): number {
+  return Date.now()
+}
+
+/** Stream a local file through SHA-256 without holding it in memory. */
+async function digestFile(path: string): Promise<Digest> {
+  const counter = digestingStream()
+  await pipeline(createReadStream(path), counter, async function* (source) {
+    // Drain without collecting: the digest is the only thing wanted here.
+    for await (const _chunk of source) void _chunk
+  })
+  return counter.digest()
+}
+
+export class DurableObject {
+  readonly id: string
+  readonly readOnly: boolean
+
+  private readonly backend: DurableBackend
+  private readonly engine: EngineAdapter
+  private readonly scratch: Scratch
+  private readonly tuning: DurableTuning
+  private readonly instance: string
+  private readonly ownerName: string
+  private readonly running: RunningEngine
+
+  /** Serializes whole logical operations. See {@link Mutex} for why there are two. */
+  private readonly ops = new Mutex()
+  /** Serializes single head compare-and-swaps, including heartbeat. */
+  private readonly headLock = new Mutex()
+
+  private head: DurableHead
+  private etag: string
+  private raw: Record<string, unknown>
+
+  private walBuffer: string[] = []
+  /** Encoded size of `walBuffer`, kept in step so execute() can budget in O(1). */
+  private walBufferBytes = 0
+  private statementCounter = 0
+  private committedStatementCount = 0
+  private lastFlushAtMs: number | undefined
+  private lastCheckpointAtMs: number | undefined
+
+  private status: 'open' | 'closing' | 'closed' = 'open'
+  private fenced = false
+  /** Local wall-clock time at which this writer stops believing its lease. */
+  private leaseDeadlineMs = 0
+  private heartbeatTimer: NodeJS.Timeout | undefined
+  private closing: Promise<void> | undefined
+
+  private constructor(init: {
+    id: string
+    backend: DurableBackend
+    engine: EngineAdapter
+    scratch: Scratch
+    tuning: DurableTuning
+    readOnly: boolean
+    instance: string
+    owner: string
+    running: RunningEngine
+    head: DurableHead
+    etag: string
+    raw: Record<string, unknown>
+  }) {
+    this.id = init.id
+    this.backend = init.backend
+    this.engine = init.engine
+    this.scratch = init.scratch
+    this.tuning = init.tuning
+    this.readOnly = init.readOnly
+    this.instance = init.instance
+    this.ownerName = init.owner
+    this.running = init.running
+    this.head = init.head
+    this.etag = init.etag
+    this.raw = init.raw
+  }
+
+  // ---------------------------------------------------------------- accessors
+
+  /** The database this object holds. Fixed for the object's lifetime. */
+  get database(): string {
+    return this.head.manifest.db
+  }
+
+  /** Lease generation currently recorded in the head. */
+  get generation(): number {
+    return this.head.lease.generation
+  }
+
+  /** A copy of the committed manifest. Observability; never authority. */
+  get manifest(): DurableManifest {
+    return {
+      db: this.head.manifest.db,
+      base: this.head.manifest.base ? { ...this.head.manifest.base } : null,
+      wal: this.head.manifest.wal.map((r) => ({ ...r })),
+      seq: this.head.manifest.seq,
+    }
+  }
+
+  /** Statements executed locally but not yet published in a WAL segment. */
+  get pendingStatements(): number {
+    return this.walBuffer.length
+  }
+
+  /**
+   * Encoded size of those statements. Exposed so a caller can apply its own
+   * backpressure — flush on a size threshold rather than discovering the
+   * segment ceiling by hitting it.
+   */
+  get pendingBytes(): number {
+    return this.walBufferBytes
+  }
+
+  /** Statements this session has published in a committed WAL segment. */
+  get committedStatements(): number {
+    return this.committedStatementCount
+  }
+
+  /**
+   * A point-in-time snapshot for a status endpoint or a log line.
+   *
+   * Taken together rather than field by field, so what it reports is internally
+   * consistent: reading a generation and a sequence number through separate
+   * getters can straddle a commit and describe a state that never existed.
+   *
+   * Carries no credentials and no SQL. Object ids and keys are safe; the
+   * statements that produced them are not, and are deliberately absent.
+   */
+  get stats(): DurableStats {
+    return {
+      objectId: this.id,
+      database: this.database,
+      readOnly: this.readOnly,
+      state: this.status,
+      fenced: this.fenced,
+      generation: this.head.lease.generation,
+      owner: this.ownerName,
+      instance: this.instance,
+      leaseExpiresAt:
+        this.readOnly || this.leaseDeadlineMs === 0 ? undefined : new Date(this.leaseDeadlineMs),
+      committedSeq: this.head.manifest.seq,
+      baseKey: this.head.manifest.base?.key,
+      walSegments: this.head.manifest.wal.length,
+      executedStatements: this.statementCounter,
+      committedStatements: this.committedStatementCount,
+      pendingStatements: this.walBuffer.length,
+      pendingBytes: this.walBufferBytes,
+      lastFlushAt: this.lastFlushAtMs === undefined ? undefined : new Date(this.lastFlushAtMs),
+      lastCheckpointAt:
+        this.lastCheckpointAtMs === undefined ? undefined : new Date(this.lastCheckpointAtMs),
+    }
+  }
+
+  /** True once this writer has lost, or given up on, its lease. */
+  get isFenced(): boolean {
+    return this.fenced
+  }
+
+  /** Absolute path of this object's private scratch tree. */
+  get scratchPath(): string {
+    return this.scratch.root
+  }
+
+  // --------------------------------------------------------------- public API
+
+  /**
+   * Run a read-only statement. Refused unless core proves it is exactly one
+   * READ_ONLY statement — the method name is not the gate, the analysis is.
+   */
+  async query(sql: string, options?: QueryOptions): Promise<string> {
+    return this.ops.run(async () => {
+      this.assertUsable()
+      const analysis = await this.engine.analyze(sql, this.database)
+      assertQueryAllowed(analysis)
+      return this.engine.query(sql, options?.format ?? 'JSONEachRow')
+    })
+  }
+
+  /**
+   * Run one mutating statement and buffer it for the WAL.
+   *
+   * The statement is executed first and buffered only on success, so a
+   * statement that failed is never replayed. The returned ticket is the
+   * watermark to pass to {@link flushThrough} when the caller needs the write
+   * to be durable before it answers someone.
+   */
+  async execute(sql: string): Promise<WriteTicket> {
+    return this.ops.run(async () => {
+      this.assertWriter()
+      const analysis = await this.engine.analyze(sql, this.database)
+      assertExecuteAllowed(analysis, this.database)
+
+      // Both limits are checked here rather than at flush, and before the
+      // statement runs rather than after.
+      //
+      // The ordering is the point. A statement that has executed cannot be
+      // un-executed, so a buffer that has grown past what a segment can hold
+      // can no longer be flushed at all — every flush would fail encoding
+      // while the local database has already moved on. `checkpoint()` can
+      // still rescue it, since it archives the database rather than the
+      // buffer, but a caller has to know that, and nothing would have warned
+      // it. Worse, that state is reachable from a single transient failure: a
+      // flush that fails leaves the buffer intact by design, and a caller that
+      // keeps writing walks straight into it.
+      //
+      // Refusing here instead turns an unrecoverable flush into a recoverable
+      // execute. Nothing has run, so the refusal costs only the statement.
+      assertStatementWithinLimit(sql)
+      const lineBytes = walLineBytes(sql)
+      if (this.walBufferBytes + lineBytes > LIMITS.MAX_WAL_SEGMENT_BYTES) {
+        throw new DurableLimitExceededError(
+          `durable: this statement would take the unflushed buffer to ` +
+            `${this.walBufferBytes + lineBytes} bytes, over the ${LIMITS.MAX_WAL_SEGMENT_BYTES}-byte ` +
+            `WAL segment limit; flush() or checkpoint() first`,
+          { limit: LIMITS.MAX_WAL_SEGMENT_BYTES, actual: this.walBufferBytes + lineBytes },
+        )
+      }
+
+      await this.engine.run(sql)
+      this.walBuffer.push(sql)
+      this.walBufferBytes += lineBytes
+      this.statementCounter++
+      return { statement: this.statementCounter }
+    })
+  }
+
+  /**
+   * Publish the buffered statements as one immutable WAL segment and commit
+   * the reference. Returns the published reference, or `undefined` when there
+   * was nothing buffered.
+   */
+  async flush(): Promise<DurableObjectRef | undefined> {
+    return this.ops.run(() => this.flushLocked())
+  }
+
+  /**
+   * Durability barrier for one ticket. Returns immediately if that statement
+   * is already committed, which is what makes concurrent callers coalesce onto
+   * a single head write: the first through the queue publishes the segment
+   * covering all of them, and the rest find their watermark already met.
+   */
+  async flushThrough(ticket: WriteTicket): Promise<void> {
+    if (ticket.statement <= this.committedStatementCount) return
+    await this.ops.run(async () => {
+      if (ticket.statement <= this.committedStatementCount) return
+      await this.flushLocked()
+    })
+  }
+
+  /**
+   * Replace the base with a full backup of the current local database and
+   * clear the WAL list.
+   *
+   * Holds the operation queue for its whole duration, so nothing new is
+   * executed into a database that is being archived. Heartbeat is unaffected —
+   * it contends only for the head lock, which this takes just for the final
+   * commit.
+   */
+  async checkpoint(): Promise<DurableObjectRef> {
+    return this.ops.run(() => this.checkpointLocked())
+  }
+
+  /**
+   * Drain, flush, release the lease, then release local resources.
+   *
+   * Local cleanup happens whether or not the remote steps worked, and a remote
+   * failure is still thrown. A close that swallowed a failed flush would be
+   * reporting a durability barrier it did not reach.
+   */
+  async close(): Promise<void> {
+    if (!this.closing) this.closing = this.closeInner()
+    return this.closing
+  }
+
+  // ------------------------------------------------------------ open sequence
+
+  static async open(deps: DurableObjectDeps, options: DurableOpenOptions = {}): Promise<DurableObject> {
+    const tuning: DurableTuning = { ...DEFAULT_TUNING, ...options.tuning }
+    if (tuning.heartbeatIntervalMs > tuning.leaseTtlMs / 3) {
+      throw new RangeError(
+        `durable: heartbeatIntervalMs (${tuning.heartbeatIntervalMs}) must be at most a third of ` +
+          `leaseTtlMs (${tuning.leaseTtlMs}); the contract requires room for a retry before expiry`,
+      )
+    }
+    const readOnly = options.readOnly === true
+    const owner = options.owner ?? `chdb-node-${process.pid}`
+    const instance = randomUUID()
+
+    const engine = await deps.engineFactory()
+    let scratch: Scratch | undefined
+    let leaseTaken: { head: DurableHead; etag: string; raw: Record<string, unknown> } | undefined
+    let started = false
+
+    try {
+      // Compatibility is settled before anything is created or claimed: an
+      // object this engine cannot read should cost nothing but two strings.
+      const running: RunningEngine = {
+        version: await engine.version(),
+        // Optional until chdb-core exposes the generation itself; every
+        // release so far is the V1 baseline.
+        backupFormat: (await engine.backupFormat?.()) ?? BACKUP_FORMAT_BASELINE,
+      }
+      const existing = await readHead(deps.backend)
+
+      if (existing) {
+        assertReadable(existing.head)
+        assertEngineCompatible(existing.head, running)
+        if (!readOnly) assertWritable(existing.head)
+      } else if (readOnly || options.existingOnly) {
+        throw new DurableNotFoundError(
+          `durable: object ${deps.id} does not exist at ${deps.backend.describe}`,
+        )
+      }
+
+      if (readOnly) {
+        // No lease, no heartbeat: the manifest read here is the snapshot this
+        // handle serves for its whole life. Immutable references make that
+        // safe even while a writer keeps committing.
+        const snap = existing as NonNullable<typeof existing>
+        scratch = await makeScratch(options.scratchRoot)
+        await engine.start({ dataPath: scratch.data, backupsAllowedPath: scratch.backups })
+        started = true
+        await restoreInto(engine, deps.backend, snap.head, scratch, running, options.onRestoreProgress)
+        return new DurableObject({
+          id: deps.id,
+          backend: deps.backend,
+          engine,
+          scratch,
+          tuning,
+          readOnly: true,
+          instance,
+          owner,
+          running,
+          head: snap.head,
+          etag: snap.etag,
+          raw: snap.raw,
+        })
+      }
+
+      leaseTaken = existing
+        ? await acquireLease(deps.backend, existing, { instance, owner, tuning, force: options.force === true })
+        : await createCold(deps.backend, {
+            database: options.database ?? 'default',
+            running,
+            instance,
+            owner,
+            tuning,
+            id: deps.id,
+          })
+
+      scratch = await makeScratch(options.scratchRoot)
+      await engine.start({ dataPath: scratch.data, backupsAllowedPath: scratch.backups })
+      started = true
+
+      await restoreInto(engine, deps.backend, leaseTaken.head, scratch, running, options.onRestoreProgress)
+
+      const object = new DurableObject({
+        id: deps.id,
+        backend: deps.backend,
+        engine,
+        scratch,
+        tuning,
+        readOnly: false,
+        instance,
+        owner,
+        running,
+        head: leaseTaken.head,
+        etag: leaseTaken.etag,
+        raw: leaseTaken.raw,
+      })
+      object.leaseDeadlineMs = nowMs() + tuning.leaseTtlMs
+
+      // Restore can outlast a lease. Confirming ownership before the handle
+      // escapes is what stops a writer from starting work on a database
+      // someone else has already taken over (contract §5.2 step 7).
+      await object.renewLease()
+      object.startHeartbeat()
+      leaseTaken = undefined
+      return object
+    } catch (e) {
+      // Unwind in the reverse order of acquisition, and never let a cleanup
+      // failure mask the error that caused it.
+      // close() has to tolerate a failed start: the engine may hold a
+      // connection, or nothing at all, and the caller cannot tell which.
+      void started
+      await engine.close().catch(() => {})
+      if (leaseTaken) {
+        await releaseLease(deps.backend, leaseTaken, instance).catch(() => {})
+      }
+      if (scratch) await rm(scratch.root, { recursive: true, force: true }).catch(() => {})
+      throw e
+    }
+  }
+
+  // ------------------------------------------------------------ internal work
+
+  private assertUsable(): void {
+    if (this.status === 'closed') {
+      throw new DurableClosedError(`durable: object ${this.id} is closed`)
+    }
+    if (this.fenced) {
+      throw new DurableLeaseFencedError(
+        `durable: object ${this.id} lost its lease (generation ${this.generation}); this handle cannot be used again`,
+      )
+    }
+  }
+
+  private assertWriter(): void {
+    this.assertUsable()
+    if (this.readOnly) {
+      throw new DurableClassificationRefusedError(
+        `durable: object ${this.id} is open read-only; only READ_ONLY statements are accepted`,
+      )
+    }
+    if (nowMs() >= this.leaseDeadlineMs) {
+      // Self-fence. The lease may in fact still be ours, but we cannot show
+      // it, and "probably still the writer" is not a state to write from.
+      this.fence()
+      throw new DurableLeaseFencedError(
+        `durable: object ${this.id} could not confirm its lease before it lapsed; the writer has fenced itself`,
+      )
+    }
+  }
+
+  private fence(): void {
+    this.fenced = true
+    this.stopHeartbeat()
+  }
+
+  private async flushLocked(): Promise<DurableObjectRef | undefined> {
+    this.assertWriter()
+    if (this.walBuffer.length === 0) return undefined
+
+    const statements = [...this.walBuffer]
+    const bytes = encodeWalSegment(statements)
+    const digest = digestOf(bytes)
+    const key = walKey(this.generation, this.head.manifest.seq + 1)
+    const ref: DurableObjectRef = { key, size: digest.size, sha256: digest.sha256 }
+
+    await this.publishBytes(ref, bytes)
+    await this.commitHead({
+      build: (current) => ({
+        ...current,
+        manifest: {
+          ...current.manifest,
+          wal: [...current.manifest.wal, ref],
+          seq: current.manifest.seq + 1,
+        },
+      }),
+      committed: (observed) => observed.manifest.wal.some((w) => w.key === key),
+      key,
+    })
+
+    this.walBuffer.splice(0, statements.length)
+    this.walBufferBytes = this.walBuffer.reduce((n, s) => n + walLineBytes(s), 0)
+    this.committedStatementCount += statements.length
+    this.lastFlushAtMs = nowMs()
+    return ref
+  }
+
+  private async checkpointLocked(): Promise<DurableObjectRef> {
+    this.assertWriter()
+
+    const archive = join(this.scratch.backups, `checkpoint-${Date.now().toString(36)}-${uuid8()}.tar.gz`)
+    try {
+      await this.engine.backupDatabase(this.database, archive)
+    } catch (e) {
+      await unlink(archive).catch(() => {})
+      throw e instanceof DurableEngineError
+        ? e
+        : new DurableEngineError(`durable: backup of ${JSON.stringify(this.database)} failed`, { cause: e })
+    }
+
+    try {
+      const digest = await digestFile(archive)
+      const key = checkpointKey(this.generation, this.head.manifest.seq + 1)
+      const ref: DurableObjectRef = { key, size: digest.size, sha256: digest.sha256 }
+
+      await this.publishFile(ref, archive)
+      const covered = this.walBuffer.length
+      await this.commitHead({
+        build: (current) => ({
+          ...current,
+          manifest: { ...current.manifest, base: ref, wal: [], seq: current.manifest.seq + 1 },
+        }),
+        committed: (observed) => observed.manifest.base?.key === key,
+        key,
+      })
+
+      // Only now. Until the head names this base, the old base plus the old
+      // WAL is still the authoritative state, and these statements are only
+      // recoverable from the buffer.
+      this.walBuffer.splice(0, covered)
+      this.walBufferBytes = this.walBuffer.reduce((n, s) => n + walLineBytes(s), 0)
+      this.committedStatementCount += covered
+      this.lastCheckpointAtMs = nowMs()
+      return ref
+    } finally {
+      await unlink(archive).catch(() => {})
+    }
+  }
+
+  private async closeInner(): Promise<void> {
+    this.status = 'closing'
+    this.stopHeartbeat()
+    await this.ops.sealAndDrain(() => new DurableClosedError(`durable: object ${this.id} is closing`))
+
+    let failure: unknown
+    try {
+      if (!this.readOnly && !this.fenced) {
+        await this.ops.runSealed(async () => {
+          if (this.walBuffer.length > 0) await this.flushLocked()
+          await this.releaseLeaseLocked()
+        })
+      }
+    } catch (e) {
+      failure = e
+    }
+
+    // Native connection and scratch go back whatever happened above: a remote
+    // failure is a durability problem, not a reason to leak a connection or a
+    // temp tree.
+    try {
+      await this.engine.close()
+    } catch (e) {
+      failure ??= e
+    }
+    try {
+      await rm(this.scratch.root, { recursive: true, force: true })
+    } catch (e) {
+      failure ??= e
+    }
+    this.status = 'closed'
+    if (failure) throw failure
+  }
+
+  private async releaseLeaseLocked(): Promise<void> {
+    await this.commitHead({
+      build: (current) => ({
+        ...current,
+        lease: { generation: current.lease.generation, owner: null, instance: null, expires_at: null },
+      }),
+      committed: (observed) => observed.lease.instance === null,
+      key: HEAD_KEY,
+      // Releasing is the last thing this instance does; after it succeeds the
+      // ownership check would fail by construction.
+      skipOwnershipAfter: true,
+    })
+    this.fenced = false
+    this.leaseDeadlineMs = 0
+  }
+
+  // ----------------------------------------------------------------- lease
+
+  private startHeartbeat(): void {
+    if (this.readOnly) return
+    this.heartbeatTimer = setInterval(() => {
+      void this.renewLease().catch(() => {
+        // Failure is not fatal on its own — the next attempt may succeed. What
+        // is fatal is reaching the locally believed expiry without a
+        // confirmation, and assertWriter() checks exactly that.
+      })
+    }, this.tuning.heartbeatIntervalMs)
+    this.heartbeatTimer.unref?.()
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = undefined
+    }
+  }
+
+  /** One heartbeat: extend the expiry, leaving generation and seq untouched. */
+  private async renewLease(): Promise<void> {
+    if (this.readOnly || this.fenced || this.status === 'closed') return
+    const expiresAt = (nowMs() + this.tuning.leaseTtlMs) / 1000
+    await this.commitHead({
+      build: (current) => ({ ...current, lease: { ...current.lease, expires_at: expiresAt } }),
+      committed: (observed) =>
+        observed.lease.instance === this.instance &&
+        observed.lease.expires_at !== null &&
+        observed.lease.expires_at >= expiresAt,
+      key: HEAD_KEY,
+    })
+    this.leaseDeadlineMs = nowMs() + this.tuning.leaseTtlMs
+  }
+
+  // ------------------------------------------------------- immutable publish
+
+  private async publishBytes(ref: DurableObjectRef, bytes: Uint8Array): Promise<void> {
+    const outcome = await this.backend.putBytesIfAbsent(ref.key, bytes)
+    if (outcome === 'created') return
+    await this.reconcileUpload(ref, outcome)
+  }
+
+  private async publishFile(ref: DurableObjectRef, localPath: string): Promise<void> {
+    const outcome = await this.backend.putFileIfAbsent(ref.key, localPath)
+    if (outcome === 'created') return
+    await this.reconcileUpload(ref, outcome)
+  }
+
+  /**
+   * Settle an upload that did not cleanly create (contract §5.8).
+   *
+   * The key is unique to this attempt, so "already exists" can only mean an
+   * earlier try by this same writer landed. Re-reading and comparing the
+   * digest is what turns a lost response into a fact: matching bytes are the
+   * bytes we meant to publish, different bytes are corruption, and an absent
+   * object means the write genuinely did not happen and can be retried
+   * against the same conditional create.
+   */
+  private async reconcileUpload(ref: DurableObjectRef, outcome: 'already-exists' | 'ambiguous'): Promise<void> {
+    const stream = await this.backend.openReadStream(ref.key)
+    if (!stream) {
+      if (outcome === 'already-exists') {
+        throw new DurableCorruptError(
+          `durable: ${ref.key} was reported as existing but cannot be read from ${this.backend.describe}`,
+        )
+      }
+      throw new DurableCommitAmbiguousError(
+        `durable: could not determine whether ${ref.key} was uploaded to ${this.backend.describe}`,
+        { key: ref.key },
+      )
+    }
+    const counter = digestingStream()
+    await pipeline(stream, counter, async function* (source) {
+      for await (const _chunk of source) void _chunk
+    })
+    assertDigest(ref, counter.digest(), 'published object')
+  }
+
+  // ------------------------------------------------------------- head commit
+
+  /**
+   * The single path through which this object writes `head.json`.
+   *
+   * Every caller supplies two things: how to build the next head from whatever
+   * the current one turns out to be, and how to recognise its own intent in a
+   * head it did not write. The second is what makes a lost response
+   * recoverable — after re-reading, either the intent is visible and this
+   * committed, or ownership is gone and this is fenced, or neither is true and
+   * it can try again inside the deadline.
+   */
+  private async commitHead(params: {
+    build: (current: DurableHead) => DurableHead
+    committed: (observed: DurableHead) => boolean
+    key: string
+    skipOwnershipAfter?: boolean
+  }): Promise<void> {
+    await this.headLock.run(async () => {
+      const deadline = nowMs() + this.tuning.commitDeadlineMs
+      let attempts = 0
+
+      let sawAmbiguous = false
+
+      for (;;) {
+        attempts++
+        const candidate = this.raiseCompatibilityFloor(params.build(this.head))
+        const outcome = await this.backend.replaceIfMatch(
+          HEAD_KEY,
+          serializeHead(candidate, this.raw),
+          this.etag,
+        )
+
+        if (outcome.status === 'replaced') {
+          this.adopt(candidate, outcome.etag)
+          return
+        }
+
+        if (outcome.status === 'ambiguous') sawAmbiguous = true
+
+        // Either someone else wrote (`not-replaced`) or the answer was lost
+        // (`ambiguous`). Both are settled the same way: look at what is
+        // actually there.
+        const fresh = await readHead(this.backend)
+        if (!fresh) {
+          throw new DurableCorruptError(
+            `durable: ${HEAD_KEY} disappeared from ${this.backend.describe} while committing`,
+          )
+        }
+
+        const stillOurs =
+          fresh.head.lease.instance === this.instance &&
+          fresh.head.lease.generation === this.head.lease.generation
+
+        if (params.committed(fresh.head) && (stillOurs || params.skipOwnershipAfter)) {
+          this.adopt(fresh.head, fresh.etag, fresh.raw)
+          return
+        }
+
+        if (!stillOurs) {
+          this.fence()
+          throw new DurableLeaseFencedError(
+            `durable: object ${this.id} was taken over (generation ${fresh.head.lease.generation}); ` +
+              `this writer can no longer commit`,
+          )
+        }
+
+        // Ownership intact and the intent is not there: our ETag was stale.
+        // Adopt the current one and retry within the deadline.
+        this.adopt(fresh.head, fresh.etag, fresh.raw)
+
+        if (attempts >= this.tuning.maxCommitAttempts || nowMs() >= deadline) {
+          // Two different answers, and the caller acts on them differently.
+          // If every attempt came back as a definite refusal, the commit
+          // provably did not happen and retrying later is safe. If any attempt
+          // was ambiguous, it may have landed, and a blind retry could publish
+          // twice.
+          if (sawAmbiguous) {
+            throw new DurableCommitAmbiguousError(
+              `durable: gave up committing ${params.key} after ${attempts} attempts without ` +
+                `proving the outcome`,
+              { key: params.key },
+            )
+          }
+          throw new DurableTimeoutError(
+            `durable: could not commit ${params.key} within ${this.tuning.commitDeadlineMs}ms ` +
+              `(${attempts} attempts, each definitively refused); nothing was committed`,
+          )
+        }
+      }
+    })
+  }
+
+  /**
+   * Record this engine's compatibility requirements on every head write,
+   * without ever relaxing what is already stored.
+   *
+   * The protocol says a writer must not lower either requirement. Taking the
+   * maximum rather than overwriting is what enforces that: an object whose
+   * base was produced by a newer engine keeps demanding that engine even if an
+   * older one somehow reaches a write, instead of quietly advertising itself
+   * as readable by a build that cannot restore it.
+   */
+  private raiseCompatibilityFloor(head: DurableHead): DurableHead {
+    return {
+      ...head,
+      engine: {
+        ...head.engine,
+        version: this.running.version,
+        backup_format: Math.max(head.engine.backup_format, this.running.backupFormat),
+        min_reader: maxEngineVersion(head.engine.min_reader, this.running.version),
+      },
+    }
+  }
+
+  private adopt(head: DurableHead, etag: string, raw?: Record<string, unknown>): void {
+    this.head = head
+    this.etag = etag
+    if (raw) this.raw = raw
+    else this.raw = JSON.parse(Buffer.from(serializeHead(head, this.raw)).toString('utf8'))
+  }
+}
+
+// ------------------------------------------------------------------ helpers
+
+async function makeScratch(root?: string): Promise<Scratch> {
+  const base = await mkdtemp(join(root ?? tmpdir(), 'chdb-durable-'))
+  const scratch: Scratch = {
+    root: base,
+    data: join(base, 'data'),
+    backups: join(base, 'backups'),
+    staging: join(base, 'staging'),
+  }
+  // The engine validates that a backup target's parent directory exists, and
+  // its allowed-path guard resolves relative paths somewhere nobody wants, so
+  // all three are created up front and always absolute.
+  await mkdir(scratch.data, { recursive: true })
+  await mkdir(scratch.backups, { recursive: true })
+  await mkdir(scratch.staging, { recursive: true })
+  return scratch
+}
+
+async function readHead(
+  backend: DurableBackend,
+): Promise<{ head: DurableHead; etag: string; raw: Record<string, unknown> } | undefined> {
+  const got = await backend.getBytesWithEtag(HEAD_KEY)
+  if (!got) return undefined
+  const { head, raw } = parseHead(got.bytes)
+  return { head, etag: got.etag, raw }
+}
+
+/**
+ * Restore the manifest's state into the scratch engine: base, then WAL in
+ * order. Both are verified against length and SHA-256 before use, and a
+ * missing or mismatched object stops the open rather than yielding a
+ * partially recovered database (contract §4.5).
+ */
+async function restoreInto(
+  engine: EngineAdapter,
+  backend: DurableBackend,
+  head: DurableHead,
+  scratch: Scratch,
+  running: RunningEngine,
+  onProgress?: (progress: RestoreProgress) => void,
+): Promise<void> {
+  const db = head.manifest.db
+  const base = head.manifest.base
+  // A reporting callback is never allowed to break the recovery it reports on.
+  const report = (p: RestoreProgress): void => {
+    try {
+      onProgress?.(p)
+    } catch {
+      /* deliberately ignored */
+    }
+  }
+
+  if (base === null) {
+    report({ phase: 'creating-database', database: db })
+    await engine.createDatabase(db)
+  } else {
+    report({ phase: 'restoring-base', key: base.key, size: base.size })
+    const stream = await backend.openReadStream(base.key)
+    if (!stream) {
+      throw new DurableCorruptError(
+        `durable: manifest names base ${base.key}, which is not present at ${backend.describe}`,
+      )
+    }
+    const staged = join(scratch.staging, `base-${uuid8()}.part`)
+    const archive = join(scratch.backups, `base-${uuid8()}.tar.gz`)
+    await streamToVerifiedFile(stream, base, staged, archive, 'base checkpoint')
+    try {
+      await engine.restoreDatabase(db, archive)
+    } catch (e) {
+      // The gate already established that this engine is allowed to read the
+      // object, so a RESTORE that fails anyway means the compatibility promise
+      // was violated rather than that the engine hit an ordinary error. The
+      // distinction is the caller's next move: upgrade the engine, or report a
+      // core defect. Reporting it as a plain `engine` error hides both.
+      throw new DurableEngineIncompatibleError(
+        `durable: restoring base ${base.key} into ${JSON.stringify(db)} failed on chdb ` +
+          `${running.version}. The archive was produced by ${head.engine.version} and the object ` +
+          `declares min_reader ${head.engine.min_reader} at archive format ` +
+          `${head.engine.backup_format}, so this restore was expected to be supported`,
+        { cause: e, expected: head.engine.version, actual: running.version },
+      )
+    }
+    await unlink(archive).catch(() => {})
+  }
+
+  await engine.useDatabase(db)
+
+  let replayed = 0
+  for (const [i, ref] of head.manifest.wal.entries()) {
+    report({
+      phase: 'replaying-wal',
+      segment: i + 1,
+      segments: head.manifest.wal.length,
+      statements: replayed,
+      key: ref.key,
+    })
+    const bytes = await backend.getBytes(ref.key)
+    if (!bytes) {
+      throw new DurableCorruptError(
+        `durable: manifest names WAL segment ${ref.key}, which is not present at ${backend.describe}`,
+      )
+    }
+    assertDigest(ref, digestOf(bytes), 'WAL segment')
+    for (const sql of decodeWalSegment(bytes, ref.key)) {
+      // Replay goes straight to the engine. Routing it back through the public
+      // execute() would re-analyse statements core already accepted and, worse,
+      // append every one of them to the WAL a second time.
+      await engine.run(sql)
+      replayed++
+    }
+  }
+  report({ phase: 'ready', statementsReplayed: replayed })
+}
+
+/** Atomically create a cold object and take generation 1 in the same write. */
+async function createCold(
+  backend: DurableBackend,
+  params: {
+    database: string
+    running: RunningEngine
+    instance: string
+    owner: string
+    tuning: DurableTuning
+    id: string
+  },
+): Promise<{ head: DurableHead; etag: string; raw: Record<string, unknown> }> {
+  const head = coldHead(params.database, params.running.version, params.running.backupFormat)
+  head.lease = {
+    generation: 1,
+    owner: params.owner,
+    instance: params.instance,
+    expires_at: (nowMs() + params.tuning.leaseTtlMs) / 1000,
+  }
+  const outcome = await backend.putBytesIfAbsent(HEAD_KEY, serializeHead(head))
+
+  if (outcome === 'created') {
+    const fresh = await readHead(backend)
+    if (!fresh) {
+      throw new DurableCorruptError(
+        `durable: created ${HEAD_KEY} at ${backend.describe} but it cannot be read back`,
+      )
+    }
+    return fresh
+  }
+
+  // Lost the race, or the response was lost. Either way the answer is in the
+  // object: if the head that is there names this instance, the create landed.
+  const fresh = await readHead(backend)
+  if (!fresh) {
+    throw new DurableCommitAmbiguousError(
+      `durable: could not determine whether object ${params.id} was created at ${backend.describe}`,
+      { key: HEAD_KEY },
+    )
+  }
+  if (fresh.head.lease.instance === params.instance) return fresh
+
+  assertReadable(fresh.head)
+  assertEngineCompatible(fresh.head, params.running)
+  assertWritable(fresh.head)
+  return acquireLease(backend, fresh, {
+    instance: params.instance,
+    owner: params.owner,
+    tuning: params.tuning,
+    force: false,
+  })
+}
+
+/**
+ * Take the writer lease by compare-and-swap.
+ *
+ * An unheld lease is free. A held one is only takeable once its recorded
+ * expiry is behind us by more than the clock-skew allowance — the allowance is
+ * there because the two writers' clocks are not the same clock, and a lease
+ * that looks expired by a second might not be. Taking a lease that has not
+ * expired is possible, but only as an explicit `force`, never as a retry.
+ */
+async function acquireLease(
+  backend: DurableBackend,
+  start: { head: DurableHead; etag: string; raw: Record<string, unknown> },
+  params: { instance: string; owner: string; tuning: DurableTuning; force: boolean },
+): Promise<{ head: DurableHead; etag: string; raw: Record<string, unknown> }> {
+  let current = start
+  const deadline = nowMs() + params.tuning.commitDeadlineMs
+
+  for (let attempt = 1; ; attempt++) {
+    const lease = current.head.lease
+    if (lease.owner !== null && !params.force) {
+      const expiresAtMs = (lease.expires_at ?? 0) * 1000
+      const takeableAtMs = expiresAtMs + params.tuning.clockSkewAllowanceMs
+      if (nowMs() < takeableAtMs) {
+        throw new DurableLeaseHeldError(
+          `durable: ${JSON.stringify(lease.owner)} holds the writer lease (generation ${lease.generation})`,
+          { owner: lease.owner, expiresInSeconds: (expiresAtMs - nowMs()) / 1000 },
+        )
+      }
+    }
+
+    const generation = lease.generation + 1
+    const candidate: DurableHead = {
+      ...current.head,
+      lease: {
+        generation,
+        owner: params.owner,
+        instance: params.instance,
+        expires_at: (nowMs() + params.tuning.leaseTtlMs) / 1000,
+      },
+    }
+    const outcome = await backend.replaceIfMatch(
+      HEAD_KEY,
+      serializeHead(candidate, current.raw),
+      current.etag,
+    )
+    if (outcome.status === 'replaced') {
+      return { head: candidate, etag: outcome.etag, raw: current.raw }
+    }
+
+    const fresh = await readHead(backend)
+    if (!fresh) {
+      throw new DurableCorruptError(
+        `durable: ${HEAD_KEY} disappeared from ${backend.describe} while taking the lease`,
+      )
+    }
+    if (fresh.head.lease.instance === params.instance) return fresh
+
+    if (attempt >= params.tuning.maxCommitAttempts || nowMs() >= deadline) {
+      throw new DurableLeaseHeldError(
+        `durable: could not take the writer lease after ${attempt} attempts; ` +
+          `generation is now ${fresh.head.lease.generation}`,
+        fresh.head.lease.owner !== null ? { owner: fresh.head.lease.owner } : undefined,
+      )
+    }
+    current = fresh
+  }
+}
+
+/** Best-effort lease release used when an open fails part-way through. */
+async function releaseLease(
+  backend: DurableBackend,
+  held: { head: DurableHead; etag: string; raw: Record<string, unknown> },
+  instance: string,
+): Promise<void> {
+  const fresh = await readHead(backend)
+  if (!fresh || fresh.head.lease.instance !== instance) return
+  const candidate: DurableHead = {
+    ...fresh.head,
+    lease: { generation: fresh.head.lease.generation, owner: null, instance: null, expires_at: null },
+  }
+  await backend.replaceIfMatch(HEAD_KEY, serializeHead(candidate, fresh.raw), fresh.etag)
+}

--- a/src/durable/object.ts
+++ b/src/durable/object.ts
@@ -496,6 +496,18 @@ export class DurableObject {
 
   static async open(deps: DurableObjectDeps, options: DurableOpenOptions = {}): Promise<DurableObject> {
     const tuning: DurableTuning = { ...DEFAULT_TUNING, ...options.tuning }
+    // Every one of these ends up in arithmetic that decides whether this
+    // process still owns the object. A NaN TTL propagates to `expires_at`,
+    // which JSON renders as null, producing a lease with an owner and no
+    // expiry: nobody can take it over and this writer never self-fences,
+    // because every comparison against NaN is false.
+    for (const [name, value] of Object.entries(tuning)) {
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new RangeError(
+          `durable: tuning.${name} must be a finite positive number, got ${String(value)}`,
+        )
+      }
+    }
     if (tuning.heartbeatIntervalMs > tuning.leaseTtlMs / 3) {
       throw new RangeError(
         `durable: heartbeatIntervalMs (${tuning.heartbeatIntervalMs}) must be at most a third of ` +
@@ -588,7 +600,10 @@ export class DurableObject {
         etag: leaseTaken.etag,
         raw: leaseTaken.raw,
       })
-      object.leaseDeadlineMs = nowMs() + tuning.leaseTtlMs
+      object.leaseDeadlineMs = Math.min(
+        (leaseTaken.head.lease.expires_at ?? 0) * 1000,
+        nowMs() + tuning.leaseTtlMs,
+      )
 
       // Restore can outlast a lease. Confirming ownership before the handle
       // escapes is what stops a writer from starting work on a database
@@ -658,6 +673,10 @@ export class DurableObject {
     const ref: DurableObjectRef = { key, size: digest.size, sha256: digest.sha256 }
 
     await this.publishBytes(ref, bytes)
+    // The upload is network I/O and can outlast the lease. Checking only at
+    // entry would let a writer that was required to self-fence mid-upload go
+    // on to commit the manifest anyway.
+    this.assertWriter()
     await this.commitHead({
       build: (current) => ({
         ...current,
@@ -697,6 +716,10 @@ export class DurableObject {
       const ref: DurableObjectRef = { key, size: digest.size, sha256: digest.sha256 }
 
       await this.publishFile(ref, archive)
+      // A full backup plus its upload is the longest thing this object does,
+      // easily longer than a lease TTL. Ownership was checked before it
+      // started; it has to hold now, when the commit actually happens.
+      this.assertWriter()
       const covered = this.walBuffer.length
       await this.commitHead({
         build: (current) => ({
@@ -794,16 +817,31 @@ export class DurableObject {
   /** One heartbeat: extend the expiry, leaving generation and seq untouched. */
   private async renewLease(): Promise<void> {
     if (this.readOnly || this.fenced || this.status === 'closed') return
-    const expiresAt = (nowMs() + this.tuning.leaseTtlMs) / 1000
+
+    // The expiry has to be computed inside the lock, not before waiting for
+    // it. Computed early and then delayed behind a long checkpoint commit,
+    // the value written could already be in the past — while the local
+    // deadline below was refreshed from the current clock. The object would
+    // then keep writing under a lease other writers are entitled to take.
+    let written = 0
     await this.commitHead({
-      build: (current) => ({ ...current, lease: { ...current.lease, expires_at: expiresAt } }),
+      build: (current) => {
+        written = (nowMs() + this.tuning.leaseTtlMs) / 1000
+        return { ...current, lease: { ...current.lease, expires_at: written } }
+      },
       committed: (observed) =>
         observed.lease.instance === this.instance &&
         observed.lease.expires_at !== null &&
-        observed.lease.expires_at >= expiresAt,
+        observed.lease.expires_at >= written,
       key: HEAD_KEY,
     })
-    this.leaseDeadlineMs = nowMs() + this.tuning.leaseTtlMs
+
+    // Believe what is actually stored, not what a fresh clock would allow.
+    // Reconciliation can settle on a head written by an earlier attempt whose
+    // expiry is older than this one's.
+    const persisted = this.head.lease.expires_at
+    this.leaseDeadlineMs =
+      persisted === null ? 0 : Math.min(persisted * 1000, nowMs() + this.tuning.leaseTtlMs)
   }
 
   // ------------------------------------------------------- immutable publish

--- a/src/durable/types.ts
+++ b/src/durable/types.ts
@@ -1,0 +1,127 @@
+/**
+ * The frozen wire types of Durable V1 (contract §4).
+ *
+ * Everything here is `[FROZEN]`: another binding has to be able to read what
+ * this one writes. The JSON is compared semantically, not byte for byte — key
+ * order and whitespace are free — but field names, types and meanings are not.
+ */
+
+/** Protocol baseline this build implements. Higher in a head means "do not open". */
+export const PROTOCOL_VERSION = 1
+
+/**
+ * V1 defines no non-empty feature names. Anything appearing in a head's
+ * feature lists is therefore from a future revision, and the negotiation rules
+ * (contract §4.3) apply: unknown reader feature refuses the open outright,
+ * unknown writer feature still permits a read-only open.
+ */
+export const KNOWN_READER_FEATURES: readonly string[] = []
+export const KNOWN_WRITER_FEATURES: readonly string[] = []
+
+/** Engine name recorded in `head.engine.name`. */
+export const ENGINE_NAME = 'chdb'
+
+/**
+ * Archive-format generation this build understands. V1's baseline is 1.
+ *
+ * It exists to be the one explicit signal that the backward-compatibility
+ * promise has been withdrawn: core increments it when a later release can no
+ * longer restore earlier full backups, and a reader refuses anything above its
+ * own baseline. Without it, a reader compares version numbers, sees a larger
+ * one, and walks into a RESTORE that fails halfway through recovery.
+ *
+ * The running engine's own value is not yet available — the C ABI exposes no
+ * accessor — so an adapter may report it through the optional
+ * `EngineAdapter.backupFormat()` and everything else falls back to this.
+ */
+export const BACKUP_FORMAT_BASELINE = 1
+
+export interface DurableProtocol {
+  version: number
+  reader_features: string[]
+  writer_features: string[]
+}
+
+export interface DurableEngineIdentity {
+  name: string
+  /**
+   * `chdb_version()` of the writer that last touched the object. Recorded for
+   * diagnosis and audit; it is explicitly **not** the compatibility gate.
+   */
+  version: string
+  /** Archive-format generation. A reader refuses anything above its baseline. */
+  backup_format: number
+  /**
+   * Oldest chdb release that may read the current state. A reader older than
+   * this is refused; anything at or above it opens.
+   */
+  min_reader: string
+}
+
+/**
+ * A reference to an immutable object. The size and digest are not decoration:
+ * base and WAL are verified against both before anything is restored or
+ * replayed, and they are what makes an ambiguous upload resolvable (§5.8).
+ */
+export interface DurableObjectRef {
+  /** Key relative to `<namespace>/<object-id>/`, `/`-separated, no leading slash. */
+  key: string
+  size: number
+  /** Lowercase full SHA-256 hex. */
+  sha256: string
+}
+
+/**
+ * Writer lease. A released lease is the all-null form — owner, instance and
+ * expiry absent while the generation stays, so the next acquirer knows what to
+ * increment past.
+ */
+export interface DurableLease {
+  generation: number
+  /** Human-visible name. Observability only; never an authority check. */
+  owner: string | null
+  /** Identifies one live instance. This, with the generation, is the fence. */
+  instance: string | null
+  /** Epoch seconds, fractional allowed. */
+  expires_at: number | null
+}
+
+export interface DurableManifest {
+  /** The one database this object holds. */
+  db: string
+  base: DurableObjectRef | null
+  /** Ordered by replay order. */
+  wal: DurableObjectRef[]
+  seq: number
+}
+
+/**
+ * The typed view of `head.json`. Unknown fields are not represented here —
+ * they are preserved separately by {@link ParsedHead}, because dropping them
+ * would silently strip a future revision's state (contract §4.2, §4.3).
+ */
+export interface DurableHead {
+  protocol: DurableProtocol
+  engine: DurableEngineIdentity
+  lease: DurableLease
+  manifest: DurableManifest
+}
+
+/** A head as read from the backend: the typed view plus its CAS token. */
+export interface HeadSnapshot {
+  head: DurableHead
+  /** Opaque backend CAS token. Never parsed, never assumed to be an MD5. */
+  etag: string
+  /** The raw parsed JSON, kept so unknown fields survive a write-back. */
+  raw: Record<string, unknown>
+}
+
+/** Frozen V1 limits (contract §4.4, §4.5). */
+export const LIMITS = {
+  /** One statement, UTF-8 bytes. */
+  MAX_SQL_BYTES: 64 * 1024 * 1024,
+  /** One uncompressed WAL segment, bytes. */
+  MAX_WAL_SEGMENT_BYTES: 128 * 1024 * 1024,
+  /** `head.json`, bytes. */
+  MAX_HEAD_BYTES: 1024 * 1024,
+} as const

--- a/src/durable/version.ts
+++ b/src/durable/version.ts
@@ -1,0 +1,130 @@
+/**
+ * chDB release precedence.
+ *
+ * The V1 engine gate compares versions, and the protocol is explicit that they
+ * are compared "by chDB release precedence, never as lexicographic strings".
+ * The difference is not academic: as strings, `"26.10.0" < "26.7.0"` and
+ * `"26.7.2-rc.2" > "26.7.2"`, both of which are backwards, and both of which
+ * would let a reader open an object it cannot actually restore.
+ *
+ * The ordering is semver's:
+ *
+ * ```text
+ *   26.7.2-rc.1  <  26.7.2-rc.2  <  26.7.2  <  26.7.3  <  26.8.1  <  27.0.0
+ * ```
+ *
+ * A pre-release sorts *below* the release it leads to, which is what makes an
+ * object written by `26.7.2-rc.2` readable by `26.7.2` and everything after it.
+ *
+ * chDB itself ships only two shapes, `X.Y.Z` and `X.Y.Z-rc.N`, and a patch
+ * number that has had a release candidate never gets a final release of the
+ * same number — after `26.7.2-rc.2` the next stable is `26.7.3`. So the
+ * `26.7.2-rc.2 < 26.7.2` case does not arise in practice. It is still ordered
+ * correctly, deliberately: an implementation that is more permissive than the
+ * convention costs nothing, while one that assumed the convention would be
+ * wrong the day it changed.
+ *
+ * That is also why the parser is semver-shaped rather than a two-branch match
+ * on those exact shapes. A future `26.7.2-beta.1` sorts correctly here; a
+ * tighter pattern would reject an object it could have opened safely, which is
+ * the wrong place to fail closed.
+ *
+ * Failing closed belongs where nothing can be concluded: a string that does not
+ * parse at all is refused rather than guessed at, because an unrecognised
+ * version is not evidence of compatibility, and treating it as one is how a
+ * reader restores an archive from a release nothing has tested it against.
+ */
+
+import { DurableEngineIncompatibleError } from './errors'
+
+export interface ParsedEngineVersion {
+  /** Numeric release components, e.g. `[26, 7, 2]`. At least one. */
+  release: number[]
+  /**
+   * Dot-separated pre-release identifiers, e.g. `['rc', 2]`. Absent for a final
+   * release, which sorts above every pre-release of the same numbers.
+   */
+  prerelease: (string | number)[] | undefined
+}
+
+// Numeric release, optional -prerelease, optional +build (parsed and ignored,
+// as semver requires: build metadata takes no part in precedence).
+const VERSION = /^(\d+(?:\.\d+)*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
+
+/** Parse a chDB version string, or `undefined` if it is not one. */
+export function parseEngineVersion(value: string): ParsedEngineVersion | undefined {
+  const m = VERSION.exec(value.trim())
+  if (!m) return undefined
+  const release = (m[1] as string).split('.').map(Number)
+  if (release.some((n) => !Number.isSafeInteger(n) || n < 0)) return undefined
+  const raw = m[2]
+  return {
+    release,
+    prerelease:
+      raw === undefined
+        ? undefined
+        : raw.split('.').map((id) => (/^\d+$/.test(id) ? Number(id) : id)),
+  }
+}
+
+function comparePrerelease(a: (string | number)[], b: (string | number)[]): number {
+  const n = Math.max(a.length, b.length)
+  for (let i = 0; i < n; i++) {
+    // A shorter identifier list sorts lower when all shared parts are equal:
+    // rc.1 comes before rc.1.1.
+    if (i >= a.length) return -1
+    if (i >= b.length) return 1
+    const x = a[i] as string | number
+    const y = b[i] as string | number
+    if (x === y) continue
+    const xNum = typeof x === 'number'
+    const yNum = typeof y === 'number'
+    // Numeric identifiers always sort below alphanumeric ones.
+    if (xNum && !yNum) return -1
+    if (!xNum && yNum) return 1
+    if (xNum && yNum) return (x as number) < (y as number) ? -1 : 1
+    return (x as string) < (y as string) ? -1 : 1
+  }
+  return 0
+}
+
+/**
+ * Compare two parsed versions: negative if `a` precedes `b`, zero if they are
+ * the same release, positive otherwise.
+ */
+export function comparePrecedence(a: ParsedEngineVersion, b: ParsedEngineVersion): number {
+  const n = Math.max(a.release.length, b.release.length)
+  for (let i = 0; i < n; i++) {
+    // A missing component is zero, so 26.7 and 26.7.0 are the same release.
+    const x = a.release[i] ?? 0
+    const y = b.release[i] ?? 0
+    if (x !== y) return x < y ? -1 : 1
+  }
+  if (a.prerelease === undefined && b.prerelease === undefined) return 0
+  // No pre-release outranks any pre-release of the same numbers.
+  if (a.prerelease === undefined) return 1
+  if (b.prerelease === undefined) return -1
+  return comparePrerelease(a.prerelease, b.prerelease)
+}
+
+/**
+ * Compare two version strings, refusing either one this code cannot parse.
+ * `what` names the comparison so the error says which value was the problem.
+ */
+export function compareEngineVersions(a: string, b: string): number {
+  const pa = parseEngineVersion(a)
+  const pb = parseEngineVersion(b)
+  if (!pa || !pb) {
+    const bad = !pa ? a : b
+    throw new DurableEngineIncompatibleError(
+      `durable: cannot order chdb version ${JSON.stringify(bad)} by release precedence, ` +
+        `so compatibility cannot be established; refusing rather than guessing`,
+    )
+  }
+  return comparePrecedence(pa, pb)
+}
+
+/** The later of two version strings, by precedence. */
+export function maxEngineVersion(a: string, b: string): string {
+  return compareEngineVersions(a, b) >= 0 ? a : b
+}

--- a/src/durable/wal.ts
+++ b/src/durable/wal.ts
@@ -111,6 +111,12 @@ export function decodeWalSegment(bytes: Uint8Array, key: string): string[] {
         `durable: WAL segment ${key} line ${i + 1} has no string "sql" field`,
       )
     }
+    // The per-statement ceiling is part of the frozen format, so it binds the
+    // reader as well. A conforming writer cannot produce a larger statement,
+    // and replaying one from a segment that somehow contains it would run SQL
+    // the limit exists to prevent — the segment ceiling alone leaves room for
+    // a single statement twice the allowed size.
+    assertStatementWithinLimit(sql)
     out.push(sql)
   }
   return out

--- a/src/durable/wal.ts
+++ b/src/durable/wal.ts
@@ -1,0 +1,117 @@
+/**
+ * WAL segment encoding and decoding (contract §4.4).
+ *
+ * The format is deliberately dull: UTF-8 JSONL, one `{"sql": "..."}` object
+ * per line, newline-terminated, replayed in manifest order then line order.
+ * Being dull is what lets four language bindings agree on it.
+ *
+ * Two limits are enforced on the write side and tolerated on the read side, as
+ * the contract requires: a reader must be able to load anything a conforming
+ * writer could have produced, so it only refuses what is over the *frozen*
+ * ceiling, never a lower local preference.
+ *
+ * What this file does not do is make statements deterministic. `now()`,
+ * `rand()` and reads of mutable external sources are replayed verbatim and
+ * will produce whatever they produce; V1 promises ordered replay of the
+ * original statement text and nothing more. Materialising those values before
+ * calling `execute()` is the caller's job.
+ */
+
+import { DurableCorruptError, DurableLimitExceededError } from './errors'
+import { LIMITS } from './types'
+
+/**
+ * Bytes this statement will occupy in a segment, counting its newline.
+ *
+ * Must stay exactly consistent with {@link encodeWalSegment}: it is what the
+ * object layer budgets against before executing, and a budget that disagrees
+ * with the encoder by even one byte per line puts the boundary in the wrong
+ * place. `encodeWalSegment` joins with `\n` and appends one, which comes to a
+ * newline per line, so the per-statement cost is additive and this can be
+ * summed. A test asserts the two agree.
+ */
+export function walLineBytes(sql: string): number {
+  return Buffer.byteLength(JSON.stringify({ sql }), 'utf8') + 1
+}
+
+/** Refuse a statement that could not be written into a conforming segment. */
+export function assertStatementWithinLimit(sql: string): void {
+  const bytes = Buffer.byteLength(sql, 'utf8')
+  if (bytes > LIMITS.MAX_SQL_BYTES) {
+    throw new DurableLimitExceededError(
+      `durable: statement is ${bytes} UTF-8 bytes, over the V1 per-statement limit of ${LIMITS.MAX_SQL_BYTES}`,
+      { limit: LIMITS.MAX_SQL_BYTES, actual: bytes },
+    )
+  }
+}
+
+/**
+ * Encode buffered statements into one segment. Throws `limit_exceeded` rather
+ * than splitting: a segment boundary is a commit boundary, so silently
+ * splitting would turn one caller-visible flush into two, and a crash between
+ * them would commit a prefix the caller was never told about.
+ */
+export function encodeWalSegment(statements: readonly string[]): Uint8Array {
+  const lines: string[] = []
+  for (const sql of statements) {
+    assertStatementWithinLimit(sql)
+    lines.push(JSON.stringify({ sql }))
+  }
+  const bytes = Buffer.from(lines.length === 0 ? '' : lines.join('\n') + '\n', 'utf8')
+  if (bytes.byteLength > LIMITS.MAX_WAL_SEGMENT_BYTES) {
+    throw new DurableLimitExceededError(
+      `durable: WAL segment would be ${bytes.byteLength} bytes, over the V1 limit of ` +
+        `${LIMITS.MAX_WAL_SEGMENT_BYTES}; flush more often`,
+      { limit: LIMITS.MAX_WAL_SEGMENT_BYTES, actual: bytes.byteLength },
+    )
+  }
+  return bytes
+}
+
+/**
+ * Decode a verified segment into its statements.
+ *
+ * Strict on every count the contract names: exactly one JSON object per line,
+ * a string `sql`, and a terminating newline. A tolerant reader here would be
+ * the worst kind of bug — it would skip a statement and hand back a database
+ * that looks fine and is missing a write.
+ */
+export function decodeWalSegment(bytes: Uint8Array, key: string): string[] {
+  if (bytes.byteLength > LIMITS.MAX_WAL_SEGMENT_BYTES) {
+    throw new DurableLimitExceededError(
+      `durable: WAL segment ${key} is ${bytes.byteLength} bytes, over the V1 limit of ${LIMITS.MAX_WAL_SEGMENT_BYTES}`,
+      { limit: LIMITS.MAX_WAL_SEGMENT_BYTES, actual: bytes.byteLength },
+    )
+  }
+  const text = Buffer.from(bytes).toString('utf8')
+  if (text.length === 0) return []
+  if (!text.endsWith('\n')) {
+    throw new DurableCorruptError(
+      `durable: WAL segment ${key} does not end with a newline; it may be truncated`,
+    )
+  }
+  const out: string[] = []
+  const lines = text.slice(0, -1).split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] as string
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch (e) {
+      throw new DurableCorruptError(`durable: WAL segment ${key} line ${i + 1} is not valid JSON`, {
+        cause: e,
+      })
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new DurableCorruptError(`durable: WAL segment ${key} line ${i + 1} is not a JSON object`)
+    }
+    const sql = (parsed as Record<string, unknown>)['sql']
+    if (typeof sql !== 'string') {
+      throw new DurableCorruptError(
+        `durable: WAL segment ${key} line ${i + 1} has no string "sql" field`,
+      )
+    }
+    out.push(sql)
+  }
+  return out
+}

--- a/src/libchdb/index.ts
+++ b/src/libchdb/index.ts
@@ -1,0 +1,155 @@
+/**
+ * `chdb/libchdb` — where the engine shared library is, and nothing else.
+ *
+ * This module resolves a filesystem path. It does not `require` the addon, it
+ * does not `dlopen` anything, and it has no side effects beyond reading the
+ * filesystem. That restraint is the whole point: the callers who need it are
+ * the ones who load `libchdb` themselves — a Bun `dlopen`, a `koffi` binding,
+ * a subprocess — and for them, pulling in `chdb_node.node` would mean two
+ * copies of an engine that binds one data path per process.
+ *
+ * Resolution order, most specific first:
+ *
+ *   1. `CHDB_LIBCHDB_PATH` — an explicit file. Overrides everything, and is
+ *      the intended way to point at a local `chdb-core` build.
+ *   2. `CHDB_LIBCHDB_DIR` — a directory to look inside.
+ *   3. The platform package `@chdb/lib-<platform>`, located through
+ *      `require.resolve` of its `package.json` so the addon is never executed.
+ *   4. The repository root, for a working copy that ran `npm run libchdb`.
+ *
+ * The library file is named `libchdb.so` on every platform this package
+ * publishes, macOS included — the platform packages copy it under that name
+ * rather than renaming per platform. `libchdb.dylib` is still accepted, since
+ * a locally built or hand-placed copy may use the platform-conventional name.
+ */
+
+import { existsSync, statSync } from 'fs'
+import { dirname, isAbsolute, join, resolve } from 'path'
+import { createRequire } from 'module'
+import { ChdbPlatformUnsupportedError } from '../errors'
+
+/** Names to look for inside a candidate directory, in order. */
+const LIBRARY_NAMES = ['libchdb.so', 'libchdb.dylib'] as const
+
+/** Same table as the native loader; kept here so this module imports nothing from it. */
+const PLATFORM_PACKAGES: Readonly<Record<string, string>> = {
+  'darwin-arm64': '@chdb/lib-darwin-arm64',
+  'darwin-x64': '@chdb/lib-darwin-x64',
+  'linux-x64': '@chdb/lib-linux-x64-gnu',
+  'linux-arm64': '@chdb/lib-linux-arm64-gnu',
+}
+
+export interface ResolveLibchdbOptions {
+  /** Search these directories before the built-in candidates. */
+  extraDirs?: readonly string[]
+  /** Read overrides from here instead of `process.env`. */
+  env?: NodeJS.ProcessEnv
+}
+
+export interface LibchdbLocation {
+  /** Absolute path to the shared library. */
+  path: string
+  /** Which rule produced it: useful in a startup log when a build looks wrong. */
+  source: 'env-file' | 'env-dir' | 'platform-package' | 'repository' | 'extra-dir'
+  /** The platform package it came from, when it came from one. */
+  packageName?: string
+}
+
+function firstLibraryIn(dir: string): string | undefined {
+  for (const name of LIBRARY_NAMES) {
+    const candidate = join(dir, name)
+    if (existsSync(candidate)) return candidate
+  }
+  return undefined
+}
+
+export function platformKey(): string {
+  return `${process.platform}-${process.arch}`
+}
+
+/**
+ * Locate the engine library, or throw a diagnostic listing everywhere that was
+ * tried. Callers that would rather branch than catch can use
+ * {@link tryResolveLibchdb}.
+ */
+export function resolveLibchdb(options: ResolveLibchdbOptions = {}): LibchdbLocation {
+  const env = options.env ?? process.env
+  const tried: string[] = []
+
+  const explicit = env['CHDB_LIBCHDB_PATH']
+  if (explicit) {
+    const path = resolve(explicit)
+    // An explicit override that is wrong is a configuration mistake, not a
+    // reason to quietly fall through to a different library than the operator
+    // asked for — that is how a process ends up running an engine nobody
+    // intended.
+    if (!existsSync(path) || !statSync(path).isFile()) {
+      throw new ChdbPlatformUnsupportedError(
+        `chdb: CHDB_LIBCHDB_PATH points at ${path}, which is not a file`,
+      )
+    }
+    return { path, source: 'env-file' }
+  }
+
+  const envDir = env['CHDB_LIBCHDB_DIR']
+  if (envDir) {
+    const found = firstLibraryIn(resolve(envDir))
+    if (found) return { path: found, source: 'env-dir' }
+    throw new ChdbPlatformUnsupportedError(
+      `chdb: CHDB_LIBCHDB_DIR is ${resolve(envDir)}, which contains none of ${LIBRARY_NAMES.join(', ')}`,
+    )
+  }
+
+  for (const dir of options.extraDirs ?? []) {
+    const abs = isAbsolute(dir) ? dir : resolve(dir)
+    const found = firstLibraryIn(abs)
+    if (found) return { path: found, source: 'extra-dir' }
+    tried.push(abs)
+  }
+
+  const key = platformKey()
+  const pkg = PLATFORM_PACKAGES[key]
+  if (pkg) {
+    try {
+      // Resolving package.json rather than the package entry point is what
+      // keeps this from executing `index.js`, which would load the addon.
+      const require_ = createRequire(__filename)
+      const manifest = require_.resolve(`${pkg}/package.json`)
+      const found = firstLibraryIn(dirname(manifest))
+      if (found) return { path: found, source: 'platform-package', packageName: pkg }
+      tried.push(`${pkg} (installed, but holds none of ${LIBRARY_NAMES.join(', ')})`)
+    } catch {
+      tried.push(`${pkg} (not installed)`)
+    }
+  }
+
+  // A working copy: `npm run libchdb` drops the library at the package root.
+  const repoRoot = resolve(__dirname, '..', '..')
+  const local = firstLibraryIn(repoRoot)
+  if (local) return { path: local, source: 'repository' }
+  tried.push(repoRoot)
+
+  const hint =
+    process.platform === 'win32'
+      ? 'Windows is not supported; use WSL2.'
+      : pkg
+        ? `Expected optional dependency ${pkg}, or set CHDB_LIBCHDB_PATH.`
+        : `Platform ${key} is not supported.`
+  throw new ChdbPlatformUnsupportedError(
+    `chdb: could not locate libchdb for ${key}. ${hint} Tried: ${tried.join('; ')}`,
+  )
+}
+
+/** {@link resolveLibchdb} without the throw. */
+export function tryResolveLibchdb(options: ResolveLibchdbOptions = {}): LibchdbLocation | undefined {
+  try {
+    return resolveLibchdb(options)
+  } catch {
+    return undefined
+  }
+}
+
+/** Just the path, for callers that only want to hand it to `dlopen`. */
+export function libchdbPath(options: ResolveLibchdbOptions = {}): string {
+  return resolveLibchdb(options).path
+}

--- a/test/durable/fakes.ts
+++ b/test/durable/fakes.ts
@@ -1,0 +1,248 @@
+/**
+ * Test doubles for the durable conformance suites.
+ *
+ * The backend under test is the real {@link LocalDurableBackend} — mocking it
+ * would mean the conditional-create and compare-and-swap paths, which are the
+ * only parts of a backend that can be subtly wrong, were never exercised.
+ * {@link FaultBackend} therefore *wraps* it rather than replacing it, so a
+ * fault scenario runs the real code right up to the injected failure.
+ *
+ * The engine is a fake, because the durable state machine's correctness does
+ * not depend on ClickHouse actually executing anything, and a real engine
+ * binds one data path per process. The real engine is covered separately by
+ * the Bun end-to-end suite.
+ */
+
+import { readFile, writeFile } from 'fs/promises'
+import type { DurableBackend, GetWithEtag, PutOutcome, ReplaceOutcome } from '../../src/durable/backend'
+import type { Readable } from 'stream'
+import {
+  QueryClass,
+  type EngineAdapter,
+  type EngineStartOptions,
+  type QueryAnalysis,
+} from '../../src/durable/engine-adapter'
+
+/**
+ * A stand-in for `chdb_classify_query_n`.
+ *
+ * Deliberately crude, and deliberately confined to test code: a prefix table
+ * like this is exactly what the contract forbids a binding from shipping,
+ * because it cannot see through inline `FORMAT` data or resolve an unqualified
+ * name against the session database. Here it only has to produce the analyses
+ * the scenarios need; the real classifier is exercised by the Bun suite.
+ */
+export function fakeAnalyze(sql: string, targetDatabase: string): QueryAnalysis {
+  const trimmed = sql.trim().replace(/;\s*$/, '')
+  const upper = trimmed.toUpperCase()
+  const statementCount = trimmed.length === 0 ? 0 : trimmed.split(';').filter((s) => s.trim()).length
+
+  let queryClass: QueryClass
+  if (/^(SELECT|SHOW|DESCRIBE|DESC|EXPLAIN|EXISTS|CHECK)\b/.test(upper)) {
+    queryClass = QueryClass.ReadOnly
+  } else if (/^(SET|USE|SYSTEM|BACKUP|RESTORE|ATTACH|DETACH|KILL)\b/.test(upper)) {
+    queryClass = QueryClass.Control
+  } else if (/^INSERT\s+INTO\s+FUNCTION\b/.test(upper) || /INTO OUTFILE/.test(upper)) {
+    queryClass = QueryClass.Control
+  } else if (/^CREATE\s+(FUNCTION|NAMED COLLECTION|USER|ROLE)\b/.test(upper) || /\bSYSTEM\./.test(upper)) {
+    queryClass = QueryClass.MutatingGlobal
+  } else if (/^(INSERT|CREATE|ALTER|DROP|TRUNCATE|RENAME|OPTIMIZE|UPDATE|DELETE|EXCHANGE)\b/.test(upper)) {
+    queryClass = QueryClass.Mutating
+  } else {
+    queryClass = QueryClass.Unknown
+  }
+
+  const changesDatabaseLifecycle = /^(CREATE|DROP|RENAME)\s+DATABASE\b/.test(upper)
+  const hasSecrets = /SECRET_ACCESS_KEY|IDENTIFIED WITH|PASSWORD/i.test(trimmed)
+  const foreignTarget = /\b([A-Za-z_][A-Za-z0-9_]*)\./.exec(trimmed)
+  const writesOnlyTargetDatabase =
+    queryClass === QueryClass.Unknown
+      ? false
+      : queryClass === QueryClass.ReadOnly
+        ? true
+        : !changesDatabaseLifecycle &&
+          queryClass === QueryClass.Mutating &&
+          (!foreignTarget || foreignTarget[1] === targetDatabase)
+
+  return {
+    statementCount: queryClass === QueryClass.Unknown && statementCount === 1 ? 0 : statementCount,
+    queryClass,
+    hasSecrets: queryClass === QueryClass.Unknown ? false : hasSecrets,
+    writesOnlyTargetDatabase,
+    changesDatabaseLifecycle,
+  }
+}
+
+/**
+ * An engine whose whole database is the ordered list of statements it has been
+ * given. A backup is that list on disk; a restore replaces it. That is enough
+ * to tell whether the state machine restored the right base, replayed the
+ * right WAL, and did it in the right order.
+ */
+export class FakeEngine implements EngineAdapter {
+  statements: string[] = []
+  versionString = '26.7.0'
+  currentDatabase: string | undefined
+  dataPath: string | undefined
+  started = false
+  closed = false
+
+  /** Set to make the next `run` throw, simulating a statement that fails locally. */
+  failNextRun: Error | undefined
+  /** Set to make every backup throw. */
+  backupFailure: Error | undefined
+  /** Set to make every restore throw. */
+  restoreFailure: Error | undefined
+  /** Override the analysis for a specific statement. */
+  analysisOverrides = new Map<string, QueryAnalysis>()
+
+  async version(): Promise<string> {
+    return this.versionString
+  }
+
+  async start(options: EngineStartOptions): Promise<void> {
+    this.dataPath = options.dataPath
+    this.started = true
+  }
+
+  async createDatabase(database: string): Promise<void> {
+    this.currentDatabase ??= database
+  }
+
+  async useDatabase(database: string): Promise<void> {
+    this.currentDatabase = database
+  }
+
+  async analyze(sql: string, targetDatabase: string): Promise<QueryAnalysis> {
+    return this.analysisOverrides.get(sql) ?? fakeAnalyze(sql, targetDatabase)
+  }
+
+  async query(sql: string, _format: string): Promise<string> {
+    return JSON.stringify({ sql, statements: this.statements.length })
+  }
+
+  async run(sql: string): Promise<void> {
+    if (this.failNextRun) {
+      const e = this.failNextRun
+      this.failNextRun = undefined
+      throw e
+    }
+    this.statements.push(sql)
+  }
+
+  async backupDatabase(_database: string, filePath: string): Promise<void> {
+    if (this.backupFailure) throw this.backupFailure
+    // Mirrors core: the target must not already exist.
+    await writeFile(filePath, JSON.stringify(this.statements), { flag: 'wx' })
+  }
+
+  async restoreDatabase(_database: string, filePath: string): Promise<void> {
+    if (this.restoreFailure) throw this.restoreFailure
+    const raw = await readFile(filePath, 'utf8')
+    this.statements = JSON.parse(raw) as string[]
+  }
+
+  async close(): Promise<void> {
+    this.closed = true
+  }
+}
+
+export type FaultPoint =
+  | { on: 'putBytes'; key?: RegExp; result: PutOutcome | 'throw' | 'write-then-ambiguous' | 'divergent-then-exists' }
+  | { on: 'putFile'; key?: RegExp; result: PutOutcome | 'throw' | 'write-then-ambiguous' }
+  | { on: 'replace'; result: 'not-replaced' | 'ambiguous' | 'throw' | 'commit-then-ambiguous' }
+
+/**
+ * Wraps a real backend and injects one scripted fault per queued entry.
+ *
+ * The `*-then-ambiguous` modes are the interesting ones and the reason this
+ * exists: they perform the underlying write for real and *then* report the
+ * response as lost. That is the failure the contract spends a whole section
+ * on, and it cannot be reproduced by a backend that simply refuses.
+ */
+export class FaultBackend implements DurableBackend {
+  readonly describe: string
+  private readonly inner: DurableBackend
+  private readonly queue: FaultPoint[] = []
+
+  constructor(inner: DurableBackend) {
+    this.inner = inner
+    this.describe = inner.describe
+  }
+
+  /** Queue one fault. Faults fire in the order queued, one call each. */
+  inject(fault: FaultPoint): this {
+    this.queue.push(fault)
+    return this
+  }
+
+  get pendingFaults(): number {
+    return this.queue.length
+  }
+
+  /** Generic on the discriminant so each caller gets its own variant back. */
+  private take<K extends FaultPoint['on']>(on: K, key?: string): Extract<FaultPoint, { on: K }> | undefined {
+    const i = this.queue.findIndex(
+      (f) => f.on === on && (!('key' in f) || !f.key || (key !== undefined && f.key.test(key))),
+    )
+    if (i === -1) return undefined
+    return this.queue.splice(i, 1)[0] as Extract<FaultPoint, { on: K }>
+  }
+
+  getBytes(key: string): Promise<Uint8Array | undefined> {
+    return this.inner.getBytes(key)
+  }
+
+  getBytesWithEtag(key: string): Promise<GetWithEtag | undefined> {
+    return this.inner.getBytesWithEtag(key)
+  }
+
+  openReadStream(key: string): Promise<Readable | undefined> {
+    return this.inner.openReadStream(key)
+  }
+
+  async putBytesIfAbsent(key: string, bytes: Uint8Array): Promise<PutOutcome> {
+    const fault = this.take('putBytes', key)
+    if (fault) {
+      if (fault.result === 'throw') throw new Error('injected: putBytesIfAbsent failed')
+      if (fault.result === 'write-then-ambiguous') {
+        await this.inner.putBytesIfAbsent(key, bytes)
+        return 'ambiguous'
+      }
+      if (fault.result === 'divergent-then-exists') {
+        // Something else is already at this key. Only the digest can tell.
+        await this.inner.putBytesIfAbsent(key, Buffer.from('{"sql":"not what we sent"}\n'))
+        return 'already-exists'
+      }
+      return fault.result
+    }
+    return this.inner.putBytesIfAbsent(key, bytes)
+  }
+
+  async putFileIfAbsent(key: string, localPath: string): Promise<PutOutcome> {
+    const fault = this.take('putFile', key)
+    if (fault) {
+      if (fault.result === 'throw') throw new Error('injected: putFileIfAbsent failed')
+      if (fault.result === 'write-then-ambiguous') {
+        await this.inner.putFileIfAbsent(key, localPath)
+        return 'ambiguous'
+      }
+      return fault.result
+    }
+    return this.inner.putFileIfAbsent(key, localPath)
+  }
+
+  async replaceIfMatch(key: string, bytes: Uint8Array, etag: string): Promise<ReplaceOutcome> {
+    const fault = this.take('replace')
+    if (fault) {
+      if (fault.result === 'throw') throw new Error('injected: replaceIfMatch failed')
+      if (fault.result === 'commit-then-ambiguous') {
+        await this.inner.replaceIfMatch(key, bytes, etag)
+        return { status: 'ambiguous' }
+      }
+      return { status: fault.result }
+    }
+    return this.inner.replaceIfMatch(key, bytes, etag)
+  }
+}
+

--- a/test/durable/full-stack.bun.test.ts
+++ b/test/durable/full-stack.bun.test.ts
@@ -1,0 +1,199 @@
+/**
+ * The whole stack, end to end.
+ *
+ * Every other suite tests one half. The engine end-to-end suite runs a real
+ * `libchdb` over a local directory; the S3 suite runs a real bucket under a
+ * fake engine. Neither is the arrangement a downstream actually ships, which
+ * is a real engine reached through Bun's FFI writing to real object storage —
+ * and the two halves meeting is exactly where a wrong assumption would hide.
+ *
+ * So this runs the whole stack in one process:
+ *
+ * ```text
+ *   Bun
+ *     -> chdb/durable          state machine
+ *     -> chdb/durable/s3       AWS SDK, conditional writes
+ *     -> LibchdbFfiEngine      bun:ffi dlopen(libchdb)
+ *     -> chdb-core             backup / restore / classify
+ * ```
+ *
+ * The claim it checks is the product one: rows acknowledged on one machine
+ * come back on another that shares nothing but the bucket. "Another machine"
+ * here means a second namespace, a second engine and a second scratch tree,
+ * with the first fully closed first — the engine binds one data path per
+ * process, so the two cannot overlap.
+ *
+ * ```sh
+ * CHDB_LIBCHDB_PATH=/path/to/chdb-core/buildlib/libchdb.so \
+ * CHDB_DURABLE_S3_BUCKET=... CHDB_DURABLE_S3_ENDPOINT=... \
+ *   bun test test/durable/full-stack.bun.test.ts
+ * ```
+ */
+
+import { afterAll, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { DeleteObjectsCommand, ListObjectsV2Command, S3Client, type S3ClientConfig } from '@aws-sdk/client-s3'
+
+import { DurableNamespace } from '../../src/durable/namespace'
+import type { DurableObject } from '../../src/durable/object'
+import { tryResolveLibchdb } from '../../src/libchdb/index'
+import { LibchdbFfiEngine } from './libchdb-ffi'
+import '../../src/durable/backends/s3'
+
+const BUCKET = process.env['CHDB_DURABLE_S3_BUCKET']
+const ENDPOINT = process.env['CHDB_DURABLE_S3_ENDPOINT']
+const REGION = process.env['CHDB_DURABLE_S3_REGION'] ?? 'us-east-1'
+const PATH_STYLE = process.env['CHDB_DURABLE_S3_FORCE_PATH_STYLE'] === 'true'
+
+if (!BUCKET) throw new Error('set CHDB_DURABLE_S3_BUCKET (and CHDB_DURABLE_S3_ENDPOINT for MinIO)')
+const located = tryResolveLibchdb()
+if (!located) throw new Error('set CHDB_LIBCHDB_PATH to a chdb-core build carrying the durable ABI')
+const LIBRARY = located.path
+
+const RUN_PREFIX = `chdb-durable-stack/${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`
+const scratchDirs: string[] = []
+
+function urlFor(): string {
+  const q = ENDPOINT
+    ? `?region=${REGION}&endpoint=${encodeURIComponent(ENDPOINT)}${PATH_STYLE ? '&forcePathStyle=true' : ''}`
+    : `?region=${REGION}`
+  return `s3://${BUCKET}/${RUN_PREFIX}${q}`
+}
+
+function clientConfig(): S3ClientConfig {
+  const cfg: S3ClientConfig = { region: REGION }
+  if (ENDPOINT) cfg.endpoint = ENDPOINT
+  if (PATH_STYLE) cfg.forcePathStyle = true
+  return cfg
+}
+
+/** One "machine": its own namespace, its own engine, its own scratch tree. */
+async function machine(): Promise<DurableNamespace> {
+  const scratch = await mkdtemp(join(tmpdir(), 'maple-shape-'))
+  scratchDirs.push(scratch)
+  return new DurableNamespace(urlFor(), {
+    engineFactory: () => new LibchdbFfiEngine({ libraryPath: LIBRARY }),
+    scratchRoot: scratch,
+    tuning: { leaseTtlMs: 60_000, heartbeatIntervalMs: 15_000 },
+  })
+}
+
+function cell(csv: string): string {
+  return csv.trim().replace(/^"|"$/g, '')
+}
+
+afterAll(async () => {
+  for (const d of scratchDirs.splice(0)) await rm(d, { recursive: true, force: true })
+  const c = new S3Client(clientConfig())
+  let token: string | undefined
+  do {
+    const page = await c.send(
+      new ListObjectsV2Command({ Bucket: BUCKET, Prefix: RUN_PREFIX, ContinuationToken: token }),
+    )
+    const keys = (page.Contents ?? []).map((o) => ({ Key: o.Key as string }))
+    if (keys.length > 0) {
+      await c.send(new DeleteObjectsCommand({ Bucket: BUCKET, Delete: { Objects: keys } }))
+    }
+    token = page.IsTruncated ? page.NextContinuationToken : undefined
+  } while (token)
+  c.destroy()
+})
+
+const SCHEMA = 'CREATE TABLE events (id UInt64, note String) ENGINE = MergeTree ORDER BY id'
+
+describe(`full stack: Bun + libchdb + ${ENDPOINT ?? 'aws s3'}`, () => {
+  it('recovers acknowledged rows on a machine that shares only the bucket', async () => {
+    const objectId = `poc-${randomUUID().slice(0, 8)}`
+
+    const a = await machine()
+    const w = await a.open(objectId, { database: 'default' })
+    await w.execute(SCHEMA)
+    await w.execute("INSERT INTO events VALUES (1, 'one'), (2, 'two')")
+    const ticket = await w.execute("INSERT INTO events VALUES (3, 'three')")
+    // The barrier a product would await before answering a client.
+    await w.flushThrough(ticket)
+    await w.close()
+
+    const b = await machine()
+    const r = await b.open(objectId)
+    expect(await r.query('SELECT id, note FROM events ORDER BY id', { format: 'CSV' })).toBe(
+      '1,"one"\n2,"two"\n3,"three"\n',
+    )
+    await r.close()
+  })
+
+  it('carries a checkpoint and its trailing WAL across machines', async () => {
+    const objectId = `poc-${randomUUID().slice(0, 8)}`
+
+    const a = await machine()
+    const w = await a.open(objectId, { database: 'default' })
+    await w.execute(SCHEMA)
+    await w.execute("INSERT INTO events VALUES (1, 'before')")
+    const base = await w.checkpoint()
+    expect(w.manifest.wal).toEqual([])
+    await w.execute("INSERT INTO events VALUES (2, 'after')")
+    await w.flush()
+    await w.close()
+
+    const b = await machine()
+    const r = await b.open(objectId)
+    expect(r.manifest.base?.key).toBe(base.key)
+    expect(r.manifest.wal).toHaveLength(1)
+    expect(await r.query('SELECT id, note FROM events ORDER BY id', { format: 'CSV' })).toBe(
+      '1,"before"\n2,"after"\n',
+    )
+    await r.close()
+  })
+
+  it('brings materialized view output back through the checkpoint', async () => {
+    // A schema that leans on materialized views is the common case, and a
+    // checkpoint is a whole database backup — so derived tables return without the WAL replaying
+    // the derivation.
+    const objectId = `poc-${randomUUID().slice(0, 8)}`
+
+    const a = await machine()
+    const w = await a.open(objectId, { database: 'default' })
+    await w.execute(SCHEMA)
+    await w.execute('CREATE TABLE totals (note String, n UInt64) ENGINE = SummingMergeTree ORDER BY note')
+    await w.execute('CREATE MATERIALIZED VIEW mv TO totals AS SELECT note, count() AS n FROM events GROUP BY note')
+    await w.execute("INSERT INTO events VALUES (1, 'a'), (2, 'a'), (3, 'b')")
+    await w.checkpoint()
+    await w.close()
+
+    const b = await machine()
+    const r = await b.open(objectId)
+    expect(await r.query('SELECT note, sum(n) FROM totals GROUP BY note ORDER BY note', { format: 'CSV' })).toBe(
+      '"a",2\n"b",1\n',
+    )
+    await r.close()
+  })
+
+  it('refuses raw mutations while serving reads, as a durable product must', async () => {
+    const objectId = `poc-${randomUUID().slice(0, 8)}`
+    const a = await machine()
+    const w = await a.open(objectId, { database: 'default' })
+    await w.execute(SCHEMA)
+    await w.execute("INSERT INTO events VALUES (1, 'x')")
+
+    // The /local/query contract: one read-only statement, nothing else.
+    expect(cell(await w.query('SELECT count() FROM events', { format: 'CSV' }))).toBe('1')
+    for (const sql of [
+      "INSERT INTO events VALUES (2, 'y')",
+      'CREATE DATABASE other',
+      'SELECT 1; SELECT 2',
+      "INSERT INTO FUNCTION file('/tmp/leak.csv') SELECT 1",
+    ]) {
+      let threw = false
+      try {
+        await w.query(sql)
+      } catch {
+        threw = true
+      }
+      expect(threw, sql).toBe(true)
+    }
+    await w.close()
+  })
+})

--- a/test/durable/libchdb-e2e.bun.test.ts
+++ b/test/durable/libchdb-e2e.bun.test.ts
@@ -1,0 +1,313 @@
+/**
+ * End-to-end conformance against a real `libchdb`.
+ *
+ * Everything above this file has been checked against a fake engine, which
+ * proves the state machine and proves nothing about the seam. This suite runs
+ * the same control plane over the actual library — the real backup format, the
+ * real restore, and above all the real `chdb_classify_query_n`, because the
+ * entry-point gates are only as good as the analysis behind them and a test
+ * double cannot tell you that core agrees.
+ *
+ * It runs under Bun rather than vitest because it reaches the library through
+ * `bun:ffi`, which is also the shape a downstream that owns its own `dlopen`
+ * will use. Point it at a build with:
+ *
+ * ```sh
+ * CHDB_LIBCHDB_PATH=/path/to/chdb-core/buildlib/libchdb.so \
+ *   bun test test/durable/libchdb-e2e.bun.test.ts
+ * ```
+ *
+ * The engine binds one data path per process, so every case opens and closes
+ * its object; there is no parallelism to be had here.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+
+import { DurableNamespace } from '../../src/durable/namespace'
+import type { DurableObject } from '../../src/durable/object'
+import { isDurableErrorOf } from '../../src/durable/errors'
+import { tryResolveLibchdb } from '../../src/libchdb/index'
+import { LibchdbFfiEngine } from './libchdb-ffi'
+
+const located = tryResolveLibchdb()
+if (!located) {
+  throw new Error(
+    'libchdb not found. Set CHDB_LIBCHDB_PATH to a chdb-core build, e.g. ' +
+      'CHDB_LIBCHDB_PATH=/path/to/chdb-core/buildlib/libchdb.so',
+  )
+}
+const LIBRARY = located.path
+
+let engineVersion: string
+const roots: string[] = []
+const openObjects: DurableObject[] = []
+
+beforeAll(async () => {
+  engineVersion = await new LibchdbFfiEngine({ libraryPath: LIBRARY }).version()
+})
+
+afterEach(async () => {
+  for (const o of openObjects.splice(0)) await o.close().catch(() => {})
+  for (const r of roots.splice(0)) await rm(r, { recursive: true, force: true })
+})
+
+async function namespace(): Promise<DurableNamespace> {
+  const root = await mkdtemp(join(tmpdir(), 'durable-e2e-'))
+  roots.push(root)
+  return new DurableNamespace(pathToFileURL(join(root, 'ns')).href, {
+    engineFactory: () => new LibchdbFfiEngine({ libraryPath: LIBRARY }),
+    scratchRoot: root,
+    tuning: { leaseTtlMs: 60_000, heartbeatIntervalMs: 15_000 },
+  })
+}
+
+async function open(ns: DurableNamespace, id: string, options = {}): Promise<DurableObject> {
+  const o = await ns.open(id, options)
+  openObjects.push(o)
+  return o
+}
+
+/** First CSV cell of a single-value result. */
+function cell(csv: string): string {
+  return csv.trim().replace(/^"|"$/g, '')
+}
+
+const CREATE = 'CREATE TABLE events (id UInt64, note String) ENGINE = MergeTree ORDER BY id'
+
+async function caught(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+    return undefined
+  } catch (e) {
+    return e
+  }
+}
+
+describe('durable object over real libchdb', () => {
+  it('records the exact engine version the library reports', async () => {
+    const ns = await namespace()
+    const o = await open(ns, 'obj', { database: 'default' })
+    await o.close()
+    openObjects.length = 0
+
+    const head = JSON.parse(
+      await Bun.file(join(new URL(ns.url).pathname, 'obj', 'head.json')).text(),
+    )
+    expect(head.engine).toEqual({
+      name: 'chdb',
+      version: engineVersion,
+      backup_format: 1,
+      // A fresh object can only be read by the engine that made it, or later.
+      min_reader: engineVersion,
+    })
+    expect(head.protocol.version).toBe(1)
+  })
+
+  it('survives losing the machine: WAL replay reproduces the rows', async () => {
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database: 'default' })
+    await a.execute(CREATE)
+    await a.execute("INSERT INTO events VALUES (1, 'one'), (2, 'two')")
+    const ticket = await a.execute("INSERT INTO events VALUES (3, 'three')")
+    await a.flushThrough(ticket)
+    // Simulate the process dying with the writes committed but not closed.
+    await a.close()
+    openObjects.length = 0
+
+    const b = await open(ns, 'obj')
+    expect(cell(await b.query('SELECT count() FROM events', { format: 'CSV' }))).toBe('3')
+    expect(await b.query('SELECT id, note FROM events ORDER BY id', { format: 'CSV' })).toBe(
+      '1,"one"\n2,"two"\n3,"three"\n',
+    )
+  })
+
+  it('checkpoints, truncates the WAL, and still restores everything', async () => {
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database: 'default' })
+    await a.execute(CREATE)
+    await a.execute("INSERT INTO events VALUES (1, 'before')")
+    await a.flush()
+    const base = await a.checkpoint()
+    expect(a.manifest.wal).toEqual([])
+    expect(a.manifest.base?.key).toBe(base.key)
+
+    await a.execute("INSERT INTO events VALUES (2, 'after')")
+    await a.flush()
+    await a.close()
+    openObjects.length = 0
+
+    const b = await open(ns, 'obj')
+    expect(b.manifest.base?.key).toBe(base.key)
+    expect(b.manifest.wal).toHaveLength(1)
+    expect(await b.query('SELECT id, note FROM events ORDER BY id', { format: 'CSV' })).toBe(
+      '1,"before"\n2,"after"\n',
+    )
+  })
+
+  it('carries materialized view output through a checkpoint', async () => {
+    // A checkpoint is a whole-database backup, so derived tables come back
+    // without the WAL having to replay the derivation.
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database: 'default' })
+    await a.execute(CREATE)
+    await a.execute('CREATE TABLE totals (note String, n UInt64) ENGINE = SummingMergeTree ORDER BY note')
+    await a.execute('CREATE MATERIALIZED VIEW mv TO totals AS SELECT note, count() AS n FROM events GROUP BY note')
+    await a.execute("INSERT INTO events VALUES (1, 'a'), (2, 'a'), (3, 'b')")
+    await a.checkpoint()
+    await a.close()
+    openObjects.length = 0
+
+    const b = await open(ns, 'obj')
+    expect(await b.query('SELECT note, sum(n) FROM totals GROUP BY note ORDER BY note', { format: 'CSV' })).toBe(
+      '"a",2\n"b",1\n',
+    )
+  })
+
+  it('handles a database name that needs quoting', async () => {
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database: 'my-db`weird' })
+    await a.execute('CREATE TABLE q (id UInt64) ENGINE = MergeTree ORDER BY id')
+    await a.execute('INSERT INTO q VALUES (7)')
+    await a.checkpoint()
+    await a.close()
+    openObjects.length = 0
+
+    const b = await open(ns, 'obj')
+    expect(b.database).toBe('my-db`weird')
+    expect(cell(await b.query('SELECT id FROM q', { format: 'CSV' }))).toBe('7')
+  })
+
+  it('serves a read-only snapshot without taking the lease', async () => {
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database: 'default' })
+    await a.execute(CREATE)
+    await a.execute("INSERT INTO events VALUES (1, 'x')")
+    await a.flush()
+    await a.close()
+    openObjects.length = 0
+
+    const r = await open(ns, 'obj', { readOnly: true })
+    expect(cell(await r.query('SELECT count() FROM events', { format: 'CSV' }))).toBe('1')
+    expect(isDurableErrorOf(await caught(() => r.execute("INSERT INTO events VALUES (2, 'y')")), 'classification_refused')).toBe(true)
+  })
+})
+
+describe('core analysis gates the public surface', () => {
+  let ns: DurableNamespace
+  let o: DurableObject
+
+  async function withObject(): Promise<DurableObject> {
+    ns = await namespace()
+    o = await open(ns, 'obj', { database: 'default' })
+    await o.execute(CREATE)
+    return o
+  }
+
+  it('refuses a mutation submitted through query()', async () => {
+    const obj = await withObject()
+    expect(isDurableErrorOf(await caught(() => obj.query("INSERT INTO events VALUES (1, 'x')")), 'classification_refused')).toBe(true)
+  })
+
+  it('refuses a read submitted through execute()', async () => {
+    const obj = await withObject()
+    expect(isDurableErrorOf(await caught(() => obj.execute('SELECT 1')), 'classification_refused')).toBe(true)
+  })
+
+  it('refuses a batch at both entry points', async () => {
+    const obj = await withObject()
+    expect(isDurableErrorOf(await caught(() => obj.query('SELECT 1; SELECT 2')), 'classification_refused')).toBe(true)
+    expect(
+      isDurableErrorOf(
+        await caught(() => obj.execute("INSERT INTO events VALUES (1,'a'); INSERT INTO events VALUES (2,'b')")),
+        'classification_refused',
+      ),
+    ).toBe(true)
+  })
+
+  it('refuses a write to another database', async () => {
+    const obj = await withObject()
+    expect(isDurableErrorOf(await caught(() => obj.execute("INSERT INTO other.events VALUES (1, 'x')")), 'classification_refused')).toBe(true)
+  })
+
+  it('refuses a write that leaves the engine entirely', async () => {
+    const obj = await withObject()
+    expect(isDurableErrorOf(await caught(() => obj.execute("INSERT INTO FUNCTION file('/tmp/leak.csv') SELECT 1")), 'classification_refused')).toBe(true)
+  })
+
+  it('refuses a database lifecycle change', async () => {
+    const obj = await withObject()
+    expect(isDurableErrorOf(await caught(() => obj.execute('CREATE DATABASE sneaky')), 'classification_refused')).toBe(true)
+    expect(isDurableErrorOf(await caught(() => obj.execute('DROP DATABASE default')), 'classification_refused')).toBe(true)
+  })
+
+  it('refuses global state a checkpoint could not carry', async () => {
+    const obj = await withObject()
+    expect(isDurableErrorOf(await caught(() => obj.execute('CREATE FUNCTION addone AS (x) -> x + 1')), 'classification_refused')).toBe(true)
+  })
+
+  it('refuses session control, so the current database cannot drift', async () => {
+    const obj = await withObject()
+    for (const sql of ['USE system', 'SET max_threads = 4', 'SYSTEM FLUSH LOGS']) {
+      expect(isDurableErrorOf(await caught(() => obj.execute(sql)), 'classification_refused'), sql).toBe(true)
+      expect(isDurableErrorOf(await caught(() => obj.query(sql)), 'classification_refused'), sql).toBe(true)
+    }
+    expect(cell(await obj.query('SELECT currentDatabase()', { format: 'CSV' }))).toBe('default')
+  })
+
+  it('refuses a mutation carrying a credential, without echoing it', async () => {
+    const obj = await withObject()
+    const e = await caught(() =>
+      obj.execute("CREATE NAMED COLLECTION c AS access_key_id = 'AKIAEXAMPLE', secret_access_key = 'shhh'"),
+    )
+    // Core classifies this as MUTATING_GLOBAL, which V1 refuses outright; the
+    // secret flag is the second reason it could never be logged.
+    expect(isDurableErrorOf(e, 'classification_refused') || isDurableErrorOf(e, 'secret_refused')).toBe(true)
+    expect((e as Error).message).not.toContain('AKIAEXAMPLE')
+    expect((e as Error).message).not.toContain('shhh')
+  })
+
+  it('fails closed on SQL core cannot parse', async () => {
+    const obj = await withObject()
+    expect(isDurableErrorOf(await caught(() => obj.execute('this is not sql ((')), 'classification_refused')).toBe(true)
+    expect(isDurableErrorOf(await caught(() => obj.query('this is not sql ((')), 'classification_refused')).toBe(true)
+  })
+
+  it('does not record a refused statement in the WAL', async () => {
+    const obj = await withObject()
+    await obj.flush()
+    const before = obj.manifest.seq
+    await caught(() => obj.execute('CREATE DATABASE sneaky'))
+    expect(obj.pendingStatements).toBe(0)
+    await obj.flush()
+    expect(obj.manifest.seq).toBe(before)
+  })
+
+  it('lets a read-only statement carrying a secret run, since it never reaches the WAL', async () => {
+    const obj = await withObject()
+    // Parses, reads, and would carry a credential — allowed, but the caller is
+    // responsible for not logging the text.
+    const out = await obj.query("SELECT 'secret_access_key' AS s", { format: 'CSV' })
+    expect(cell(out)).toBe('secret_access_key')
+  })
+})
+
+describe('lease behaviour with a real engine', () => {
+  it('refuses a second writer and permits an explicit takeover', async () => {
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database: 'default' })
+    await a.execute(CREATE)
+
+    expect(isDurableErrorOf(await caught(() => ns.open('obj')), 'lease_held')).toBe(true)
+
+    // A forced takeover needs the first writer's engine gone first: the engine
+    // binds one data path per process, and the second object needs its own.
+    await a.close()
+    openObjects.length = 0
+    const b = await open(ns, 'obj', { force: true })
+    expect(b.generation).toBeGreaterThan(1)
+  })
+})

--- a/test/durable/libchdb-ffi.ts
+++ b/test/durable/libchdb-ffi.ts
@@ -1,0 +1,289 @@
+/**
+ * An {@link EngineAdapter} that reaches `libchdb` directly through Bun's FFI.
+ *
+ * This exists to prove the point the whole `chdb/durable` design rests on: the
+ * control plane has no idea what is underneath it. The same state machine that
+ * chdb-node will drive through its native addon is driven here by a `dlopen`
+ * of the library a `chdb-core` build just produced, with no addon in the
+ * process at all — which is exactly the shape a Bun-based downstream needs.
+ *
+ * It is also the only way to check the control plane against the real engine
+ * without compiling anything, so the end-to-end suite runs under Bun.
+ *
+ * Kept in `test/` rather than shipped: the published package's default adapter
+ * belongs on the addon, and a Bun-only module in the dependency graph would be
+ * a trap for Node users. Downstreams that want this shape should own their
+ * copy — it is fifty lines of `dlopen` plus the symbol table below.
+ */
+
+import { dlopen, FFIType, ptr, read, toArrayBuffer, type Pointer } from 'bun:ffi'
+import type {
+  EngineAdapter,
+  EngineStartOptions,
+  QueryAnalysis,
+} from '../../src/durable/engine-adapter'
+import { QueryClass } from '../../src/durable/engine-adapter'
+import { DurableEngineError } from '../../src/durable/errors'
+
+const SYMBOLS = {
+  chdb_version: { args: [], returns: FFIType.cstring },
+  chdb_connect: { args: [FFIType.i32, FFIType.ptr], returns: FFIType.ptr },
+  chdb_close_conn: { args: [FFIType.ptr], returns: FFIType.void },
+  chdb_query_n: {
+    args: [FFIType.ptr, FFIType.ptr, FFIType.u64_fast, FFIType.ptr, FFIType.u64_fast],
+    returns: FFIType.ptr,
+  },
+  chdb_result_error: { args: [FFIType.ptr], returns: FFIType.cstring },
+  chdb_result_buffer: { args: [FFIType.ptr], returns: FFIType.ptr },
+  chdb_result_length: { args: [FFIType.ptr], returns: FFIType.u64_fast },
+  chdb_destroy_query_result: { args: [FFIType.ptr], returns: FFIType.void },
+  chdb_backup_database_n: {
+    args: [
+      FFIType.ptr,
+      FFIType.ptr,
+      FFIType.u64_fast,
+      FFIType.ptr,
+      FFIType.u64_fast,
+      FFIType.ptr,
+      FFIType.u64_fast,
+    ],
+    returns: FFIType.ptr,
+  },
+  chdb_restore_database_n: {
+    args: [FFIType.ptr, FFIType.ptr, FFIType.u64_fast, FFIType.ptr, FFIType.u64_fast],
+    returns: FFIType.ptr,
+  },
+  chdb_classify_query_n: {
+    args: [FFIType.ptr, FFIType.ptr, FFIType.u64_fast, FFIType.ptr, FFIType.u64_fast, FFIType.ptr],
+    returns: FFIType.i32,
+  },
+} as const
+
+type Lib = ReturnType<typeof dlopen<typeof SYMBOLS>>
+
+let cached: Lib | undefined
+
+/**
+ * `dlopen` the library once per process. A second `dlopen` of the same engine
+ * would be a second engine, and the engine binds one data path per process.
+ */
+export function loadLibchdb(path: string): Lib {
+  if (cached) return cached
+  try {
+    cached = dlopen(path, SYMBOLS)
+  } catch (e) {
+    // Far and away the most likely cause is a libchdb that predates the
+    // durable ABI, and `dlopen` reports that as a bare TypeError naming one
+    // symbol. Since the published @chdb/lib-* packages still ship such a
+    // build, and the resolver prefers them over a local one, this is the
+    // error a developer meets first — so it should say what to do about it
+    // rather than what the loader saw.
+    const missing = /Symbol "([A-Za-z0-9_]+)" not found/.exec(
+      e instanceof Error ? e.message : String(e),
+    )?.[1]
+    if (missing) {
+      throw new DurableEngineError(
+        `durable: ${path} does not export ${missing}. This libchdb predates the durable ABI ` +
+          `(chdb_backup_database_n, chdb_restore_database_n, chdb_classify_query_n, chdb_version). ` +
+          `Point CHDB_LIBCHDB_PATH at a chdb-core build that has it — note the published ` +
+          `@chdb/lib-* packages are resolved first, so the variable is how you override them.`,
+        { cause: e },
+      )
+    }
+    throw e
+  }
+  return cached
+}
+
+/** NUL-terminated buffer, plus the byte length the `_n` entry points want. */
+function cstr(s: string): { buf: Buffer; len: number } {
+  const bytes = Buffer.from(s, 'utf8')
+  const buf = Buffer.alloc(bytes.length + 1)
+  bytes.copy(buf)
+  return { buf, len: bytes.length }
+}
+
+/** ClickHouse identifier quoting: backticks, with inner backticks doubled. */
+function quoteIdentifier(name: string): string {
+  return '`' + name.replace(/`/g, '``') + '`'
+}
+
+export interface LibchdbEngineOptions {
+  /** Absolute path to `libchdb.so` / `libchdb.dylib`. */
+  libraryPath: string
+  /** Extra `--setting=value` arguments appended to the connection. */
+  extraArgs?: readonly string[]
+}
+
+export class LibchdbFfiEngine implements EngineAdapter {
+  private readonly lib: Lib
+  private readonly options: LibchdbEngineOptions
+  /** `chdb_connection *` returned by connect; what close wants. */
+  private handle: Pointer | null = null
+  /** The dereferenced `chdb_connection`; what every other call wants. */
+  private conn: Pointer | null = null
+
+  constructor(options: LibchdbEngineOptions) {
+    this.options = options
+    this.lib = loadLibchdb(options.libraryPath)
+  }
+
+  async version(): Promise<string> {
+    return String(this.lib.symbols.chdb_version())
+  }
+
+  async start(options: EngineStartOptions): Promise<void> {
+    // The settings here are the ones a durable writer cannot leave to chance.
+    // Asynchronous inserts and non-synchronous mutations both mean "the
+    // statement returned before its effect landed", which would put a
+    // statement in the WAL whose local effect is not yet in the database the
+    // next checkpoint archives. `SET` is CONTROL, so a caller cannot undo
+    // them through the public surface.
+    const argv = [
+      'chdb',
+      `--path=${options.dataPath}`,
+      `--backups.allowed_path=${options.backupsAllowedPath}`,
+      '--async_insert=0',
+      '--wait_for_async_insert=1',
+      '--mutations_sync=2',
+      '--alter_sync=2',
+      ...(this.options.extraArgs ?? []),
+    ]
+    const buffers = argv.map((a) => cstr(a).buf)
+    const pointers = new BigUint64Array(buffers.length)
+    for (let i = 0; i < buffers.length; i++) {
+      pointers[i] = BigInt(ptr(buffers[i] as Buffer))
+    }
+    const handle = this.lib.symbols.chdb_connect(argv.length, ptr(pointers))
+    if (!handle) throw new DurableEngineError('durable: chdb_connect returned NULL')
+    this.handle = handle
+    const conn = read.ptr(handle, 0)
+    if (!conn) throw new DurableEngineError('durable: chdb_connect produced a NULL connection')
+    this.conn = conn as unknown as Pointer
+  }
+
+  private requireConn(): Pointer {
+    if (!this.conn) throw new DurableEngineError('durable: engine is not started')
+    return this.conn
+  }
+
+  /** Run a statement and return its formatted output, or throw the engine error. */
+  private call(sql: string, format: string): string {
+    const conn = this.requireConn()
+    const q = cstr(sql)
+    const f = cstr(format)
+    const result = this.lib.symbols.chdb_query_n(conn, ptr(q.buf), q.len, ptr(f.buf), f.len)
+    if (!result) throw new DurableEngineError('durable: chdb_query_n returned NULL')
+    try {
+      const err = this.lib.symbols.chdb_result_error(result)
+      if (err) throw new DurableEngineError(`durable: engine error: ${String(err)}`)
+      const len = Number(this.lib.symbols.chdb_result_length(result))
+      if (len === 0) return ''
+      const buf = this.lib.symbols.chdb_result_buffer(result)
+      if (!buf) return ''
+      return Buffer.from(toArrayBuffer(buf, 0, len)).toString('utf8')
+    } finally {
+      this.lib.symbols.chdb_destroy_query_result(result)
+    }
+  }
+
+  /** Shared shape for the two management entry points, which return a result too. */
+  private manage(
+    run: () => Pointer | null,
+    what: string,
+  ): void {
+    const result = run()
+    if (!result) throw new DurableEngineError(`durable: ${what} returned NULL`)
+    try {
+      const err = this.lib.symbols.chdb_result_error(result)
+      if (err) throw new DurableEngineError(`durable: ${what} failed: ${String(err)}`)
+    } finally {
+      this.lib.symbols.chdb_destroy_query_result(result)
+    }
+  }
+
+  async createDatabase(database: string): Promise<void> {
+    this.call(`CREATE DATABASE IF NOT EXISTS ${quoteIdentifier(database)}`, 'CSV')
+  }
+
+  async useDatabase(database: string): Promise<void> {
+    this.call(`USE ${quoteIdentifier(database)}`, 'CSV')
+  }
+
+  async query(sql: string, format: string): Promise<string> {
+    return this.call(sql, format)
+  }
+
+  async run(sql: string): Promise<void> {
+    this.call(sql, 'CSV')
+  }
+
+  async backupDatabase(database: string, filePath: string): Promise<void> {
+    const conn = this.requireConn()
+    const db = cstr(database)
+    const fp = cstr(filePath)
+    this.manage(
+      () =>
+        // V1 always passes a NULL base: an incremental archive records the
+        // absolute path of its base, which does not exist on the machine that
+        // restores it.
+        this.lib.symbols.chdb_backup_database_n(
+          conn,
+          ptr(db.buf),
+          db.len,
+          ptr(fp.buf),
+          fp.len,
+          null,
+          0,
+        ),
+      'chdb_backup_database_n',
+    )
+  }
+
+  async restoreDatabase(database: string, filePath: string): Promise<void> {
+    const conn = this.requireConn()
+    const db = cstr(database)
+    const fp = cstr(filePath)
+    this.manage(
+      () =>
+        this.lib.symbols.chdb_restore_database_n(conn, ptr(db.buf), db.len, ptr(fp.buf), fp.len),
+      'chdb_restore_database_n',
+    )
+  }
+
+  async analyze(sql: string, targetDatabase: string): Promise<QueryAnalysis> {
+    const conn = this.requireConn()
+    const q = cstr(sql)
+    const db = cstr(targetDatabase)
+    // struct chdb_query_analysis_v1 { uint32 struct_size, statement_count, flags, query_class }
+    const out = new Uint32Array(4)
+    out[0] = out.byteLength
+    const state = this.lib.symbols.chdb_classify_query_n(
+      conn,
+      ptr(q.buf),
+      q.len,
+      ptr(db.buf),
+      db.len,
+      ptr(out),
+    )
+    if (state !== 0) {
+      throw new DurableEngineError('durable: chdb_classify_query_n reported CHDBError')
+    }
+    const flags = out[2] as number
+    return {
+      statementCount: out[1] as number,
+      queryClass: out[3] as QueryClass,
+      hasSecrets: (flags & 0x1) !== 0,
+      writesOnlyTargetDatabase: (flags & 0x2) !== 0,
+      changesDatabaseLifecycle: (flags & 0x4) !== 0,
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.handle) {
+      this.lib.symbols.chdb_close_conn(this.handle)
+      this.handle = null
+      this.conn = null
+    }
+  }
+}

--- a/test/durable/protocol.test.ts
+++ b/test/durable/protocol.test.ts
@@ -718,6 +718,22 @@ describe('local backend conditional operations', () => {
     }
   })
 
+  it('publishes into a prefix that does not exist yet, and only walks once', async () => {
+    // The first publish creates the directory chain, whose entries are as
+    // unflushed as the object itself; the walk covers them. Later publishes
+    // create nothing and must not pay for it.
+    const root = await mkdtemp(join(tmpdir(), 'durable-deep-'))
+    const be = new LocalDurableBackend({ root: join(root, 'a', 'b', 'obj') })
+
+    expect(await be.putBytesIfAbsent('checkpoints/1-1-aaaaaaaa.tar.gz', Buffer.from('first'))).toBe('created')
+    expect(Buffer.from((await be.getBytes('checkpoints/1-1-aaaaaaaa.tar.gz'))!).toString()).toBe('first')
+
+    // Second publish into the now-existing prefix still works and stays conditional.
+    expect(await be.putBytesIfAbsent('checkpoints/1-2-bbbbbbbb.tar.gz', Buffer.from('second'))).toBe('created')
+    expect(await be.putBytesIfAbsent('checkpoints/1-2-bbbbbbbb.tar.gz', Buffer.from('other'))).toBe('already-exists')
+    expect(Buffer.from((await be.getBytes('checkpoints/1-2-bbbbbbbb.tar.gz'))!).toString()).toBe('second')
+  })
+
   it('surfaces an unreadable version chain instead of serving a stale version', async () => {
     // The probe's answer decides which version is current. Treating an I/O or
     // permission failure as "absent" would hand back the version below it and

--- a/test/durable/protocol.test.ts
+++ b/test/durable/protocol.test.ts
@@ -524,6 +524,19 @@ describe('review regressions: head parsing', () => {
     expectCategory(() => parseHead(bytes(e)), 'corrupt')
   })
 
+  it('refuses to emit a head this parser would reject', () => {
+    // head.json is created with a conditional create and V1 has no destroy, so
+    // publishing an unreadable one makes the object permanently unopenable.
+    // Failing at the write is the only recoverable end.
+    expectCategory(() => serializeHead(coldHead('', '26.7.2')), 'corrupt')
+    const noVersion = coldHead('mem', '26.7.2')
+    noVersion.engine.version = ''
+    expectCategory(() => serializeHead(noVersion), 'corrupt')
+    const noFloor = coldHead('mem', '26.7.2')
+    noFloor.engine.min_reader = ''
+    expectCategory(() => serializeHead(noFloor), 'corrupt')
+  })
+
   it('refuses malformed UTF-8 rather than rewriting it as replacement characters', () => {
     // Lenient decoding turned invalid bytes in an *unknown* field into U+FFFD
     // and wrote them back mangled, corrupting the one thing round-tripping is

--- a/test/durable/protocol.test.ts
+++ b/test/durable/protocol.test.ts
@@ -9,7 +9,8 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { mkdtemp, readFile, writeFile } from 'fs/promises'
+import { existsSync } from 'fs'
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -691,6 +692,41 @@ describe('local backend conditional operations', () => {
     expect(outcomes).toEqual(['not-replaced', 'replaced'])
     // Whoever won, the pointer names their version and it is readable.
     expect((await be.getBytesWithEtag('head.json'))!.etag).toBe('v2')
+  })
+
+  it('refuses to publish through a symlinked directory', async () => {
+    // A lexically valid key can still leave the prefix if a component is a
+    // link. Whoever plants it can usually write the object anyway, but a link
+    // planted once in a shared parent should not silently redirect every
+    // later operation.
+    const root = await mkdtemp(join(tmpdir(), 'durable-link-'))
+    const objDir = join(root, 'obj')
+    const outside = join(root, 'outside')
+    await mkdir(outside, { recursive: true })
+    await mkdir(objDir, { recursive: true })
+    await symlink(outside, join(objDir, 'checkpoints'))
+
+    const be = new LocalDurableBackend({ root: objDir })
+    await expect(
+      be.putBytesIfAbsent('checkpoints/1-1-aaaaaaaa.tar.gz', Buffer.from('x')),
+    ).rejects.toThrow(/symlink/)
+    expect(existsSync(join(outside, '1-1-aaaaaaaa.tar.gz'))).toBe(false)
+  })
+
+  it('publishes a staged file with its contents flushed, on every path', async () => {
+    // The barriers live in the publish primitive, so a caller cannot reach
+    // publication without them. This checks the observable half: the object is
+    // there and correct however it got staged.
+    const be = await backend()
+    const dir = await mkdtemp(join(tmpdir(), 'durable-src-'))
+    const src = join(dir, 'checkpoint.tar.gz')
+    const payload = Buffer.from('archive bytes')
+    await writeFile(src, payload)
+
+    expect(await be.putFileIfAbsent('checkpoints/1-1-bbbbbbbb.tar.gz', src)).toBe('created')
+    expect(Buffer.from((await be.getBytes('checkpoints/1-1-bbbbbbbb.tar.gz'))!)).toEqual(payload)
+    // And it stays a conditional create.
+    expect(await be.putFileIfAbsent('checkpoints/1-1-bbbbbbbb.tar.gz', src)).toBe('already-exists')
   })
 
   it('refuses a key that would escape the object prefix', async () => {

--- a/test/durable/protocol.test.ts
+++ b/test/durable/protocol.test.ts
@@ -483,6 +483,69 @@ describe('entry-point gates', () => {
   })
 })
 
+describe('review regressions: head parsing', () => {
+  it('refuses a truncated lease instead of reading it as released', () => {
+    // A half-written lease used to parse as the all-null released form, which
+    // would hand the object to a new writer on the strength of a corrupt head.
+    for (const lease of [
+      { generation: 7 },
+      { generation: 7, owner: 'w' },
+      { generation: 7, owner: 'w', instance: 'i' },
+      { generation: 7, owner: null, instance: null },
+    ]) {
+      expectCategory(() => parseHead(bytes(goodHead({ lease }))), 'corrupt')
+    }
+    // The released form is three explicit nulls, and still parses.
+    const ok = goodHead({ lease: { generation: 7, owner: null, instance: null, expires_at: null } })
+    expect(parseHead(bytes(ok)).head.lease.owner).toBeNull()
+  })
+
+  it('refuses required manifest fields that are absent or null', () => {
+    for (const manifest of [
+      { base: null, wal: [], seq: 0 },
+      { db: 'mem', wal: [], seq: 0 },
+      { db: 'mem', base: null, seq: 0 },
+      { db: 'mem', base: null, wal: [] },
+      { db: 'mem', base: null, wal: null, seq: 0 },
+      { db: null, base: null, wal: [], seq: 0 },
+    ]) {
+      expectCategory(() => parseHead(bytes(goodHead({ manifest }))), 'corrupt')
+    }
+  })
+
+  it('refuses an explicit null in a known field that has a default', () => {
+    // The defaults exist for documents written before a field did; they are
+    // not a way to launder a null into a valid value.
+    const p = goodHead()
+    ;(p['protocol'] as Record<string, unknown>)['version'] = null
+    expectCategory(() => parseHead(bytes(p)), 'corrupt')
+    const e = goodHead()
+    ;(e['engine'] as Record<string, unknown>)['min_reader'] = null
+    expectCategory(() => parseHead(bytes(e)), 'corrupt')
+  })
+
+  it('refuses malformed UTF-8 rather than rewriting it as replacement characters', () => {
+    // Lenient decoding turned invalid bytes in an *unknown* field into U+FFFD
+    // and wrote them back mangled, corrupting the one thing round-tripping is
+    // for.
+    const good = Buffer.from(JSON.stringify(goodHead({ vendor_extension: 'PLACEHOLDER' })))
+    const bad = Buffer.from(good)
+    bad[good.indexOf(Buffer.from('PLACEHOLDER'))] = 0x80 // lone continuation byte
+    expectCategory(() => parseHead(bad), 'corrupt')
+  })
+})
+
+describe('review regressions: WAL reader limits', () => {
+  it('refuses a decoded statement over the per-statement limit', () => {
+    // The segment ceiling is twice the statement ceiling, so a hand-built
+    // segment could carry a statement no conforming writer could produce.
+    const huge = 'x'.repeat(LIMITS.MAX_SQL_BYTES + 1)
+    const segment = Buffer.from(JSON.stringify({ sql: huge }) + '\n')
+    expect(segment.byteLength).toBeLessThan(LIMITS.MAX_WAL_SEGMENT_BYTES)
+    expectCategory(() => decodeWalSegment(segment, 'wal/x'), 'limit_exceeded')
+  })
+})
+
 describe('local backend conditional operations', () => {
   async function backend(): Promise<LocalDurableBackend> {
     const root = await mkdtemp(join(tmpdir(), 'durable-be-'))
@@ -541,6 +604,80 @@ describe('local backend conditional operations', () => {
     expect(await readFile(join(objDir, 'head.json'), 'utf8')).toBe('{"ours":true}')
     const stale = await be.replaceIfMatch('head.json', Buffer.from('{"no":true}'), read.etag)
     expect(stale.status).toBe('not-replaced')
+  })
+
+  /** Move an object into the version chain, which only happens on first replace. */
+  async function chained(be: LocalDurableBackend): Promise<string> {
+    await be.putBytesIfAbsent('head.json', Buffer.from('{"v":"plain"}'))
+    const plain = (await be.getBytesWithEtag('head.json'))!
+    await be.replaceIfMatch('head.json', Buffer.from('{"v":0}'), plain.etag)
+    return (await be.getBytesWithEtag('head.json'))!.etag
+  }
+
+  it('refuses a token that names a version which is not the current one', async () => {
+    // This used to create a version nobody had read, skip the one between, and
+    // publish it — a compare-and-swap succeeding against a value never stored.
+    const be = await backend()
+    expect(await chained(be)).toBe('v1')
+    const r = await be.replaceIfMatch('head.json', Buffer.from('{"hijacked":true}'), 'v2')
+    expect(r.status).toBe('not-replaced')
+    expect(Buffer.from((await be.getBytesWithEtag('head.json'))!.bytes).toString()).toBe('{"v":0}')
+  })
+
+  it('recovers from a crash between creating a version and publishing it', async () => {
+    // The pointer is a hint; the highest existing version is the authority.
+    // Trusting the pointer wedged the object permanently — every later writer
+    // held the pointed-at token, lost the create to the orphan, and reported
+    // not-replaced forever.
+    const be = await backend()
+    expect(await chained(be)).toBe('v1')
+    const orphan = join(be.root, '.head-versions', '2.json')
+    await writeFile(orphan, '{"v":"written by a writer that died"}')
+
+    // A reader now sees the published version, not the stale pointer.
+    const seen = (await be.getBytesWithEtag('head.json'))!
+    expect(seen.etag).toBe('v2')
+    expect(Buffer.from(seen.bytes).toString()).toContain('died')
+
+    // And the chain moves on rather than deadlocking.
+    const r = await be.replaceIfMatch('head.json', Buffer.from('{"v":3}'), seen.etag)
+    expect(r.status).toBe('replaced')
+    expect((await be.getBytesWithEtag('head.json'))!.etag).toBe('v3')
+  })
+
+  it('reports a stale token honestly and leaves recovery to the caller', async () => {
+    // A writer whose own write landed but whose response was lost still holds
+    // the old token. The backend does not try to be clever about that: the
+    // token no longer names the current version, so the answer is
+    // not-replaced. Recognising the write as one's own needs the head's
+    // contents and the lease, neither of which a backend can interpret, so it
+    // belongs to commitHead's reconciliation.
+    const be = await backend()
+    expect(await chained(be)).toBe('v1')
+    const mine = Buffer.from('{"v":"mine"}')
+    await writeFile(join(be.root, '.head-versions', '2.json'), mine)
+
+    expect(await be.replaceIfMatch('head.json', mine, 'v1')).toEqual({ status: 'not-replaced' })
+    // What the caller then rereads is its own write, which is what lets the
+    // layer above conclude the commit landed.
+    const fresh = (await be.getBytesWithEtag('head.json'))!
+    expect(fresh.etag).toBe('v2')
+    expect(Buffer.from(fresh.bytes)).toEqual(mine)
+  })
+
+  it('lets one of two concurrent writers win a version and tells the other', async () => {
+    // The path that reaches the conditional-create collision: both read the
+    // same version, both try to create the one above it.
+    const be = await backend()
+    const etag = await chained(be)
+    const [a, b] = await Promise.all([
+      be.replaceIfMatch('head.json', Buffer.from('{"w":"a"}'), etag),
+      be.replaceIfMatch('head.json', Buffer.from('{"w":"b"}'), etag),
+    ])
+    const outcomes = [a.status, b.status].sort()
+    expect(outcomes).toEqual(['not-replaced', 'replaced'])
+    // Whoever won, the pointer names their version and it is readable.
+    expect((await be.getBytesWithEtag('head.json'))!.etag).toBe('v2')
   })
 
   it('refuses a key that would escape the object prefix', async () => {

--- a/test/durable/protocol.test.ts
+++ b/test/durable/protocol.test.ts
@@ -694,24 +694,6 @@ describe('local backend conditional operations', () => {
     expect((await be.getBytesWithEtag('head.json'))!.etag).toBe('v2')
   })
 
-  it('refuses to publish through a symlinked directory', async () => {
-    // A lexically valid key can still leave the prefix if a component is a
-    // link. Whoever plants it can usually write the object anyway, but a link
-    // planted once in a shared parent should not silently redirect every
-    // later operation.
-    const root = await mkdtemp(join(tmpdir(), 'durable-link-'))
-    const objDir = join(root, 'obj')
-    const outside = join(root, 'outside')
-    await mkdir(outside, { recursive: true })
-    await mkdir(objDir, { recursive: true })
-    await symlink(outside, join(objDir, 'checkpoints'))
-
-    const be = new LocalDurableBackend({ root: objDir })
-    await expect(
-      be.putBytesIfAbsent('checkpoints/1-1-aaaaaaaa.tar.gz', Buffer.from('x')),
-    ).rejects.toThrow(/symlink/)
-    expect(existsSync(join(outside, '1-1-aaaaaaaa.tar.gz'))).toBe(false)
-  })
 
   it('publishes a staged file with its contents flushed, on every path', async () => {
     // The barriers live in the publish primitive, so a caller cannot reach

--- a/test/durable/protocol.test.ts
+++ b/test/durable/protocol.test.ts
@@ -713,7 +713,21 @@ describe('local backend conditional operations', () => {
 
   it('refuses a key that would escape the object prefix', async () => {
     const be = await backend()
-    await expect(be.getBytes('../escape')).rejects.toThrow(/invalid key|escapes/)
+    for (const key of ['../escape', 'a/../../x', '/abs']) {
+      await expect(be.getBytes(key), key).rejects.toThrow(/invalid key|escapes/)
+    }
+  })
+
+  it('accepts the same keys the lexical validator does', async () => {
+    // The two checks have to agree, or the format allows an object this
+    // backend cannot touch. A name beginning with two dots is not traversal:
+    // the protocol forbids `.` and `..` only as whole components.
+    const be = await backend()
+    for (const key of ['..metadata', 'dir/..cache', '...x', 'wal/..a.jsonl']) {
+      expect(isValidObjectKey(key), key).toBe(true)
+      // Reaching a missing key rather than a rejection is the point.
+      expect(await be.getBytes(key), key).toBeUndefined()
+    }
   })
 
   it('reports a missing key rather than throwing', async () => {

--- a/test/durable/protocol.test.ts
+++ b/test/durable/protocol.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { existsSync } from 'fs'
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -716,6 +716,23 @@ describe('local backend conditional operations', () => {
     for (const key of ['../escape', 'a/../../x', '/abs']) {
       await expect(be.getBytes(key), key).rejects.toThrow(/invalid key|escapes/)
     }
+  })
+
+  it('surfaces an unreadable version chain instead of serving a stale version', async () => {
+    // The probe's answer decides which version is current. Treating an I/O or
+    // permission failure as "absent" would hand back the version below it and
+    // run every later operation against a state that is not the object's.
+    const be = await backend()
+    await chained(be)
+    const versions = join(be.root, '.head-versions')
+    await chmod(versions, 0o000)
+    try {
+      await expect(be.getBytesWithEtag('head.json')).rejects.toThrow(/failed to determine/)
+    } finally {
+      await chmod(versions, 0o755)
+    }
+    // Readable again, and the chain is intact.
+    expect((await be.getBytesWithEtag('head.json'))!.etag).toBe('v1')
   })
 
   it('accepts the same keys the lexical validator does', async () => {

--- a/test/durable/protocol.test.ts
+++ b/test/durable/protocol.test.ts
@@ -1,0 +1,557 @@
+/**
+ * Format and negotiation conformance (contract §4, §7.2, §7.3).
+ *
+ * These are the checks that decide whether another binding can read what this
+ * one writes, and — more importantly — whether this one correctly refuses what
+ * it must not read. The refusal cases matter more than the happy path: quietly
+ * ignoring a feature name or a checksum mismatch means opening a broken object
+ * and not knowing it.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { mkdtemp, readFile, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { coldHead, parseHead, serializeHead } from '../../src/durable/head'
+import { assertEngineCompatible, assertReadable, assertWritable } from '../../src/durable/negotiate'
+import { compareEngineVersions, maxEngineVersion, parseEngineVersion } from '../../src/durable/version'
+import { decodeWalSegment, encodeWalSegment, walLineBytes } from '../../src/durable/wal'
+import { checkpointKey, isValidObjectKey, walKey } from '../../src/durable/keys'
+import { LIMITS } from '../../src/durable/types'
+import { LocalDurableBackend } from '../../src/durable/backends/local'
+import {
+  QueryClass,
+  assertExecuteAllowed,
+  assertQueryAllowed,
+  type QueryAnalysis,
+} from '../../src/durable/engine-adapter'
+import { isDurableErrorOf } from '../../src/durable/errors'
+
+const SHA_A = 'a'.repeat(64)
+const SHA_B = 'b'.repeat(64)
+
+function bytes(o: unknown): Uint8Array {
+  return Buffer.from(JSON.stringify(o), 'utf8')
+}
+
+function goodHead(patch: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    protocol: { version: 1, reader_features: [], writer_features: [] },
+    engine: { name: 'chdb', version: '26.7.2', backup_format: 1, min_reader: '26.7.2' },
+    lease: { generation: 3, owner: 'w', instance: 'i', expires_at: 1788230400.0 },
+    manifest: {
+      db: 'mem',
+      base: { key: 'checkpoints/3-8-acde1234.tar.gz', size: 1048576, sha256: SHA_A },
+      wal: [{ key: 'wal/3-9-acde5678.jsonl', size: 127, sha256: SHA_B }],
+      seq: 9,
+    },
+    ...patch,
+  }
+}
+
+/** Assert an error carries a specific frozen category. */
+function expectCategory(fn: () => unknown, category: string): void {
+  let caught: unknown
+  try {
+    fn()
+  } catch (e) {
+    caught = e
+  }
+  expect(caught, `expected a ${category} error`).toBeDefined()
+  expect(isDurableErrorOf(caught, category as never), `got ${String(caught)}`).toBe(true)
+}
+
+describe('head.json schema', () => {
+  it('parses the frozen shape', () => {
+    const { head } = parseHead(bytes(goodHead()))
+    expect(head.manifest.db).toBe('mem')
+    expect(head.manifest.base?.size).toBe(1048576)
+    expect(head.manifest.wal).toHaveLength(1)
+    expect(head.lease.generation).toBe(3)
+  })
+
+  it('reads a head whose keys are in a different order and whitespace', () => {
+    const source = goodHead()
+    const flipped: Record<string, unknown> = {}
+    for (const k of Object.keys(source).reverse()) flipped[k] = source[k]
+    const { head } = parseHead(Buffer.from(JSON.stringify(flipped, null, 4), 'utf8'))
+    expect(head.manifest.seq).toBe(9)
+    expect(head.engine.version).toBe('26.7.2')
+  })
+
+  it('treats a released lease as fully null', () => {
+    const { head } = parseHead(
+      bytes(goodHead({ lease: { generation: 3, owner: null, instance: null, expires_at: null } })),
+    )
+    expect(head.lease).toEqual({ generation: 3, owner: null, instance: null, expires_at: null })
+  })
+
+  it('refuses a half-released lease rather than guessing', () => {
+    expectCategory(
+      () => parseHead(bytes(goodHead({ lease: { generation: 3, owner: 'w', instance: null, expires_at: null } }))),
+      'corrupt',
+    )
+  })
+
+  it('refuses a malformed digest', () => {
+    const h = goodHead()
+    ;(h['manifest'] as Record<string, unknown>)['base'] = {
+      key: 'checkpoints/1-1-aaaaaaaa.tar.gz',
+      size: 1,
+      sha256: 'NOTHEX',
+    }
+    expectCategory(() => parseHead(bytes(h)), 'corrupt')
+  })
+
+  it('refuses a reference whose key escapes the object prefix', () => {
+    const h = goodHead()
+    ;(h['manifest'] as Record<string, unknown>)['base'] = {
+      key: '../../etc/passwd',
+      size: 1,
+      sha256: SHA_A,
+    }
+    expectCategory(() => parseHead(bytes(h)), 'corrupt')
+  })
+
+  it('refuses a head with no engine block, because it cannot prove a version match', () => {
+    const h = goodHead()
+    delete h['engine']
+    expectCategory(() => parseHead(bytes(h)), 'corrupt')
+  })
+
+  it('refuses a head over the frozen 1 MiB limit', () => {
+    const h = goodHead({ padding: 'x'.repeat(LIMITS.MAX_HEAD_BYTES) })
+    expectCategory(() => parseHead(bytes(h)), 'limit_exceeded')
+  })
+
+  it('defaults the compatibility fields conservatively when they are absent', () => {
+    // An object written before these existed must not be retroactively widened:
+    // backup_format is the V1 baseline it necessarily used, and min_reader
+    // falls back to the producer, reproducing the old lower bound.
+    const h = goodHead()
+    ;(h['engine'] as Record<string, unknown>) = { name: 'chdb', version: '26.7.2' }
+    const { head } = parseHead(bytes(h))
+    expect(head.engine.backup_format).toBe(1)
+    expect(head.engine.min_reader).toBe('26.7.2')
+  })
+
+  it('validates the compatibility fields strictly when present', () => {
+    const bad = goodHead()
+    ;(bad['engine'] as Record<string, unknown>)['backup_format'] = 'one'
+    expectCategory(() => parseHead(bytes(bad)), 'corrupt')
+    const bad2 = goodHead()
+    ;(bad2['engine'] as Record<string, unknown>)['min_reader'] = 42
+    expectCategory(() => parseHead(bytes(bad2)), 'corrupt')
+  })
+
+  it('defaults a missing protocol block to the V1 baseline', () => {
+    const h = goodHead()
+    delete h['protocol']
+    const { head } = parseHead(bytes(h))
+    expect(head.protocol).toEqual({ version: 1, reader_features: [], writer_features: [] })
+  })
+})
+
+describe('head.json round-trip', () => {
+  it('preserves unknown fields at the top level and inside every known block', () => {
+    const original = goodHead({
+      unknown_top: { anything: [1, 2, 3] },
+      protocol: { version: 1, reader_features: [], writer_features: [], future_knob: 'keep me' },
+      engine: { name: 'chdb', version: '26.7.0', build: 'keep me too' },
+      lease: { generation: 3, owner: 'w', instance: 'i', expires_at: 1.5, note: 'and me' },
+      manifest: {
+        db: 'mem',
+        base: null,
+        wal: [],
+        seq: 0,
+        vendor_extension: { deep: true },
+      },
+    })
+    const { head, raw } = parseHead(bytes(original))
+
+    // Change something this build owns, then write back.
+    head.manifest.seq = 1
+    const out = JSON.parse(Buffer.from(serializeHead(head, raw)).toString('utf8'))
+
+    expect(out.unknown_top).toEqual({ anything: [1, 2, 3] })
+    expect(out.protocol.future_knob).toBe('keep me')
+    expect(out.engine.build).toBe('keep me too')
+    expect(out.lease.note).toBe('and me')
+    expect(out.manifest.vendor_extension).toEqual({ deep: true })
+    expect(out.manifest.seq).toBe(1)
+  })
+
+  it('round-trips a cold head through parse and serialize unchanged', () => {
+    const head = coldHead('mem', '26.7.0')
+    const { head: reparsed } = parseHead(serializeHead(head))
+    expect(reparsed).toEqual(head)
+  })
+
+  it('refuses to write a head that would exceed the limit', () => {
+    const head = coldHead('mem', '26.7.0')
+    head.manifest.wal = Array.from({ length: 20_000 }, (_, i) => ({
+      key: `wal/1-${i}-abcdefab.jsonl`,
+      size: 10,
+      sha256: SHA_A,
+    }))
+    expectCategory(() => serializeHead(head), 'limit_exceeded')
+  })
+})
+
+describe('protocol negotiation', () => {
+  it('refuses a future protocol version', () => {
+    const head = coldHead('mem', '26.7.0')
+    head.protocol.version = 2
+    expectCategory(() => assertReadable(head), 'protocol_unsupported')
+  })
+
+  it('refuses an unknown reader feature and names it', () => {
+    const head = coldHead('mem', '26.7.0')
+    head.protocol.reader_features = ['preamble']
+    let caught: unknown
+    try {
+      assertReadable(head)
+    } catch (e) {
+      caught = e
+    }
+    expect(isDurableErrorOf(caught, 'protocol_unsupported')).toBe(true)
+    expect((caught as Error).message).toContain('preamble')
+  })
+
+  it('allows reading but refuses writing on an unknown writer feature', () => {
+    const head = coldHead('mem', '26.7.0')
+    head.protocol.writer_features = ['data-wal']
+    expect(() => assertReadable(head)).not.toThrow()
+    expectCategory(() => assertWritable(head), 'protocol_unsupported')
+  })
+
+  it('opens for the producing engine and every later one', () => {
+    // The behaviour an exact-match gate got wrong. A newer chdb-core restores
+    // full backups made by an earlier one, so refusing them was refusing the
+    // normal upgrade path.
+    const head = coldHead('mem', '26.7.2-rc.2')
+    for (const v of ['26.7.2-rc.2', '26.7.2-rc.3', '26.7.2', '26.7.3', '26.8.1', '27.0.0']) {
+      expect(() => assertEngineCompatible(head, { version: v, backupFormat: 1 }), v).not.toThrow()
+    }
+  })
+
+  it('refuses a reader older than min_reader', () => {
+    const head = coldHead('mem', '26.7.2')
+    for (const v of ['26.7.1', '26.6.9', '26.7.2-rc.2', '25.1.0']) {
+      expectCategory(() => assertEngineCompatible(head, { version: v, backupFormat: 1 }), 'engine_incompatible')
+    }
+  })
+
+  it('refuses an archive format generation above this engine', () => {
+    // The escape hatch: version numbers keep rising whether or not the format
+    // still restores, so a withdrawn promise needs its own signal.
+    const head = coldHead('mem', '26.7.2')
+    head.engine.backup_format = 2
+    expectCategory(
+      () => assertEngineCompatible(head, { version: '27.0.0', backupFormat: 1 }),
+      'engine_incompatible',
+    )
+    expect(() => assertEngineCompatible(head, { version: '27.0.0', backupFormat: 2 })).not.toThrow()
+  })
+
+  it('does not gate on engine.version, which only records the producer', () => {
+    const head = coldHead('mem', '26.7.2')
+    head.engine.version = '26.7.2'
+    head.engine.min_reader = '26.7.2'
+    // Producer differs from the running engine, min_reader is satisfied: open.
+    expect(() => assertEngineCompatible(head, { version: '26.9.0', backupFormat: 1 })).not.toThrow()
+  })
+
+  it('refuses a different engine outright', () => {
+    const head = coldHead('mem', '26.7.2')
+    head.engine.name = 'not-chdb'
+    expectCategory(() => assertEngineCompatible(head, { version: '26.7.2', backupFormat: 1 }), 'engine_incompatible')
+  })
+
+  it('refuses rather than guesses when a version cannot be ordered', () => {
+    const head = coldHead('mem', '26.7.2')
+    head.engine.min_reader = 'nightly-build'
+    expectCategory(() => assertEngineCompatible(head, { version: '26.7.2', backupFormat: 1 }), 'engine_incompatible')
+  })
+})
+
+describe('release precedence', () => {
+  it('orders releases and pre-releases the way chDB ships them', () => {
+    const ascending = [
+      '25.9.0',
+      '26.7.1',
+      '26.7.2-rc.1',
+      '26.7.2-rc.2',
+      '26.7.2-rc.10',
+      '26.7.2',
+      '26.7.3',
+      '26.8.1',
+      '26.10.0',
+      '27.0.0',
+    ]
+    for (let i = 0; i < ascending.length - 1; i++) {
+      const a = ascending[i] as string
+      const b = ascending[i + 1] as string
+      expect(compareEngineVersions(a, b), `${a} < ${b}`).toBeLessThan(0)
+      expect(compareEngineVersions(b, a), `${b} > ${a}`).toBeGreaterThan(0)
+    }
+  })
+
+  it('does not order them as strings', () => {
+    // Both of these are backwards lexicographically, and both would let a
+    // reader open an object it cannot restore.
+    expect('26.10.0' < '26.7.0').toBe(true)
+    expect(compareEngineVersions('26.10.0', '26.7.0')).toBeGreaterThan(0)
+    expect('26.7.2-rc.2' > '26.7.2').toBe(true)
+    expect(compareEngineVersions('26.7.2-rc.2', '26.7.2')).toBeLessThan(0)
+  })
+
+  it('treats a missing component as zero', () => {
+    expect(compareEngineVersions('26.7', '26.7.0')).toBe(0)
+    expect(compareEngineVersions('26.7', '26.7.1')).toBeLessThan(0)
+  })
+
+  it('ignores build metadata, as precedence requires', () => {
+    expect(compareEngineVersions('26.7.2+build.5', '26.7.2')).toBe(0)
+  })
+
+  it('returns the later of two versions', () => {
+    expect(maxEngineVersion('26.7.2-rc.2', '26.7.2')).toBe('26.7.2')
+    expect(maxEngineVersion('26.8.0', '26.7.9')).toBe('26.8.0')
+  })
+
+  it("orders chDB's actual release shapes", () => {
+    // chDB ships only X.Y.Z and X.Y.Z-rc.N, and a patch that had an RC never
+    // gets a stable of the same number: after 26.7.2-rc.2 the next stable is
+    // 26.7.3. This is the sequence a real upgrade walks.
+    const shipped = ['26.7.1', '26.7.2-rc.1', '26.7.2-rc.2', '26.7.3', '26.7.4-rc.1', '26.8.0']
+    for (let i = 0; i < shipped.length - 1; i++) {
+      const a = shipped[i] as string
+      const b = shipped[i + 1] as string
+      expect(compareEngineVersions(a, b), `${a} < ${b}`).toBeLessThan(0)
+    }
+    // An object written by an RC therefore opens on every later stable.
+    expect(compareEngineVersions('26.7.3', '26.7.2-rc.2')).toBeGreaterThan(0)
+    expect(compareEngineVersions('26.8.0', '26.7.2-rc.2')).toBeGreaterThan(0)
+  })
+
+  it('still orders a same-numbered stable above its RC, though chDB does not ship one', () => {
+    // Being more permissive than the convention costs nothing; assuming the
+    // convention would be wrong the day it changes.
+    expect(compareEngineVersions('26.7.2-rc.2', '26.7.2')).toBeLessThan(0)
+  })
+
+  it('refuses to order something it cannot parse', () => {
+    expect(parseEngineVersion('nightly')).toBeUndefined()
+    expect(parseEngineVersion('')).toBeUndefined()
+    expectCategory(() => compareEngineVersions('26.7.2', 'nightly'), 'engine_incompatible')
+  })
+})
+
+describe('object keys', () => {
+  it('mints unique keys with the frozen shape', () => {
+    expect(checkpointKey(3, 8)).toMatch(/^checkpoints\/3-8-[0-9a-f]{8}\.tar\.gz$/)
+    expect(walKey(3, 9)).toMatch(/^wal\/3-9-[0-9a-f]{8}\.jsonl$/)
+    expect(walKey(1, 1)).not.toBe(walKey(1, 1))
+  })
+
+  it('rejects the key shapes a reference must never take', () => {
+    for (const bad of ['/abs', 'a//b', './a', '../a', 'a/../b', '', 'a\\b', 'a\0b']) {
+      expect(isValidObjectKey(bad), bad).toBe(false)
+    }
+    expect(isValidObjectKey('wal/1-1-abcdefab.jsonl')).toBe(true)
+  })
+})
+
+describe('WAL segments', () => {
+  it('round-trips statements in order', () => {
+    const statements = ['INSERT INTO t VALUES (1)', "ALTER TABLE t UPDATE x = 2 WHERE id = 1"]
+    const encoded = encodeWalSegment(statements)
+    expect(Buffer.from(encoded).toString('utf8').endsWith('\n')).toBe(true)
+    expect(decodeWalSegment(encoded, 'wal/x')).toEqual(statements)
+  })
+
+  it('round-trips statements containing newlines and quotes', () => {
+    const statements = ['INSERT INTO t VALUES (\'a\nb\')', 'INSERT INTO t VALUES ("c\\"d")']
+    expect(decodeWalSegment(encodeWalSegment(statements), 'wal/x')).toEqual(statements)
+  })
+
+  it('encodes an empty buffer as an empty segment', () => {
+    expect(decodeWalSegment(encodeWalSegment([]), 'wal/x')).toEqual([])
+  })
+
+  it('refuses a truncated segment rather than replaying a prefix', () => {
+    const encoded = Buffer.from(encodeWalSegment(['INSERT INTO t VALUES (1)']))
+    expectCategory(() => decodeWalSegment(encoded.subarray(0, encoded.length - 5), 'wal/x'), 'corrupt')
+  })
+
+  it('refuses a line that is not an object with a string sql', () => {
+    expectCategory(() => decodeWalSegment(Buffer.from('["INSERT"]\n'), 'wal/x'), 'corrupt')
+    expectCategory(() => decodeWalSegment(Buffer.from('{"sql":1}\n'), 'wal/x'), 'corrupt')
+    expectCategory(() => decodeWalSegment(Buffer.from('{"nope":"x"}\n'), 'wal/x'), 'corrupt')
+    expectCategory(() => decodeWalSegment(Buffer.from('not json\n'), 'wal/x'), 'corrupt')
+  })
+
+  it('budgets exactly what the encoder produces', () => {
+    // The object layer decides whether a statement fits by summing
+    // walLineBytes. If that disagrees with the encoder by even one byte per
+    // line, the boundary it enforces is the wrong boundary — so the two are
+    // pinned together here rather than left to stay in step by inspection.
+    const cases: string[][] = [
+      [],
+      ['INSERT INTO t VALUES (1)'],
+      ['INSERT INTO t VALUES (1)', 'INSERT INTO t VALUES (2)'],
+      ['a\nb', 'quote " and \\ backslash', '中文字符', '\u0000 nul'],
+      Array.from({ length: 200 }, (_, i) => `INSERT INTO t VALUES (${i})`),
+    ]
+    for (const statements of cases) {
+      const budget = statements.reduce((n, s) => n + walLineBytes(s), 0)
+      expect(budget, JSON.stringify(statements).slice(0, 60)).toBe(
+        encodeWalSegment(statements).byteLength,
+      )
+    }
+  })
+
+  it('refuses a statement over the frozen per-statement limit', () => {
+    const huge = 'x'.repeat(LIMITS.MAX_SQL_BYTES + 1)
+    expectCategory(() => encodeWalSegment([huge]), 'limit_exceeded')
+  })
+})
+
+describe('entry-point gates', () => {
+  const ok: QueryAnalysis = {
+    statementCount: 1,
+    queryClass: QueryClass.Mutating,
+    hasSecrets: false,
+    writesOnlyTargetDatabase: true,
+    changesDatabaseLifecycle: false,
+  }
+
+  it('accepts exactly one READ_ONLY statement on query', () => {
+    expect(() => assertQueryAllowed({ ...ok, queryClass: QueryClass.ReadOnly })).not.toThrow()
+  })
+
+  it('lets a read-only statement carry a secret, because it never reaches the WAL', () => {
+    expect(() =>
+      assertQueryAllowed({ ...ok, queryClass: QueryClass.ReadOnly, hasSecrets: true }),
+    ).not.toThrow()
+  })
+
+  it('refuses a mutation through query, whatever the method is called', () => {
+    expectCategory(() => assertQueryAllowed(ok), 'classification_refused')
+  })
+
+  it('refuses multiple statements at both entry points', () => {
+    expectCategory(() => assertQueryAllowed({ ...ok, queryClass: QueryClass.ReadOnly, statementCount: 2 }), 'classification_refused')
+    expectCategory(() => assertExecuteAllowed({ ...ok, statementCount: 2 }, 'mem'), 'classification_refused')
+  })
+
+  it('accepts a single in-database mutation on execute', () => {
+    expect(() => assertExecuteAllowed(ok, 'mem')).not.toThrow()
+  })
+
+  it('refuses every MUTATING_GLOBAL statement', () => {
+    expectCategory(
+      () => assertExecuteAllowed({ ...ok, queryClass: QueryClass.MutatingGlobal, writesOnlyTargetDatabase: false }, 'mem'),
+      'classification_refused',
+    )
+  })
+
+  it('refuses CONTROL and UNKNOWN, failing closed on the latter', () => {
+    expectCategory(() => assertExecuteAllowed({ ...ok, queryClass: QueryClass.Control }, 'mem'), 'classification_refused')
+    expectCategory(() => assertExecuteAllowed({ ...ok, queryClass: QueryClass.Unknown, statementCount: 0 }, 'mem'), 'classification_refused')
+  })
+
+  it('refuses a write core could not confine to this database', () => {
+    expectCategory(() => assertExecuteAllowed({ ...ok, writesOnlyTargetDatabase: false }, 'mem'), 'classification_refused')
+  })
+
+  it('refuses a database lifecycle change', () => {
+    expectCategory(() => assertExecuteAllowed({ ...ok, changesDatabaseLifecycle: true }, 'mem'), 'classification_refused')
+  })
+
+  it('refuses a secret-bearing mutation without echoing the statement', () => {
+    let caught: unknown
+    try {
+      assertExecuteAllowed({ ...ok, hasSecrets: true }, 'mem')
+    } catch (e) {
+      caught = e
+    }
+    expect(isDurableErrorOf(caught, 'secret_refused')).toBe(true)
+    expect((caught as Error).message).not.toMatch(/INSERT|SELECT|CREATE/)
+  })
+})
+
+describe('local backend conditional operations', () => {
+  async function backend(): Promise<LocalDurableBackend> {
+    const root = await mkdtemp(join(tmpdir(), 'durable-be-'))
+    return new LocalDurableBackend({ root: join(root, 'obj') })
+  }
+
+  it('creates once and refuses to overwrite', async () => {
+    const be = await backend()
+    expect(await be.putBytesIfAbsent('wal/1-1-aaaaaaaa.jsonl', Buffer.from('a'))).toBe('created')
+    expect(await be.putBytesIfAbsent('wal/1-1-aaaaaaaa.jsonl', Buffer.from('b'))).toBe('already-exists')
+    expect(Buffer.from((await be.getBytes('wal/1-1-aaaaaaaa.jsonl'))!).toString()).toBe('a')
+  })
+
+  it('replaces only against the current token', async () => {
+    const be = await backend()
+    await be.putBytesIfAbsent('head.json', Buffer.from('{"v":0}'))
+    const first = (await be.getBytesWithEtag('head.json'))!
+
+    const replaced = await be.replaceIfMatch('head.json', Buffer.from('{"v":1}'), first.etag)
+    expect(replaced.status).toBe('replaced')
+
+    const stale = await be.replaceIfMatch('head.json', Buffer.from('{"v":2}'), first.etag)
+    expect(stale.status).toBe('not-replaced')
+
+    const now = (await be.getBytesWithEtag('head.json'))!
+    expect(Buffer.from(now.bytes).toString()).toBe('{"v":1}')
+  })
+
+  it('lets exactly one of many concurrent replacers win', async () => {
+    const be = await backend()
+    await be.putBytesIfAbsent('head.json', Buffer.from('{"v":0}'))
+    const { etag } = (await be.getBytesWithEtag('head.json'))!
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, i) => be.replaceIfMatch('head.json', Buffer.from(`{"v":${i}}`), etag)),
+    )
+    expect(results.filter((r) => r.status === 'replaced')).toHaveLength(1)
+  })
+
+  it('adopts a plain head written by another implementation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-be-'))
+    const objDir = join(root, 'obj')
+    const be = new LocalDurableBackend({ root: objDir })
+    // Another binding's fixture: a plain file, no version chain.
+    await be.putBytesIfAbsent('placeholder', Buffer.from('x'))
+    await writeFile(join(objDir, 'head.json'), '{"foreign":true}')
+
+    const read = (await be.getBytesWithEtag('head.json'))!
+    expect(read.etag.startsWith('f')).toBe(true)
+    expect(Buffer.from(read.bytes).toString()).toBe('{"foreign":true}')
+
+    const out = await be.replaceIfMatch('head.json', Buffer.from('{"ours":true}'), read.etag)
+    expect(out.status).toBe('replaced')
+
+    // A plain-file reader still sees the current head through the symlink.
+    expect(await readFile(join(objDir, 'head.json'), 'utf8')).toBe('{"ours":true}')
+    const stale = await be.replaceIfMatch('head.json', Buffer.from('{"no":true}'), read.etag)
+    expect(stale.status).toBe('not-replaced')
+  })
+
+  it('refuses a key that would escape the object prefix', async () => {
+    const be = await backend()
+    await expect(be.getBytes('../escape')).rejects.toThrow(/invalid key|escapes/)
+  })
+
+  it('reports a missing key rather than throwing', async () => {
+    const be = await backend()
+    expect(await be.getBytes('wal/nope.jsonl')).toBeUndefined()
+    expect(await be.getBytesWithEtag('head.json')).toBeUndefined()
+    expect(await be.openReadStream('checkpoints/nope.tar.gz')).toBeUndefined()
+  })
+})

--- a/test/durable/s3-backend.test.ts
+++ b/test/durable/s3-backend.test.ts
@@ -1,0 +1,312 @@
+/**
+ * S3-compatible provider conformance.
+ *
+ * The contract is explicit that a provider is not supported because it claims
+ * S3 compatibility — it is supported because this suite passed against it
+ * (contract §7.5). So the whole file is parameterised: point it at MinIO, at
+ * real S3, or at R2, and it runs the same checks.
+ *
+ * ```sh
+ * CHDB_DURABLE_S3_BUCKET=my-bucket \
+ * CHDB_DURABLE_S3_ENDPOINT=http://127.0.0.1:9000 \
+ * CHDB_DURABLE_S3_REGION=us-east-1 \
+ * CHDB_DURABLE_S3_FORCE_PATH_STYLE=true \
+ * AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
+ *   npm run test:durable:s3
+ * ```
+ *
+ * Without a bucket configured the file skips rather than fails, because the
+ * rest of the durable suite has to stay runnable with no network.
+ *
+ * Two things are being checked, and the second matters more. The first is that
+ * the six backend methods behave; the second is that a durable object written
+ * through this provider on one "machine" comes back on another — a fresh
+ * engine, a fresh scratch directory, nothing shared but the bucket. That is
+ * the claim the whole feature makes, and it is only true if it is true here.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID, createHash } from 'crypto'
+import { pipeline } from 'stream/promises'
+import {
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+  S3Client,
+  type S3ClientConfig,
+} from '@aws-sdk/client-s3'
+
+import { S3DurableBackend } from '../../src/durable/backends/s3'
+import { DurableNamespace } from '../../src/durable/namespace'
+import type { DurableObject } from '../../src/durable/object'
+import { digestOf } from '../../src/durable/digest'
+import { isDurableErrorOf } from '../../src/durable/errors'
+import { FakeEngine } from './fakes'
+
+const BUCKET = process.env['CHDB_DURABLE_S3_BUCKET']
+const ENDPOINT = process.env['CHDB_DURABLE_S3_ENDPOINT']
+const REGION = process.env['CHDB_DURABLE_S3_REGION'] ?? 'us-east-1'
+const PATH_STYLE = process.env['CHDB_DURABLE_S3_FORCE_PATH_STYLE'] === 'true'
+
+/** Everything this run writes goes under one prefix, so cleanup is exact. */
+const RUN_PREFIX = `chdb-durable-test/${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`
+
+function clientConfig(): S3ClientConfig {
+  const cfg: S3ClientConfig = { region: REGION }
+  if (ENDPOINT) cfg.endpoint = ENDPOINT
+  if (PATH_STYLE) cfg.forcePathStyle = true
+  return cfg
+}
+
+const roots: string[] = []
+const openObjects: DurableObject[] = []
+let client: S3Client | undefined
+
+describe.skipIf(!BUCKET)(`S3-compatible backend (${ENDPOINT ?? 'aws'})`, () => {
+  beforeAll(() => {
+    client = new S3Client(clientConfig())
+  })
+
+  afterAll(async () => {
+    for (const o of openObjects.splice(0)) await o.close().catch(() => {})
+    for (const r of roots.splice(0)) await rm(r, { recursive: true, force: true })
+    // The protocol has no destroy, but a test that leaves objects in someone's
+    // bucket is a test that costs money. Cleanup is the suite's own business.
+    if (!client) return
+    let token: string | undefined
+    do {
+      const page = await client.send(
+        new ListObjectsV2Command({ Bucket: BUCKET, Prefix: RUN_PREFIX, ContinuationToken: token }),
+      )
+      const keys = (page.Contents ?? []).map((o) => ({ Key: o.Key as string }))
+      if (keys.length > 0) {
+        await client.send(new DeleteObjectsCommand({ Bucket: BUCKET, Delete: { Objects: keys } }))
+      }
+      token = page.IsTruncated ? page.NextContinuationToken : undefined
+    } while (token)
+    client.destroy()
+  })
+
+  function backend(name: string): S3DurableBackend {
+    return new S3DurableBackend({
+      bucket: BUCKET as string,
+      prefix: `${RUN_PREFIX}/${name}-${randomUUID().slice(0, 8)}`,
+      clientConfig: clientConfig(),
+    })
+  }
+
+  describe('conditional operations', () => {
+    it('creates once and refuses to overwrite', async () => {
+      const be = backend('create')
+      expect(await be.putBytesIfAbsent('wal/1-1-aaaaaaaa.jsonl', Buffer.from('first'))).toBe('created')
+      expect(await be.putBytesIfAbsent('wal/1-1-aaaaaaaa.jsonl', Buffer.from('second'))).toBe(
+        'already-exists',
+      )
+      expect(Buffer.from((await be.getBytes('wal/1-1-aaaaaaaa.jsonl'))!).toString()).toBe('first')
+    })
+
+    it('replaces only against the current token', async () => {
+      const be = backend('replace')
+      await be.putBytesIfAbsent('head.json', Buffer.from('{"v":0}'))
+      const first = (await be.getBytesWithEtag('head.json'))!
+
+      const ok = await be.replaceIfMatch('head.json', Buffer.from('{"v":1}'), first.etag)
+      expect(ok.status).toBe('replaced')
+
+      const stale = await be.replaceIfMatch('head.json', Buffer.from('{"v":2}'), first.etag)
+      expect(stale.status).toBe('not-replaced')
+
+      const now = (await be.getBytesWithEtag('head.json'))!
+      expect(Buffer.from(now.bytes).toString()).toBe('{"v":1}')
+      // The token moved, which is what makes the previous one stale.
+      expect(now.etag).not.toBe(first.etag)
+    })
+
+    it('lets exactly one of many concurrent replacers win', async () => {
+      const be = backend('race')
+      await be.putBytesIfAbsent('head.json', Buffer.from('{"v":0}'))
+      const { etag } = (await be.getBytesWithEtag('head.json'))!
+
+      // Every racer writes content distinct from the current object and from
+      // each other. That matters on a content-hash ETag: a racer that happened
+      // to write the bytes already there would leave the token unmoved, and a
+      // second racer holding it would also win — which is a property of the
+      // ETag, not a compare-and-swap failure. See the ETag test below.
+      const results = await Promise.all(
+        Array.from({ length: 8 }, (_, i) =>
+          be.replaceIfMatch('head.json', Buffer.from(`{"v":${i + 1}}`), etag),
+        ),
+      )
+      // A provider without real compare-and-swap fails here, and only here.
+      expect(results.filter((r) => r.status === 'replaced')).toHaveLength(1)
+      expect(results.filter((r) => r.status === 'not-replaced')).toHaveLength(7)
+    })
+
+    it('does not advance the token when the bytes do not change', async () => {
+      // Not a defect, and not something to work around — a consequence of the
+      // ETag being a content hash. It is asserted so that the assumption
+      // durable relies on stays visible: every head write must change the
+      // bytes, or the token it was written under remains usable.
+      const be = backend('idempotent')
+      await be.putBytesIfAbsent('head.json', Buffer.from('{"v":0}'))
+      const first = (await be.getBytesWithEtag('head.json'))!
+
+      const same = await be.replaceIfMatch('head.json', Buffer.from('{"v":0}'), first.etag)
+      expect(same.status).toBe('replaced')
+      const after = (await be.getBytesWithEtag('head.json'))!
+      expect(after.etag).toBe(first.etag)
+
+      // The original token still matches, because nothing about the object moved.
+      const again = await be.replaceIfMatch('head.json', Buffer.from('{"v":1}'), first.etag)
+      expect(again.status).toBe('replaced')
+      // Different bytes, so now it does move.
+      expect((await be.getBytesWithEtag('head.json'))!.etag).not.toBe(first.etag)
+    })
+
+    it('reports a missing key rather than throwing', async () => {
+      const be = backend('missing')
+      expect(await be.getBytes('wal/nope.jsonl')).toBeUndefined()
+      expect(await be.getBytesWithEtag('head.json')).toBeUndefined()
+      expect(await be.openReadStream('checkpoints/nope.tar.gz')).toBeUndefined()
+    })
+
+    it('refuses a key that would escape the object prefix', async () => {
+      const be = backend('escape')
+      await expect(be.getBytes('../escape')).rejects.toThrow(/invalid key/)
+    })
+  })
+
+  describe('large objects', () => {
+    it('streams a file up and back down with its digest intact', async () => {
+      const be = backend('stream')
+      const dir = await mkdtemp(join(tmpdir(), 'durable-s3-'))
+      roots.push(dir)
+
+      // Big enough that buffering it would be visible, small enough to be
+      // polite to a real bucket.
+      const payload = Buffer.alloc(12 * 1024 * 1024)
+      for (let i = 0; i < payload.length; i += 4096) payload.writeUInt32BE(i, i)
+      const path = join(dir, 'checkpoint.tar.gz')
+      await writeFile(path, payload)
+      const expected = digestOf(payload)
+
+      expect(await be.putFileIfAbsent('checkpoints/1-1-aaaaaaaa.tar.gz', path)).toBe('created')
+
+      const stream = await be.openReadStream('checkpoints/1-1-aaaaaaaa.tar.gz')
+      expect(stream).toBeDefined()
+      const hash = createHash('sha256')
+      let size = 0
+      await pipeline(stream!, async function* (source) {
+        for await (const chunk of source) {
+          hash.update(chunk as Buffer)
+          size += (chunk as Buffer).length
+        }
+      })
+      expect(size).toBe(expected.size)
+      expect(hash.digest('hex')).toBe(expected.sha256)
+    })
+  })
+
+  describe('recovery on another machine', () => {
+    /** A namespace whose objects live in the bucket, with a private scratch tree. */
+    async function machine(): Promise<{ ns: DurableNamespace; engines: FakeEngine[] }> {
+      const scratch = await mkdtemp(join(tmpdir(), 'durable-s3-machine-'))
+      roots.push(scratch)
+      const engines: FakeEngine[] = []
+      const suffix = ENDPOINT
+        ? `?region=${REGION}&endpoint=${encodeURIComponent(ENDPOINT)}${PATH_STYLE ? '&forcePathStyle=true' : ''}`
+        : `?region=${REGION}`
+      const ns = new DurableNamespace(`s3://${BUCKET}/${RUN_PREFIX}/recovery${suffix}`, {
+        engineFactory: () => {
+          const e = new FakeEngine()
+          engines.push(e)
+          return e
+        },
+        scratchRoot: scratch,
+        tuning: { leaseTtlMs: 60_000, heartbeatIntervalMs: 15_000 },
+      })
+      return { ns, engines }
+    }
+
+    it('recovers a WAL-only object on a machine that shares nothing but the bucket', async () => {
+      const objectId = `obj-${randomUUID().slice(0, 8)}`
+
+      const a = await machine()
+      const w = await a.ns.open(objectId, { database: 'mem' })
+      openObjects.push(w)
+      await w.execute('INSERT INTO t VALUES (1)')
+      await w.execute('INSERT INTO t VALUES (2)')
+      await w.flush()
+      await w.close()
+      openObjects.length = 0
+
+      // Different namespace instance, different engine, different scratch.
+      const b = await machine()
+      const r = await b.ns.open(objectId)
+      openObjects.push(r)
+      expect(b.engines[0]!.statements).toEqual(['INSERT INTO t VALUES (1)', 'INSERT INTO t VALUES (2)'])
+      expect(r.generation).toBe(2)
+      await r.close()
+      openObjects.length = 0
+    })
+
+    it('recovers a checkpointed object, base and trailing WAL both', async () => {
+      const objectId = `obj-${randomUUID().slice(0, 8)}`
+
+      const a = await machine()
+      const w = await a.ns.open(objectId, { database: 'mem' })
+      openObjects.push(w)
+      await w.execute('INSERT INTO t VALUES (1)')
+      const base = await w.checkpoint()
+      await w.execute('INSERT INTO t VALUES (2)')
+      await w.flush()
+      await w.close()
+      openObjects.length = 0
+
+      const b = await machine()
+      const r = await b.ns.open(objectId)
+      openObjects.push(r)
+      expect(r.manifest.base?.key).toBe(base.key)
+      expect(r.manifest.wal).toHaveLength(1)
+      expect(b.engines[0]!.statements).toEqual(['INSERT INTO t VALUES (1)', 'INSERT INTO t VALUES (2)'])
+      await r.close()
+      openObjects.length = 0
+    })
+
+    it('refuses a second writer while the first holds the lease', async () => {
+      const objectId = `obj-${randomUUID().slice(0, 8)}`
+      const a = await machine()
+      const w = await a.ns.open(objectId, { database: 'mem' })
+      openObjects.push(w)
+
+      const b = await machine()
+      let caught: unknown
+      try {
+        await b.ns.open(objectId)
+      } catch (e) {
+        caught = e
+      }
+      expect(isDurableErrorOf(caught, 'lease_held')).toBe(true)
+    })
+
+    it('serves a read-only snapshot without disturbing the writer', async () => {
+      const objectId = `obj-${randomUUID().slice(0, 8)}`
+      const a = await machine()
+      const w = await a.ns.open(objectId, { database: 'mem' })
+      openObjects.push(w)
+      await w.execute('INSERT INTO t VALUES (1)')
+      await w.flush()
+
+      const b = await machine()
+      const r = await b.ns.open(objectId, { readOnly: true })
+      openObjects.push(r)
+      expect(b.engines[0]!.statements).toEqual(['INSERT INTO t VALUES (1)'])
+      // The writer still owns the lease and can still commit.
+      await w.execute('INSERT INTO t VALUES (2)')
+      await w.flush()
+      expect(w.manifest.wal).toHaveLength(2)
+    })
+  })
+})

--- a/test/durable/state-machine.test.ts
+++ b/test/durable/state-machine.test.ts
@@ -129,6 +129,15 @@ describe('cold create and reopen', () => {
     expect(await o.flush()).toBeUndefined()
   })
 
+  it('refuses an empty database name before anything is published', async () => {
+    const h = await harness()
+    const e = await catchError(() => h.ns.open('obj', { database: '' }))
+    expect(e).toBeInstanceOf(RangeError)
+    // Nothing was written, so the id is still usable.
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    expect(o.database).toBe('mem')
+  })
+
   it('refuses to create when existingOnly is set', async () => {
     const h = await harness()
     expect(isDurableErrorOf(await catchError(() => h.ns.open('obj', { existingOnly: true })), 'not_found')).toBe(true)

--- a/test/durable/state-machine.test.ts
+++ b/test/durable/state-machine.test.ts
@@ -1,0 +1,858 @@
+/**
+ * Lifecycle, lease and fault-matrix conformance (contract §5, §7.4).
+ *
+ * The happy path here is short. Most of the file is about what happens when a
+ * step does not cleanly succeed, because that is where a durable object either
+ * keeps its promise or quietly stops keeping it: a commit whose response was
+ * lost, a checkpoint that uploaded but did not publish, a writer that was
+ * taken over while it thought it was still the writer.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtemp, readdir, readFile, rm, stat, unlink, writeFile } from 'fs/promises'
+import { existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+
+import { DurableNamespace } from '../../src/durable/namespace'
+import { LocalDurableBackend } from '../../src/durable/backends/local'
+import type { RestoreProgress } from '../../src/durable/object'
+import { DurableObject } from '../../src/durable/object'
+import { isDurableErrorOf } from '../../src/durable/errors'
+import { LIMITS } from '../../src/durable/types'
+import { FakeEngine, FaultBackend } from './fakes'
+
+const FAST = {
+  leaseTtlMs: 1_500,
+  heartbeatIntervalMs: 400,
+  clockSkewAllowanceMs: 100,
+  commitDeadlineMs: 1_500,
+  maxCommitAttempts: 3,
+}
+
+const roots: string[] = []
+const open: DurableObject[] = []
+
+afterEach(async () => {
+  for (const o of open.splice(0)) await o.close().catch(() => {})
+  for (const r of roots.splice(0)) await rm(r, { recursive: true, force: true })
+})
+
+interface Harness {
+  root: string
+  objectDir: string
+  ns: DurableNamespace
+  engines: FakeEngine[]
+  faults: FaultBackend[]
+}
+
+async function harness(options: { fault?: boolean } = {}): Promise<Harness> {
+  const root = await mkdtemp(join(tmpdir(), 'durable-sm-'))
+  roots.push(root)
+  const engines: FakeEngine[] = []
+  const faults: FaultBackend[] = []
+  const ns = new DurableNamespace(pathToFileURL(root).href, {
+    engineFactory: () => {
+      const e = new FakeEngine()
+      engines.push(e)
+      return e
+    },
+    backendFactory: (id) => {
+      const inner = new LocalDurableBackend({ root: join(root, id) })
+      if (!options.fault) return inner
+      const wrapped = new FaultBackend(inner)
+      faults.push(wrapped)
+      return wrapped
+    },
+    tuning: FAST,
+    scratchRoot: root,
+  })
+  return { root, objectDir: join(root, 'obj'), ns, engines, faults }
+}
+
+async function track(p: Promise<DurableObject>): Promise<DurableObject> {
+  const o = await p
+  open.push(o)
+  return o
+}
+
+async function catchError(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+    return undefined
+  } catch (e) {
+    return e
+  }
+}
+
+/** Names of every immutable object published under a subdirectory. */
+async function listed(dir: string): Promise<string[]> {
+  try {
+    return (await readdir(dir)).sort()
+  } catch {
+    return []
+  }
+}
+
+describe('cold create and reopen', () => {
+  it('creates the object, commits a WAL segment, and replays it on reopen', async () => {
+    const h = await harness()
+    const a = await track(h.ns.open('obj', { database: 'mem' }))
+    expect(a.generation).toBe(1)
+    expect(a.manifest.base).toBeNull()
+
+    await a.execute('INSERT INTO t VALUES (1)')
+    await a.execute('INSERT INTO t VALUES (2)')
+    expect(a.pendingStatements).toBe(2)
+
+    const ref = await a.flush()
+    expect(ref?.key).toMatch(/^wal\/1-1-[0-9a-f]{8}\.jsonl$/)
+    expect(a.pendingStatements).toBe(0)
+    expect(a.manifest.seq).toBe(1)
+    await a.close()
+    open.length = 0
+
+    const b = await track(h.ns.open('obj'))
+    expect(h.engines[1]!.statements).toEqual(['INSERT INTO t VALUES (1)', 'INSERT INTO t VALUES (2)'])
+    // Reopening from a released lease takes the next generation.
+    expect(b.generation).toBe(2)
+    expect(b.database).toBe('mem')
+  })
+
+  it('never records a statement whose local execution failed', async () => {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    h.engines[0]!.failNextRun = new Error('engine said no')
+    await expect(o.execute('INSERT INTO t VALUES (1)')).rejects.toThrow('engine said no')
+    expect(o.pendingStatements).toBe(0)
+    expect(await o.flush()).toBeUndefined()
+  })
+
+  it('refuses to create when existingOnly is set', async () => {
+    const h = await harness()
+    expect(isDurableErrorOf(await catchError(() => h.ns.open('obj', { existingOnly: true })), 'not_found')).toBe(true)
+  })
+})
+
+describe('checkpoint', () => {
+  it('replaces the base, clears the WAL list, and keeps the data', async () => {
+    const h = await harness()
+    const a = await track(h.ns.open('obj', { database: 'mem' }))
+    await a.execute('INSERT INTO t VALUES (1)')
+    await a.flush()
+    await a.execute('INSERT INTO t VALUES (2)')
+
+    // The unflushed statement is in the local database, so the backup carries
+    // it and the commit may clear it from the buffer.
+    const base = await a.checkpoint()
+    expect(base.key).toMatch(/^checkpoints\//)
+    expect(a.manifest.base?.key).toBe(base.key)
+    expect(a.manifest.wal).toEqual([])
+    expect(a.pendingStatements).toBe(0)
+    await a.close()
+    open.length = 0
+
+    const b = await track(h.ns.open('obj'))
+    expect(h.engines[1]!.statements).toEqual(['INSERT INTO t VALUES (1)', 'INSERT INTO t VALUES (2)'])
+    expect(b.manifest.base?.key).toBe(base.key)
+  })
+
+  it('leaves no archive behind in the scratch tree', async () => {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+    await o.checkpoint()
+    const backups = await listed(join(o.scratchPath, 'backups'))
+    expect(backups).toEqual([])
+  })
+})
+
+describe('read-only opens', () => {
+  it('reports not_found for an object that does not exist', async () => {
+    const h = await harness()
+    expect(isDurableErrorOf(await catchError(() => h.ns.open('obj', { readOnly: true })), 'not_found')).toBe(true)
+  })
+
+  it('takes no lease and refuses writes', async () => {
+    const h = await harness()
+    const w = await track(h.ns.open('obj', { database: 'mem' }))
+    await w.execute('INSERT INTO t VALUES (1)')
+    await w.flush()
+    await w.close()
+    open.length = 0
+
+    const r = await track(h.ns.open('obj', { readOnly: true }))
+    expect(h.engines[1]!.statements).toEqual(['INSERT INTO t VALUES (1)'])
+    expect(isDurableErrorOf(await catchError(() => r.execute('INSERT INTO t VALUES (2)')), 'classification_refused')).toBe(true)
+
+    // The lease is untouched, so a writer can still take it while this reads.
+    const w2 = await track(h.ns.open('obj'))
+    expect(w2.generation).toBe(2)
+  })
+})
+
+describe('lease, takeover and fencing', () => {
+  it('refuses a second writer while the lease is live', async () => {
+    const h = await harness()
+    await track(h.ns.open('obj', { database: 'mem' }))
+    const e = await catchError(() => h.ns.open('obj'))
+    expect(isDurableErrorOf(e, 'lease_held')).toBe(true)
+  })
+
+  it('releases the lease on a clean close so the next writer finds it free', async () => {
+    const h = await harness()
+    const a = await track(h.ns.open('obj', { database: 'mem' }))
+    expect(a.generation).toBe(1)
+    await a.close()
+    open.length = 0
+
+    const stored = JSON.parse(await readFile(join(h.objectDir, 'head.json'), 'utf8'))
+    expect(stored.lease).toEqual({ generation: 1, owner: null, instance: null, expires_at: null })
+
+    const b = await track(h.ns.open('obj'))
+    expect(b.generation).toBe(2)
+  })
+
+  it('takes over a lease whose recorded expiry is past the skew allowance', async () => {
+    const h = await harness()
+    const be = new LocalDurableBackend({ root: h.objectDir })
+    // A writer that died holding the lease: still named, expiry long gone.
+    await be.putBytesIfAbsent(
+      'head.json',
+      Buffer.from(
+        JSON.stringify({
+          protocol: { version: 1, reader_features: [], writer_features: [] },
+          engine: { name: 'chdb', version: '26.7.0' },
+          lease: { generation: 6, owner: 'dead-worker', instance: 'gone', expires_at: (Date.now() - 60_000) / 1000 },
+          manifest: { db: 'mem', base: null, wal: [], seq: 0 },
+        }),
+      ),
+    )
+    const o = await track(h.ns.open('obj'))
+    expect(o.generation).toBe(7)
+  })
+
+  it('refuses to take over a lease that has expired by less than the skew allowance', async () => {
+    const h = await harness()
+    const be = new LocalDurableBackend({ root: h.objectDir })
+    await be.putBytesIfAbsent(
+      'head.json',
+      Buffer.from(
+        JSON.stringify({
+          protocol: { version: 1, reader_features: [], writer_features: [] },
+          engine: { name: 'chdb', version: '26.7.0' },
+          lease: { generation: 6, owner: 'maybe-alive', instance: 'x', expires_at: Date.now() / 1000 },
+          manifest: { db: 'mem', base: null, wal: [], seq: 0 },
+        }),
+      ),
+    )
+    // Expired by ~0ms, allowance is 100ms: the clocks may simply disagree.
+    expect(isDurableErrorOf(await catchError(() => h.ns.open('obj')), 'lease_held')).toBe(true)
+    // Forcing is the documented escape hatch, and it is explicit.
+    const o = await track(h.ns.open('obj', { force: true }))
+    expect(o.generation).toBe(7)
+  })
+
+  it('fences the previous writer after a forced takeover', async () => {
+    const h = await harness()
+    const a = await track(h.ns.open('obj', { database: 'mem' }))
+    await a.execute('INSERT INTO t VALUES (1)')
+
+    const b = await track(h.ns.open('obj', { force: true }))
+    expect(b.generation).toBe(2)
+
+    // The old writer only learns on its next commit — which is exactly the
+    // point of fencing, and why force carries a data-loss warning.
+    const e = await catchError(() => a.flush())
+    expect(isDurableErrorOf(e, 'lease_fenced')).toBe(true)
+    expect(a.isFenced).toBe(true)
+  })
+
+  it('self-fences when it cannot confirm its lease before the window lapses', async () => {
+    const h = await harness({ fault: true })
+    const o = await track(
+      h.ns.open('obj', { database: 'mem', tuning: { ...FAST, leaseTtlMs: 300, heartbeatIntervalMs: 100 } }),
+    )
+    // Every head write from now on fails, so no heartbeat can land.
+    for (let i = 0; i < 40; i++) h.faults[0]!.inject({ on: 'replace', result: 'throw' })
+    await new Promise((r) => setTimeout(r, 500))
+
+    const e = await catchError(() => o.execute('INSERT INTO t VALUES (1)'))
+    expect(isDurableErrorOf(e, 'lease_fenced')).toBe(true)
+  })
+
+  it('keeps the lease alive across an idle period through heartbeat', async () => {
+    const h = await harness()
+    const o = await track(
+      h.ns.open('obj', { database: 'mem', tuning: { ...FAST, leaseTtlMs: 600, heartbeatIntervalMs: 150 } }),
+    )
+    await new Promise((r) => setTimeout(r, 900))
+    // Still ours: no generation bump, and writes are accepted.
+    await o.execute('INSERT INTO t VALUES (1)')
+    expect(o.generation).toBe(1)
+    expect(o.isFenced).toBe(false)
+  })
+})
+
+describe('fault matrix', () => {
+  it('keeps the old manifest and the local buffer when a WAL commit fails', async () => {
+    const h = await harness({ fault: true })
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+
+    // The segment uploads; every attempt to publish the reference is refused.
+    // Every refusal is definite, so the outcome is known — nothing committed —
+    // and that is `timeout`, not `commit_ambiguous`. The caller can retry this
+    // safely; it could not retry an ambiguous one.
+    for (let i = 0; i < 5; i++) h.faults[0]!.inject({ on: 'replace', result: 'not-replaced' })
+    const e = await catchError(() => o.flush())
+    expect(isDurableErrorOf(e, 'timeout')).toBe(true)
+
+    expect(o.manifest.wal).toEqual([])
+    // The statement is still buffered, so a later flush can still commit it.
+    expect(o.pendingStatements).toBe(1)
+    // And the orphaned segment is on disk, collectable but unreferenced.
+    expect((await listed(join(h.objectDir, 'wal'))).length).toBe(1)
+  })
+
+  it('reconciles a head commit whose response was lost into a success', async () => {
+    const h = await harness({ fault: true })
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+
+    h.faults[0]!.inject({ on: 'replace', result: 'commit-then-ambiguous' })
+    const ref = await o.flush()
+
+    expect(ref).toBeDefined()
+    expect(o.manifest.wal.map((w) => w.key)).toEqual([ref!.key])
+    expect(o.pendingStatements).toBe(0)
+  })
+
+  it('reports commit_ambiguous rather than success when nothing can be proven', async () => {
+    const h = await harness({ fault: true })
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+
+    // Every head write answers "maybe", and re-reading never shows the
+    // intent. There is no honest answer except that we do not know.
+    for (let i = 0; i < 6; i++) h.faults[0]!.inject({ on: 'replace', result: 'ambiguous' })
+    const e = await catchError(() => o.flush())
+    expect(isDurableErrorOf(e, 'commit_ambiguous')).toBe(true)
+    expect(o.pendingStatements).toBe(1)
+  })
+
+  it('treats a WAL upload that landed but lost its response as published', async () => {
+    const h = await harness({ fault: true })
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+
+    // The segment really is written; only the answer went missing. Re-reading
+    // the unique key and matching its digest turns that back into a fact.
+    h.faults[0]!.inject({ on: 'putBytes', key: /^wal\//, result: 'write-then-ambiguous' })
+    const ref = await o.flush()
+    expect(ref).toBeDefined()
+    expect(o.manifest.wal.map((w) => w.key)).toEqual([ref!.key])
+    expect(o.pendingStatements).toBe(0)
+  })
+
+  it('treats a checkpoint upload that landed but lost its response as published', async () => {
+    const h = await harness({ fault: true })
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+
+    h.faults[0]!.inject({ on: 'putFile', key: /^checkpoints\//, result: 'write-then-ambiguous' })
+    const base = await o.checkpoint()
+    expect(o.manifest.base?.key).toBe(base.key)
+  })
+
+  it('reports an upload it cannot find as ambiguous rather than as published', async () => {
+    const h = await harness({ fault: true })
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+
+    // Nothing was written and the answer was lost: there is no proof either
+    // way, and inventing one would be the only unrecoverable mistake here.
+    h.faults[0]!.inject({ on: 'putBytes', key: /^wal\//, result: 'ambiguous' })
+    expect(isDurableErrorOf(await catchError(() => o.flush()), 'commit_ambiguous')).toBe(true)
+    expect(o.pendingStatements).toBe(1)
+  })
+
+  it('refuses a published object whose bytes are not the bytes it meant to publish', async () => {
+    const h = await harness({ fault: true })
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+
+    // The key exists, holding content that is not ours. A key match is not
+    // proof of a commit; a digest match is.
+    h.faults[0]!.inject({ on: 'putBytes', key: /^wal\//, result: 'divergent-then-exists' })
+    const e = await catchError(() => o.flush())
+    expect(isDurableErrorOf(e, 'corrupt')).toBe(true)
+    expect((e as Error).message).toMatch(/sha256|size/)
+    expect(o.pendingStatements).toBe(1)
+  })
+
+  it('keeps the old base recoverable when a checkpoint uploads but does not publish', async () => {
+    const h = await harness({ fault: true })
+    const a = await track(h.ns.open('obj', { database: 'mem' }))
+    await a.execute('INSERT INTO t VALUES (1)')
+    await a.flush()
+    const walBefore = a.manifest.wal.map((w) => w.key)
+
+    await a.execute('INSERT INTO t VALUES (2)')
+    for (let i = 0; i < 5; i++) h.faults[0]!.inject({ on: 'replace', result: 'not-replaced' })
+    expect(isDurableErrorOf(await catchError(() => a.checkpoint()), 'timeout')).toBe(true)
+
+    // Old manifest intact, unflushed statement still buffered.
+    expect(a.manifest.base).toBeNull()
+    expect(a.manifest.wal.map((w) => w.key)).toEqual(walBefore)
+    expect(a.pendingStatements).toBe(1)
+    // The uploaded checkpoint is an orphan, not a new base.
+    expect((await listed(join(h.objectDir, 'checkpoints'))).length).toBe(1)
+  })
+
+  it('closes the partial engine and releases the lease when replay fails', async () => {
+    const h = await harness()
+    const a = await track(h.ns.open('obj', { database: 'mem' }))
+    await a.execute('INSERT INTO t VALUES (1)')
+    await a.flush()
+    await a.close()
+    open.length = 0
+
+    const before = await readdir(h.root)
+    // The next engine refuses to replay.
+    const failing = new FakeEngine()
+    failing.failNextRun = new Error('replay exploded')
+    const ns = new DurableNamespace(pathToFileURL(h.root).href, {
+      engineFactory: () => failing,
+      backendFactory: (id) => new LocalDurableBackend({ root: join(h.root, id) }),
+      tuning: FAST,
+      scratchRoot: h.root,
+    })
+    await expect(ns.open('obj')).rejects.toThrow('replay exploded')
+
+    expect(failing.closed).toBe(true)
+    // The lease was released, so a healthy writer can still take the object.
+    const recovered = await track(h.ns.open('obj'))
+    expect(recovered.manifest.wal).toHaveLength(1)
+    // And no scratch tree was left behind.
+    const after = await readdir(h.root)
+    expect(after.filter((d) => d.startsWith('chdb-durable-')).length).toBeLessThanOrEqual(
+      before.filter((d) => d.startsWith('chdb-durable-')).length + 1,
+    )
+  })
+
+  it('surfaces a failed close flush and still releases local resources', async () => {
+    const h = await harness({ fault: true })
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+    for (let i = 0; i < 6; i++) h.faults[0]!.inject({ on: 'replace', result: 'not-replaced' })
+
+    const e = await catchError(() => o.close())
+    expect(isDurableErrorOf(e, 'timeout')).toBe(true)
+    expect(h.engines[0]!.closed).toBe(true)
+    expect(existsSync(o.scratchPath)).toBe(false)
+    open.length = 0
+
+    expect(isDurableErrorOf(await catchError(() => o.execute('INSERT INTO t VALUES (2)')), 'closed')).toBe(true)
+  })
+})
+
+describe('corruption', () => {
+  async function objectWithWal(): Promise<Harness> {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+    await o.flush()
+    await o.close()
+    open.length = 0
+    return h
+  }
+
+  it('refuses to open when a referenced WAL segment is gone', async () => {
+    const h = await objectWithWal()
+    const dir = join(h.objectDir, 'wal')
+    for (const f of await readdir(dir)) await unlink(join(dir, f))
+    expect(isDurableErrorOf(await catchError(() => h.ns.open('obj')), 'corrupt')).toBe(true)
+  })
+
+  it('refuses to open when a WAL segment does not match its digest', async () => {
+    const h = await objectWithWal()
+    const dir = join(h.objectDir, 'wal')
+    const [name] = await readdir(dir)
+    const path = join(dir, name as string)
+    const size = (await stat(path)).size
+    // Same length, different bytes: only the checksum can catch this.
+    await unlink(path)
+    await writeFile(path, 'x'.repeat(size))
+    const e = await catchError(() => h.ns.open('obj'))
+    expect(isDurableErrorOf(e, 'corrupt')).toBe(true)
+    expect((e as Error).message).toMatch(/sha256/)
+  })
+
+  it('refuses to open when a WAL segment is the wrong length', async () => {
+    const h = await objectWithWal()
+    const dir = join(h.objectDir, 'wal')
+    const [name] = await readdir(dir)
+    const path = join(dir, name as string)
+    const body = await readFile(path)
+    await unlink(path)
+    await writeFile(path, Buffer.concat([body, Buffer.from('\n')]))
+    const e = await catchError(() => h.ns.open('obj'))
+    expect(isDurableErrorOf(e, 'corrupt')).toBe(true)
+    expect((e as Error).message).toMatch(/size/)
+  })
+
+  it('refuses to open when the base checkpoint is gone', async () => {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+    await o.checkpoint()
+    await o.close()
+    open.length = 0
+
+    const dir = join(h.objectDir, 'checkpoints')
+    for (const f of await readdir(dir)) await unlink(join(dir, f))
+    expect(isDurableErrorOf(await catchError(() => h.ns.open('obj')), 'corrupt')).toBe(true)
+  })
+})
+
+describe('foreign heads', () => {
+  /** A head as another binding would have written it: plain file, unknown fields. */
+  async function writeForeignHead(objectDir: string, extra: Record<string, unknown>): Promise<void> {
+    const be = new LocalDurableBackend({ root: objectDir })
+    await be.putBytesIfAbsent(
+      'head.json',
+      Buffer.from(
+        JSON.stringify({
+          protocol: { version: 1, reader_features: [], writer_features: [], vendor_flag: 7 },
+          engine: { name: 'chdb', version: '26.7.0', built_by: 'python' },
+          lease: { generation: 4, owner: null, instance: null, expires_at: null },
+          manifest: { db: 'mem', base: null, wal: [], seq: 2, vendor_note: 'keep' },
+          top_level_extension: ['a', 'b'],
+          ...extra,
+        }),
+      ),
+    )
+  }
+
+  it('preserves unknown fields across open, execute, flush, checkpoint and close', async () => {
+    const h = await harness()
+    await writeForeignHead(h.objectDir, {})
+
+    const o = await track(h.ns.open('obj'))
+    expect(o.generation).toBe(5)
+    await o.execute('INSERT INTO t VALUES (1)')
+    await o.flush()
+    await o.checkpoint()
+    await o.close()
+    open.length = 0
+
+    const stored = JSON.parse(await readFile(join(h.objectDir, 'head.json'), 'utf8'))
+    expect(stored.top_level_extension).toEqual(['a', 'b'])
+    expect(stored.protocol.vendor_flag).toBe(7)
+    expect(stored.engine.built_by).toBe('python')
+    expect(stored.manifest.vendor_note).toBe('keep')
+    // And this build's own fields moved on.
+    expect(stored.manifest.base).not.toBeNull()
+    expect(stored.manifest.wal).toEqual([])
+    expect(stored.lease.owner).toBeNull()
+  })
+
+  async function writeHeadWithEngine(objectDir: string, engine: Record<string, unknown>): Promise<void> {
+    const be = new LocalDurableBackend({ root: objectDir })
+    await be.putBytesIfAbsent(
+      'head.json',
+      Buffer.from(
+        JSON.stringify({
+          protocol: { version: 1, reader_features: [], writer_features: [] },
+          engine,
+          lease: { generation: 1, owner: null, instance: null, expires_at: null },
+          manifest: { db: 'mem', base: null, wal: [], seq: 0 },
+        }),
+      ),
+    )
+  }
+
+  it('opens an object written by an older engine', async () => {
+    // FakeEngine reports 26.7.0. Under the old exact-match gate this was
+    // refused, which meant an engine upgrade orphaned every existing object.
+    const h = await harness()
+    await writeHeadWithEngine(h.objectDir, {
+      name: 'chdb',
+      version: '26.6.0',
+      backup_format: 1,
+      min_reader: '26.6.0',
+    })
+    const o = await track(h.ns.open('obj'))
+    expect(o.generation).toBe(2)
+  })
+
+  it('refuses an object that demands a newer engine than this one', async () => {
+    const h = await harness()
+    await writeHeadWithEngine(h.objectDir, {
+      name: 'chdb',
+      version: '26.9.0',
+      backup_format: 1,
+      min_reader: '26.9.0',
+    })
+    expect(isDurableErrorOf(await catchError(() => h.ns.open('obj')), 'engine_incompatible')).toBe(true)
+  })
+
+  it('refuses an archive format generation this engine does not restore', async () => {
+    const h = await harness()
+    await writeHeadWithEngine(h.objectDir, {
+      name: 'chdb',
+      version: '26.7.0',
+      backup_format: 2,
+      min_reader: '26.7.0',
+    })
+    expect(isDurableErrorOf(await catchError(() => h.ns.open('obj')), 'engine_incompatible')).toBe(true)
+  })
+
+  it('raises the compatibility floor on write and never lowers it', async () => {
+    // The object already demands a newer reader than this engine could claim
+    // for itself; a write must not relax that.
+    const h = await harness()
+    await writeHeadWithEngine(h.objectDir, {
+      name: 'chdb',
+      version: '26.6.0',
+      backup_format: 1,
+      min_reader: '26.6.0',
+    })
+    const o = await track(h.ns.open('obj'))
+    await o.execute('INSERT INTO t VALUES (1)')
+    await o.flush()
+    await o.close()
+    open.length = 0
+
+    const stored = JSON.parse(await readFile(join(h.objectDir, 'head.json'), 'utf8'))
+    // Raised to this engine, since its writes are what a reader now has to cope with.
+    expect(stored.engine.min_reader).toBe('26.7.0')
+    expect(stored.engine.version).toBe('26.7.0')
+    expect(stored.engine.backup_format).toBe(1)
+  })
+
+  it('allows a read-only open but refuses the lease on an unknown writer feature', async () => {
+    const h = await harness()
+    await writeForeignHead(h.objectDir, {
+      protocol: { version: 1, reader_features: [], writer_features: ['data-wal'] },
+    })
+    expect(isDurableErrorOf(await catchError(() => h.ns.open('obj')), 'protocol_unsupported')).toBe(true)
+    const r = await track(h.ns.open('obj', { readOnly: true }))
+    expect(r.readOnly).toBe(true)
+  })
+
+  it('refuses any open on an unknown reader feature', async () => {
+    const h = await harness()
+    await writeForeignHead(h.objectDir, {
+      protocol: { version: 1, reader_features: ['preamble'], writer_features: [] },
+    })
+    expect(isDurableErrorOf(await catchError(() => h.ns.open('obj', { readOnly: true })), 'protocol_unsupported')).toBe(true)
+    expect(isDurableErrorOf(await catchError(() => h.ns.open('obj')), 'protocol_unsupported')).toBe(true)
+  })
+})
+
+describe('bounded buffer', () => {
+  /** Fill the buffer to just under the segment ceiling, cheaply. */
+  async function fillTo(o: DurableObject, targetBytes: number): Promise<void> {
+    const chunk = 'x'.repeat(1024 * 1024)
+    while (o.pendingBytes + 2 * 1024 * 1024 < targetBytes) {
+      await o.execute(`INSERT INTO t VALUES ('${chunk}')`)
+    }
+  }
+
+  it('tracks the encoded size of what is buffered', async () => {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    expect(o.pendingBytes).toBe(0)
+    await o.execute('INSERT INTO t VALUES (1)')
+    const one = o.pendingBytes
+    expect(one).toBeGreaterThan(0)
+    await o.execute('INSERT INTO t VALUES (2)')
+    expect(o.pendingBytes).toBe(one * 2)
+    await o.flush()
+    expect(o.pendingBytes).toBe(0)
+  })
+
+  it('refuses the statement that would make the buffer unflushable', async () => {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await fillTo(o, LIMITS.MAX_WAL_SEGMENT_BYTES)
+
+    const executedBefore = o.stats.executedStatements
+    const pendingBefore = o.pendingStatements
+    // One more megabyte-sized statement crosses the ceiling.
+    const e = await catchError(() => o.execute(`INSERT INTO t VALUES ('${'y'.repeat(3 * 1024 * 1024)}')`))
+    expect(isDurableErrorOf(e, 'limit_exceeded')).toBe(true)
+
+    // Refused before running, so nothing was executed and nothing was buffered.
+    expect(o.stats.executedStatements).toBe(executedBefore)
+    expect(o.pendingStatements).toBe(pendingBefore)
+    expect(h.engines[0]!.statements).toHaveLength(pendingBefore)
+
+    // And the object is still perfectly usable: the buffer can still flush.
+    const ref = await o.flush()
+    expect(ref).toBeDefined()
+    expect(o.pendingBytes).toBe(0)
+  })
+
+  it('stays flushable after a failed flush followed by more writes', async () => {
+    // The path that made this worth fixing: a transient failure leaves the
+    // buffer intact by design, and a caller that keeps writing used to walk
+    // into a buffer no flush could ever encode.
+    const h = await harness({ fault: true })
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute('INSERT INTO t VALUES (1)')
+    for (let i = 0; i < 5; i++) h.faults[0]!.inject({ on: 'replace', result: 'not-replaced' })
+    expect(isDurableErrorOf(await catchError(() => o.flush()), 'timeout')).toBe(true)
+    expect(o.pendingStatements).toBe(1)
+
+    await fillTo(o, LIMITS.MAX_WAL_SEGMENT_BYTES)
+    const e = await catchError(() => o.execute(`INSERT INTO t VALUES ('${'z'.repeat(3 * 1024 * 1024)}')`))
+    expect(isDurableErrorOf(e, 'limit_exceeded')).toBe(true)
+
+    // The recovery the old code could not offer.
+    const ref = await o.flush()
+    expect(ref).toBeDefined()
+    expect(o.pendingBytes).toBe(0)
+  })
+
+  it('still refuses a single statement over the per-statement limit', async () => {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    const huge = 'q'.repeat(LIMITS.MAX_SQL_BYTES + 1)
+    expect(isDurableErrorOf(await catchError(() => o.execute(`INSERT INTO t VALUES ('${huge}')`)), 'limit_exceeded')).toBe(true)
+    expect(o.pendingStatements).toBe(0)
+  })
+})
+
+describe('observability', () => {
+  it('reports a consistent snapshot across a write, flush and checkpoint', async () => {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+
+    let s = o.stats
+    expect(s.objectId).toBe('obj')
+    expect(s.database).toBe('mem')
+    expect(s.state).toBe('open')
+    expect(s.generation).toBe(1)
+    expect(s.fenced).toBe(false)
+    expect(s.readOnly).toBe(false)
+    expect(s.baseKey).toBeUndefined()
+    expect(s.lastFlushAt).toBeUndefined()
+    expect(s.lastCheckpointAt).toBeUndefined()
+    expect(s.leaseExpiresAt).toBeInstanceOf(Date)
+
+    await o.execute('INSERT INTO t VALUES (1)')
+    s = o.stats
+    expect(s.executedStatements).toBe(1)
+    expect(s.committedStatements).toBe(0)
+    expect(s.pendingStatements).toBe(1)
+    expect(s.pendingBytes).toBeGreaterThan(0)
+
+    await o.flush()
+    s = o.stats
+    expect(s.committedStatements).toBe(1)
+    expect(s.pendingStatements).toBe(0)
+    expect(s.walSegments).toBe(1)
+    expect(s.committedSeq).toBe(1)
+    expect(s.lastFlushAt).toBeInstanceOf(Date)
+
+    await o.checkpoint()
+    s = o.stats
+    expect(s.baseKey).toMatch(/^checkpoints\//)
+    expect(s.walSegments).toBe(0)
+    expect(s.lastCheckpointAt).toBeInstanceOf(Date)
+  })
+
+  it('reports fenced state after a takeover', async () => {
+    const h = await harness()
+    const a = await track(h.ns.open('obj', { database: 'mem' }))
+    await a.execute('INSERT INTO t VALUES (1)')
+    await track(h.ns.open('obj', { force: true }))
+    await catchError(() => a.flush())
+    expect(a.stats.fenced).toBe(true)
+  })
+
+  it('carries no credentials or SQL, so it is safe to log', async () => {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    await o.execute("INSERT INTO t VALUES ('a-value-that-must-not-leak')")
+    expect(JSON.stringify(o.stats)).not.toContain('a-value-that-must-not-leak')
+    expect(JSON.stringify(o.stats)).not.toContain('INSERT')
+  })
+
+  it('reports restore progress through the phases', async () => {
+    const h = await harness()
+    const w = await track(h.ns.open('obj', { database: 'mem' }))
+    await w.execute('INSERT INTO t VALUES (1)')
+    await w.flush()
+    await w.execute('INSERT INTO t VALUES (2)')
+    await w.flush()
+    await w.close()
+    open.length = 0
+
+    const seen: RestoreProgress[] = []
+    const r = await track(h.ns.open('obj', { onRestoreProgress: (p) => seen.push(p) }))
+    expect(seen.map((p) => p.phase)).toEqual([
+      'creating-database',
+      'replaying-wal',
+      'replaying-wal',
+      'ready',
+    ])
+    const last = seen[seen.length - 1] as { phase: 'ready'; statementsReplayed: number }
+    expect(last.statementsReplayed).toBe(2)
+    const second = seen[2] as { segment: number; segments: number; statements: number }
+    expect(second.segment).toBe(2)
+    expect(second.segments).toBe(2)
+    expect(second.statements).toBe(1)
+    expect(r.stats.committedSeq).toBe(2)
+  })
+
+  it('does not let a throwing progress callback fail the open', async () => {
+    const h = await harness()
+    const w = await track(h.ns.open('obj', { database: 'mem' }))
+    await w.execute('INSERT INTO t VALUES (1)')
+    await w.flush()
+    await w.close()
+    open.length = 0
+
+    const r = await track(
+      h.ns.open('obj', {
+        onRestoreProgress: () => {
+          throw new Error('reporting blew up')
+        },
+      }),
+    )
+    expect(h.engines[1]!.statements).toEqual(['INSERT INTO t VALUES (1)'])
+    expect(r.stats.state).toBe('open')
+  })
+})
+
+describe('write barriers', () => {
+  it('coalesces concurrent waiters onto a single head commit', async () => {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+
+    const tickets = []
+    for (let i = 0; i < 5; i++) tickets.push(await o.execute(`INSERT INTO t VALUES (${i})`))
+    await Promise.all(tickets.map((t) => o.flushThrough(t)))
+
+    // One segment, not five: the first waiter through the queue published a
+    // segment covering all of them and the rest found their watermark met.
+    expect(o.manifest.wal).toHaveLength(1)
+    expect(o.manifest.seq).toBe(1)
+    expect((await listed(join(h.objectDir, 'wal'))).length).toBe(1)
+  })
+
+  it('is a no-op for a ticket already covered', async () => {
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    const t = await o.execute('INSERT INTO t VALUES (1)')
+    await o.flushThrough(t)
+    const seq = o.manifest.seq
+    await o.flushThrough(t)
+    expect(o.manifest.seq).toBe(seq)
+  })
+})

--- a/test/durable/state-machine.test.ts
+++ b/test/durable/state-machine.test.ts
@@ -830,6 +830,68 @@ describe('observability', () => {
   })
 })
 
+describe('review regressions: lease timing', () => {
+  it('rejects tuning values that are not finite and positive', async () => {
+    // NaN was the dangerous one: it reaches expires_at, JSON renders it null,
+    // and the result is a lease with an owner and no expiry — untakeable by
+    // anyone else and never self-fencing here, since every comparison against
+    // NaN is false.
+    const h = await harness()
+    for (const bad of [
+      { leaseTtlMs: NaN },
+      { leaseTtlMs: Infinity },
+      { heartbeatIntervalMs: 0 },
+      { commitDeadlineMs: -1 },
+      { maxCommitAttempts: NaN },
+      { clockSkewAllowanceMs: NaN },
+    ]) {
+      const e = await catchError(() => h.ns.open('obj', { database: 'mem', tuning: { ...FAST, ...bad } }))
+      expect(e, JSON.stringify(bad)).toBeInstanceOf(RangeError)
+    }
+  })
+
+  it('refuses to commit a flush whose lease lapsed during the upload', async () => {
+    // Checking only at entry let a writer that was required to self-fence
+    // mid-upload go on to publish the manifest anyway.
+    const h = await harness({ fault: true })
+    const o = await track(
+      h.ns.open('obj', { database: 'mem', tuning: { ...FAST, leaseTtlMs: 400, heartbeatIntervalMs: 120 } }),
+    )
+    await o.execute('INSERT INTO t VALUES (1)')
+    // No heartbeat can land from here on, so the lease lapses while the
+    // segment is being uploaded.
+    for (let i = 0; i < 40; i++) h.faults[0]!.inject({ on: 'replace', result: 'throw' })
+    await new Promise((r) => setTimeout(r, 600))
+
+    expect(isDurableErrorOf(await catchError(() => o.flush()), 'lease_fenced')).toBe(true)
+    expect(o.manifest.wal).toEqual([])
+  })
+
+  it('refuses to commit a checkpoint whose lease lapsed during the backup', async () => {
+    const h = await harness({ fault: true })
+    const o = await track(
+      h.ns.open('obj', { database: 'mem', tuning: { ...FAST, leaseTtlMs: 400, heartbeatIntervalMs: 120 } }),
+    )
+    await o.execute('INSERT INTO t VALUES (1)')
+    for (let i = 0; i < 40; i++) h.faults[0]!.inject({ on: 'replace', result: 'throw' })
+    await new Promise((r) => setTimeout(r, 600))
+
+    expect(isDurableErrorOf(await catchError(() => o.checkpoint()), 'lease_fenced')).toBe(true)
+    expect(o.manifest.base).toBeNull()
+  })
+
+  it('never believes a deadline the stored lease does not support', async () => {
+    // The local deadline is bounded by what actually persisted, so a renewal
+    // that reconciles onto an older head cannot extend the window past it.
+    const h = await harness()
+    const o = await track(h.ns.open('obj', { database: 'mem' }))
+    const stats = o.stats
+    expect(stats.leaseExpiresAt).toBeInstanceOf(Date)
+    const stored = JSON.parse(await readFile(join(h.objectDir, 'head.json'), 'utf8'))
+    expect(stats.leaseExpiresAt!.getTime()).toBeLessThanOrEqual(stored.lease.expires_at * 1000 + 1)
+  })
+})
+
 describe('write barriers', () => {
   it('coalesces concurrent waiters onto a single head commit', async () => {
     const h = await harness()

--- a/test/durable/subpath.test.ts
+++ b/test/durable/subpath.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Packaging guarantees for the two new subpaths.
+ *
+ * The assertion that matters is the first one: importing `chdb/durable` must
+ * not load native code. It is checked in a child process with `process.dlopen`
+ * replaced by a throw, because that is the only check that cannot pass by
+ * accident — a spy on the loader module would miss a transitive require, and
+ * an assertion inside this process would already be running alongside whatever
+ * the rest of the suite loaded.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { execFileSync } from 'child_process'
+import { existsSync, mkdtempSync, writeFileSync } from 'fs'
+import { mkdtemp, mkdir, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+
+import { resolveLibchdb, tryResolveLibchdb } from '../../src/libchdb/index'
+
+const DIST = resolve(__dirname, '..', '..', 'dist')
+const built = existsSync(join(DIST, 'durable', 'index.js'))
+
+function runNode(source: string): string {
+  return execFileSync(process.execPath, ['-e', source], {
+    encoding: 'utf8',
+    cwd: resolve(__dirname, '..', '..'),
+  }).trim()
+}
+
+describe.skipIf(!built)('subpath imports', () => {
+  it('loads chdb/durable without loading any native addon', () => {
+    const out = runNode(`
+      process.dlopen = () => { throw new Error('durable subpath loaded native code') }
+      const d = require('./dist/durable/index.js')
+      if (typeof d.DurableNamespace !== 'function') throw new Error('missing DurableNamespace')
+      const native = Object.keys(require.cache).filter(p => p.endsWith('.node'))
+      if (native.length) throw new Error('native modules loaded: ' + native.join(','))
+      console.log('clean')
+    `)
+    expect(out).toBe('clean')
+  })
+
+  it('loads chdb/libchdb without loading any native addon', () => {
+    const out = runNode(`
+      process.dlopen = () => { throw new Error('libchdb subpath loaded native code') }
+      const l = require('./dist/libchdb/index.js')
+      if (typeof l.resolveLibchdb !== 'function') throw new Error('missing resolveLibchdb')
+      const native = Object.keys(require.cache).filter(p => p.endsWith('.node'))
+      if (native.length) throw new Error('native modules loaded: ' + native.join(','))
+      console.log('clean')
+    `)
+    expect(out).toBe('clean')
+  })
+
+  it('exposes named exports to ESM importers', () => {
+    const out = runNode(`
+      import('./dist/durable/index.js').then(m => {
+        if (typeof m.DurableNamespace !== 'function') throw new Error('no named export')
+        if (m.QueryClass.MutatingGlobal !== 2) throw new Error('enum mismatch')
+        console.log('clean')
+      }).catch(e => { console.error(e); process.exit(1) })
+    `)
+    expect(out).toBe('clean')
+  })
+
+  it('does not pull the AWS SDK into a plain chdb/durable import', () => {
+    // The S3 backend lives behind its own subpath precisely so this stays
+    // true. If it ever gets imported from the barrel, every durable user
+    // starts paying for an SDK they may not use.
+    const out = runNode(`
+      require('./dist/durable/index.js')
+      const aws = Object.keys(require.cache).filter(p => p.includes('@aws-sdk') || p.includes('@smithy'))
+      if (aws.length) throw new Error('AWS SDK loaded: ' + aws.length + ' modules')
+      console.log('clean')
+    `)
+    expect(out).toBe('clean')
+  })
+
+  it('registers the s3 scheme when its subpath is imported', () => {
+    const out = runNode(`
+      require('./dist/durable/backends/s3.js')
+      const { DurableNamespace } = require('./dist/durable/index.js')
+      new DurableNamespace('s3://b/p?region=us-east-1', { engineFactory: () => ({}) })
+      console.log('clean')
+    `)
+    expect(out).toBe('clean')
+  })
+
+  it('names the missing import when an s3 URL is used without it', () => {
+    // "No backend for s3" while the S3 backend sits in the same package is a
+    // confusing five minutes; the error should end it.
+    const out = runNode(`
+      const { DurableNamespace } = require('./dist/durable/index.js')
+      try {
+        new DurableNamespace('s3://b/p', { engineFactory: () => ({}) })
+        throw new Error('should have thrown')
+      } catch (e) { console.log(e.message) }
+    `)
+    expect(out).toContain("chdb/durable/s3")
+  })
+
+  it('declares both subpaths in package.json exports', () => {
+    const pkg = require('../../package.json') as { exports: Record<string, unknown> }
+    expect(pkg.exports['./durable']).toBeDefined()
+    expect(pkg.exports['./libchdb']).toBeDefined()
+    expect(pkg.exports['./durable/s3']).toBeDefined()
+  })
+})
+
+describe('libchdb resolution', () => {
+  it('honours an explicit CHDB_LIBCHDB_PATH', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'libchdb-'))
+    const file = join(dir, 'libchdb.so')
+    await writeFile(file, 'not really a library')
+    const found = resolveLibchdb({ env: { CHDB_LIBCHDB_PATH: file } })
+    expect(found).toEqual({ path: file, source: 'env-file' })
+  })
+
+  it('fails loudly when the explicit override is wrong, rather than falling through', () => {
+    // Silently using a different library than the operator named is how a
+    // process ends up running an engine nobody chose.
+    expect(() => resolveLibchdb({ env: { CHDB_LIBCHDB_PATH: '/nope/libchdb.so' } })).toThrow(
+      /CHDB_LIBCHDB_PATH/,
+    )
+  })
+
+  it('searches a directory given by CHDB_LIBCHDB_DIR', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'libchdb-'))
+    await writeFile(join(dir, 'libchdb.dylib'), 'x')
+    expect(resolveLibchdb({ env: { CHDB_LIBCHDB_DIR: dir } }).source).toBe('env-dir')
+  })
+
+  it('searches caller-supplied directories before the built-in candidates', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'libchdb-'))
+    await mkdir(join(dir, 'nested'))
+    await writeFile(join(dir, 'nested', 'libchdb.so'), 'x')
+    const found = resolveLibchdb({ env: {}, extraDirs: [join(dir, 'nested')] })
+    expect(found.source).toBe('extra-dir')
+  })
+
+  it('reports nothing rather than throwing from the try variant', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'libchdb-'))
+    writeFileSync(join(dir, 'unrelated'), 'x')
+    expect(tryResolveLibchdb({ env: { CHDB_LIBCHDB_DIR: dir } })).toBeUndefined()
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,10 @@
     "checkJs": false,
     "types": ["node"]
   },
-  "include": ["src", "test"]
+  "include": ["src", "test"],
+  // The Bun-only durable files import `bun:ffi` and `bun:test`, which have no
+  // declarations under @types/node. They are checked by `bun test`, which
+  // transpiles them directly; pulling in @types/bun here would put a second set
+  // of global declarations alongside @types/node for every other file.
+  "exclude": ["test/durable/libchdb-ffi.ts", "test/durable/*.bun.test.ts"]
 }

--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -11,12 +11,20 @@ cd "$(dirname "$0")"
 # Fail fast so a bad download never silently leaves a stale/partial libchdb.
 set -e
 
-# Pre-release engine for the 3.1.0-rc.1 test line (carries the written-rows
-# accessors the raw/streaming insert needs; absent in the v26.5.0 stable line).
+# Pre-release engine carrying the Durable V1 ABI: chdb_backup_database_n,
+# chdb_restore_database_n and the chdb_classify_query_n that reports statement
+# count and target-database proof. chdb/durable's engine adapter cannot be built
+# without them, and no stable release exports them yet.
+#
+# Note chdb_version() on this build returns the full "26.7.2-rc.2", suffix and
+# all. Durable records that string in head.engine.version and opens only on an
+# exact match, so an object written against this RC is not readable by the
+# eventual 26.7.2 stable. That is the contract working as designed (V1 pins the
+# engine exactly), but it means RC-era objects are throwaway.
 #
 # Keep the pin on its own line and literal: the release check greps for it when
 # it proposes a bump.
-CHDB_ENGINE_PIN=v26.7.0
+CHDB_ENGINE_PIN=v26.7.2-rc.2
 
 # CHDB_ENGINE_VERSION overrides the pin, which is how the release check runs the
 # suite against an engine this repository has not adopted yet. It is a different
@@ -44,7 +52,7 @@ LATEST_RELEASE="${CHDB_ENGINE_VERSION:-$CHDB_ENGINE_PIN}"
 # ERR_DLOPEN_FAILED instead.
 #
 # The publish and cleanroom workflows read CHDB_LIB_VERSION from here.
-LIBCHDB_NPM_VERSION=26.7.0-stable.1
+LIBCHDB_NPM_VERSION=26.7.2-rc.2.1
 
 # Download the correct version based on the platform
 case "$(uname -s)" in

--- a/vitest.durable.config.ts
+++ b/vitest.durable.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config'
+
+// The durable control plane is pure TypeScript with no native dependency, so it
+// gets its own project rather than joining the v3 suite. Two reasons, and the
+// second is the important one:
+//
+//  1. It needs no engine, so it can run in parallel and in any environment.
+//  2. The v3 suite's setup file imports the CJS entrypoint, which loads the
+//     native addon. Running these tests there would make the "importing
+//     chdb/durable loads nothing native" assertion vacuous — the addon would
+//     already be in the process.
+//
+// The Bun end-to-end suite (*.bun.ts) is excluded: it runs under `bun test`
+// because it reaches libchdb through bun:ffi.
+export default defineConfig({
+  test: {
+    include: ['test/durable/**/*.test.ts'],
+    exclude: ['test/durable/**/*.bun.test.ts'],
+    environment: 'node',
+    testTimeout: 20_000,
+  },
+})


### PR DESCRIPTION
**Do not merge yet.** The pure-TypeScript half is complete and verified against `chdb-core v26.7.2-rc.2`. What remains is packaging and the optional addon adapter — see *What remains* below. Nothing here is blocked on chdb-core any more.

## What this adds

Three subpaths. Importing any of them loads no native code.

| Subpath | What it is |
| --- | --- |
| `chdb/durable` | Durable V1 control plane: object layout, `head.json`, manifest, lease, CAS, fencing, WAL, checkpoint orchestration, frozen error categories, local backend |
| `chdb/durable/s3` | S3-compatible backend — AWS S3, Cloudflare R2, MinIO. Registers the `s3` scheme on import |
| `chdb/libchdb` | Resolves where `libchdb.so` is. Does not open it |

The protocol is specified in `CHDB_DURABLE_V1_CONTRACT.md` in the chdb repository, which is the source of truth. Where this and the contract disagree, the contract is right and this is a bug.

Note the contract supersedes `CHDB_DURABLE_MULTI_BINDING_ROADMAP.md` on several points: V1 is single-database, single-statement, statement WAL, full checkpoint, and refuses all `MUTATING_GLOBAL`. Preamble, UDF replay, incremental checkpoints and Parquet WAL are V2 candidates and are not implemented here.

## Why the engine is injected

`chdb-core` binds one data path per process. A control plane that transitively required `chdb_node.node` would put a second engine into a process that can only have one — precisely the position a downstream reaching `libchdb` through its own `bun:ffi` `dlopen` is in. So the engine arrives as an `EngineAdapter` the caller supplies.

`test/durable/subpath.test.ts` asserts this in a child process with `process.dlopen` replaced by a throw, and separately that `chdb/durable` pulls in zero AWS SDK modules. A spy on the loader would miss a transitive require; an in-process assertion would already be running alongside whatever the rest of the suite had loaded.

## Verification

All against engine **`26.7.2-rc.2`**, from the published release artifact:

| Suite | Result |
| --- | --- |
| Protocol, state machine, fault matrix (no engine) | 96 passing |
| S3 provider conformance — **AWS S3** `us-east-2` | 11 passing |
| S3 provider conformance — MinIO `RELEASE.2025-09-07` | 11 passing, run repeatedly |
| End-to-end vs real `libchdb` (local backend) | 19 passing |
| **Full stack** — Bun + `bun:ffi` libchdb + real AWS S3 | 4 passing |
| Existing v3 suite on the same engine build | 478 passing |

AWS S3 and MinIO agree on every point that matters: `If-None-Match: *` and `If-Match` are atomic on both, an eight-way race with one stale token leaves exactly one winner on both, and re-PUTting identical bytes advances the token on neither.

That last one is not a curiosity. An S3 ETag is a content hash, so a byte-identical write leaves the CAS token valid and a second racer holding it also wins. Durable is safe because every head write moves the bytes — generation, `expires_at`, or `manifest.seq`. That is a dependency rather than a coincidence, so it is recorded in the backend and pinned by a test on both providers.

Cloudflare R2 is **not** claimed. Same code path, but the contract asks for each provider to be measured on its own (§7.5) and it has not been run.

The full-stack suite is the arrangement a downstream actually deploys, and the only place the other two suites' halves meet — each covers one (real engine over a local directory, or a real bucket under a fake engine), and both can pass while an assumption held by only one of them is wrong.

## Engine pinning, and what it means during an RC

V1 records `chdb_version()` in `head.engine.version` and opens only on an exact string match — there is no compatibility matrix yet, so "close enough" would mean restoring an archive into a build nothing has tested it against (contract §8.1 item 7).

This build reports the full **`26.7.2-rc.2`**, suffix included. So an object written now is **not** readable by the eventual `26.7.2` stable, or by any later RC. It fails cleanly with `engine_incompatible` rather than misreading anything, but it fails.

**Objects created during the RC period are disposable.** A proof of concept should not accumulate data it expects to keep.

## What remains

Nothing here waits on chdb-core. What is left is packaging and an optional convenience:

- **publish `chdb@rc`** — the only item a downstream consuming this from npm actually needs
- **`@chdb/lib-*` RC platform packages** — `optionalDependencies` and `LIBCHDB_NPM_VERSION` are already at `26.7.2-rc.2.1`, but the newest on npm is `26.7.0-stable.1`. chdb-node's own publish workflow builds these, reading `CHDB_LIB_VERSION` from `update_libchdb.sh`; until it runs, an install skips the optional dependency and the resolver falls through to the working tree (which is what CI arranges with `rm -rf node_modules/@chdb/lib-*`)
- **default `EngineAdapter` over the addon** (`src/durable/adapters/chdb-node.ts`) — needed by Node callers who do not bring their own engine. A downstream that already `dlopen`s `libchdb` itself does not need it
- **engine-dependent suites into CI**
- multipart upload past the 5 GiB single-`PutObject` ceiling
- reachability-based GC (see below)
- Cloudflare R2 conformance; GCS and Azure backends

## Testing

```sh
npm run test:durable          # 96 tests, no engine, no network
npm run test:durable:s3       # provider conformance; skips without a bucket
npm run test:durable:e2e      # real libchdb, under Bun
npm run test:durable:stack    # Bun + libchdb + real object storage
```

The unit suites run the **real** `LocalDurableBackend`. Mocking it would leave conditional create and CAS — the only parts of a backend that can be subtly wrong — untested. `FaultBackend` wraps it, including modes that write for real and *then* lose the response.

`CHDB_LIBCHDB_PATH` is required for the Bun suites: the resolver prefers an installed `@chdb/lib-*` over the working tree, and the published one predates the durable ABI, so a local build gets shadowed as soon as those packages install. Running without it now fails with a message saying exactly that instead of a bare `dlopen` TypeError.

**CI does not run `test:durable` yet** — `vitest.config.ts` only includes `test/v3/**`. Adding it needs no RC and can go in this PR if reviewers want it.

## Two things worth a reviewer's attention

**The WAL buffer is bounded at `execute()`, not at `flush()`.** A statement that has run cannot be un-run, so a buffer grown past the 128 MiB a segment holds could never be flushed again — and that state was reachable from one transient failure, since a failed flush deliberately keeps the buffer and a caller that keeps writing walks into it. Checking before the statement runs turns an unrecoverable flush into a recoverable refusal. The budget and the encoder must agree exactly or the boundary is wrong, so they are pinned together by a test.

**Objects only grow.** Every checkpoint orphans the previous base and the WAL it subsumed, and V1 deletes nothing. The reflex fix is dangerous: an age-based lifecycle rule will corrupt objects, because a live base can be arbitrarily old and "delete older than N days" deletes bases that manifests still point at. Safe reclamation needs manifest reachability plus a grace period, which is why the contract holds it to V2. Documented rather than fixed here.

## Review starting points

- `src/durable/object.ts` — the state machine; `commitHead` is where ambiguity is resolved
- `src/durable/backends/local.ts` — why the CAS is a symlinked version chain rather than a lock file
- `src/durable/backends/s3.ts` — why the SDK's own retries are safe given how the object layer resolves outcomes
- `docs/design/durable-control-plane.md` — the reasoning, and the V1 boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pure-TypeScript Durable V1 control plane with `chdb/durable`, `chdb/durable/s3`, and `chdb/libchdb`
> - Introduces the Durable V1 control plane: an engine-independent TypeScript module that manages durable object lifecycle, WAL/checkpoint persistence, leases, fencing, query/execute validation, and recovery via an injected `EngineAdapter` seam. The control plane loads no native code itself.
> - Adds a local filesystem backend ([src/durable/backends/local.ts](https://github.com/chdb-io/chdb-node/pull/90/files#diff-39c2b7897c843c47cfa6eca1cf7f3822e3b64faed053673740123c32a585283a)) and an S3-compatible backend ([src/durable/backends/s3.ts](https://github.com/chdb-io/chdb-node/pull/90/files#diff-7c188e4d8fc8faf5b7336f6226d8ad4359ea0de082fc71652dcd51aab82d966e)) implementing conditional create and compare-and-swap replacement.
> - Adds `chdb/libchdb` ([src/libchdb/index.ts](https://github.com/chdb-io/chdb-node/pull/90/files#diff-b19c6afc487cfd6df49b4ffe6f1e1547fff51f4b7fe9eb8b0322c45a82eaf29b)), a non-native shared-library path resolver with explicit/env/dir/platform-package search precedence.
> - Adds durable error hierarchy, version negotiation, WAL codecs, digest verification, key validation, and a mutex serializer across [src/durable/](https://github.com/chdb-io/chdb-node/pull/90/files#diff-cdcc0a85add2165364fa8fd5c8b2cbd1cdd3464dbeab16db42d092264a657343) modules.
> - Adds protocol, state-machine, S3 conformance, libchdb FFI, and full-stack test suites, plus CI jobs for engine-independent durable tests and MinIO-backed S3 conformance.
> - Risk: native engine package pins move from the 26.7.0 stable line to the 26.7.2-rc.2.1 RC line in [package.json](https://github.com/chdb-io/chdb-node/pull/90/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and [update_libchdb.sh](https://github.com/chdb-io/chdb-node/pull/90/files#diff-6f35e23173ec48cae47760551bfa867846783d6a777bcf30354d7dd8e2e11ecb) to match the required Durable V1 ABI symbols; existing installs will resolve the RC packages. The S3 subpath makes `@aws-sdk/client-s3` an optional peer dependency (floor v3).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee3cbfc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->