### PR TITLE
Support per-session ClickHouse startup configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,43 @@ Errors are typed (`ChdbSyntaxError`, `ChdbQueryError`, `ChdbConnectionError`,
 `ChdbAbortError`, `ChdbTimeoutError`, …), each carrying `.code`, the ClickHouse
 `.clickhouseCode`, and `.cause`.
 
+### Session startup configuration
+
+Pass a ClickHouse configuration file without changing the process environment or working directory:
+
+```js
+const session = new Session("./data", { configFile: "/secure/path/clickhouse.xml" });
+try {
+  const result = await session.queryAsync("SELECT 1");
+} finally {
+  session.close();
+}
+```
+
+For example, an endpoint-specific signing region can be configured with:
+
+```xml
+<clickhouse>
+  <s3>
+    <intermediary>
+      <endpoint>https://storage.example/</endpoint>
+      <region>eu-west-1</region>
+    </intermediary>
+  </s3>
+</clickhouse>
+```
+
+`configFile` must name an existing, readable regular file. Relative paths are
+resolved before opening the session. Invalid files fail without replacing an
+existing default connection. The file remains caller-owned and is not deleted
+when the session closes.
+
+Sessions sharing a data directory must use the same resolved configuration path,
+including the choice to omit configuration. Close all connections to that
+directory before selecting another configuration. This option requires a rebuilt
+platform binding with startup-configuration support. Older bindings fail rather
+than silently ignoring the option.
+
 ### One data directory at a time
 
 libchdb binds a single data directory per process, so opening a `Session` takes

--- a/index.d.ts
+++ b/index.d.ts
@@ -245,6 +245,14 @@ export interface ChdbQueryStream extends AsyncIterable<StreamChunk> {
  */
 export interface SessionOptions {
   /**
+   * ClickHouse startup configuration file. Relative paths resolve from the current
+   * working directory. The file must be readable and regular. Sessions sharing a
+   * data path must use the same resolved configuration path until all are closed.
+   * Requires a native binding with session configuration support.
+   * Closing the session does not delete this file.
+   */
+  configFile?: string;
+  /**
    * Opt-in: install SIGINT/SIGTERM handlers that close this session. Default
    * is `false` (a library must not steal the user's signals). These handlers
    * never call `process.exit`; the app decides how to terminate.

--- a/index.js
+++ b/index.js
@@ -583,6 +583,27 @@ class Session {
   #signalHandler = null; // opt-in signal handler, deregistered on close()
 
   constructor(path = "", opts = {}) {
+    // Validate startup options before creating a directory or releasing the default connection.
+    let configFile;
+    const configured = opts?.configFile;
+    if (configured !== undefined) {
+      if (typeof configured !== 'string' || configured.length === 0 || configured.includes('\0')) {
+        throw new ChdbConnectionError('Session configFile must be a non-empty file path without null bytes.');
+      }
+      configFile = resolvePath(configured);
+      try {
+        if (!fs.statSync(configFile).isFile()) {
+          throw new ChdbConnectionError('Session configFile must refer to a regular file.');
+        }
+        fs.accessSync(configFile, fs.constants.R_OK);
+      } catch (e) {
+        throw new ChdbConnectionError('Cannot read the session configFile.', { cause: e });
+      }
+      if (chdbNode.supportsSessionConfig !== true) {
+        throw new ChdbConnectionError(
+          'The loaded native binding does not support Session configFile. Install a native binding with session configuration support.');
+      }
+    }
     // Opening a session destroys the shared default connection: libchdb binds
     // one data directory per process, so the in-memory default has to yield.
     // Destroying it while a query is still running on it is not survivable —
@@ -644,7 +665,9 @@ class Session {
     try {
       const key = this.path ? resolvePath(this.path) : this.path;
       this._key = key; // normalized directory, for the deferred-teardown bookkeeping
-      this.connection = chdbNode.CreateConnection(key);
+      this.connection = configFile === undefined
+        ? chdbNode.CreateConnection(key)
+        : chdbNode.CreateConnection(key, configFile);
     } catch (e) {
       if (this.isTemp) { try { this.#removeTempDir(); } catch (_) {} }
       throw asConnectionError(e);

--- a/lib/chdb_node.cpp
+++ b/lib/chdb_node.cpp
@@ -3,6 +3,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -13,7 +15,7 @@
 #include <napi.h>
 
 typedef void * ChdbConnection;
-ChdbConnection CreateConnection(const char * path, char ** error_message);
+ChdbConnection CreateConnection(const char * path, const std::string &configFile, char ** error_message);
 void CloseConnection(ChdbConnection conn);
 char * QueryWithConnection(ChdbConnection conn, const char * query, const char * format, char ** error_message);
 
@@ -74,21 +76,26 @@ char * QueryWithConnection(ChdbConnection conn, const char * query, const char *
 // mutates the registry off the main thread.
 struct Registry {
   std::string boundKey;                  // path the EmbeddedServer is bound to (valid while !conns.empty())
+  std::string boundConfigFile;           // startup config path, or "" when none was supplied
   std::set<chdb_connection *> conns;     // every live connection (sessions + the default)
   chdb_connection *defaultConn = nullptr; // the lazy in-memory default (key ""), if up
 };
 static Registry g_reg;
 static std::mutex g_reg_mu;
 
-static chdb_connection *open_raw(const std::string &path) {
+static chdb_connection *open_raw(const std::string &path, const std::string &configFile) {
   char prog[] = "clickhouse";
   std::string pathArg;
-  char *args[2] = { prog, nullptr };
+  std::string configArg;
+  char *args[4] = { prog, nullptr, nullptr, nullptr };
   int argc = 1;
   if (!path.empty()) {
     pathArg = "--path=" + path;
-    args[1] = const_cast<char *>(pathArg.c_str());
-    argc = 2;
+    args[argc++] = const_cast<char *>(pathArg.c_str());
+  }
+  if (!configFile.empty()) {
+    configArg = "--config-file=" + configFile;
+    args[argc++] = const_cast<char *>(configArg.c_str());
   }
   chdb_connection *conn_ptr = chdb_connect(argc, args);
   return (conn_ptr && *conn_ptr) ? conn_ptr : nullptr;
@@ -113,6 +120,7 @@ static void hard_close_all() {
   g_reg.conns.clear();
   g_reg.defaultConn = nullptr;
   g_reg.boundKey.clear();
+  g_reg.boundConfigFile.clear();
 }
 
 static void ensure_atexit() {
@@ -137,7 +145,7 @@ static chdb_connection *get_default_conn(char **error_message) {
                                "') is active; close it before using standalone query()").c_str());
     return nullptr;
   }
-  chdb_connection *c = open_raw("");
+  chdb_connection *c = open_raw("", "");
   if (!c) {
     if (error_message && !*error_message)
       *error_message = strdup("Failed to acquire default connection");
@@ -145,42 +153,50 @@ static chdb_connection *get_default_conn(char **error_message) {
   }
   g_reg.defaultConn = c;
   g_reg.boundKey = "";
+  g_reg.boundConfigFile.clear();
   g_reg.conns.insert(c);
   return c;
 }
 
-// Session connection: same bound path opens ANOTHER independent connection; a
-// live in-memory default yields; a different data directory is rejected.
-static chdb_connection *acquire_session_conn(const std::string &path, char **error_message) {
+// Session connection: the default yields. Other connections must use the same
+// data path and startup config file.
+static chdb_connection *acquire_session_conn(const std::string &path,
+                                            const std::string &configFile,
+                                            char **error_message) {
   ensure_atexit();
   std::lock_guard<std::mutex> lk(g_reg_mu);
+  if (g_reg.defaultConn) {
+    erase_arrow_tables_for_conn(g_reg.defaultConn);
+    chdb_close_conn(g_reg.defaultConn);
+    g_reg.conns.erase(g_reg.defaultConn);
+    g_reg.defaultConn = nullptr;
+    if (g_reg.conns.empty()) {
+      g_reg.boundKey.clear();
+      g_reg.boundConfigFile.clear();
+    }
+  }
   if (!g_reg.conns.empty()) {
-    if (g_reg.boundKey.empty()) {
-      // Only the in-memory default is up (boundKey ""). It is transient and must
-      // yield so this session can bind a real data directory.
-      if (g_reg.defaultConn) {
-        erase_arrow_tables_for_conn(g_reg.defaultConn);
-        chdb_close_conn(g_reg.defaultConn);
-        g_reg.conns.erase(g_reg.defaultConn);
-        g_reg.defaultConn = nullptr;
-      }
-      // conns is now empty; fall through to bind `path`.
-    } else if (g_reg.boundKey != path) {
+    if (g_reg.boundKey != path) {
       if (error_message && !*error_message)
         *error_message = strdup((std::string("chdb: only one active data directory per "
                                  "process; close the current session (path='") + g_reg.boundKey +
                                  "') before opening '" + path + "'").c_str());
       return nullptr;
     }
-    // else boundKey == path: an independent connection to the same server.
+    if (g_reg.boundConfigFile != configFile) {
+      if (error_message && !*error_message)
+        *error_message = strdup("chdb: a different config file is active; close all sessions before changing the config file");
+      return nullptr;
+    }
   }
-  chdb_connection *c = open_raw(path);
+  chdb_connection *c = open_raw(path, configFile);
   if (!c) {
     if (error_message && !*error_message)
       *error_message = strdup((std::string("Failed to create connection for path '") + path + "'").c_str());
     return nullptr;
   }
   g_reg.boundKey = path;
+  g_reg.boundConfigFile = configFile;
   g_reg.conns.insert(c);
   return c;
 }
@@ -197,7 +213,10 @@ static void release_session_conn(chdb_connection *conn) {
   g_reg.conns.erase(it);
   if (conn == g_reg.defaultConn) g_reg.defaultConn = nullptr;
   // Last connection out unbinds the EmbeddedServer so a different path may bind.
-  if (g_reg.conns.empty()) g_reg.boundKey.clear();
+  if (g_reg.conns.empty()) {
+    g_reg.boundKey.clear();
+    g_reg.boundConfigFile.clear();
+  }
 }
 
 static char *exec_query(chdb_connection conn, const char *query,
@@ -279,11 +298,11 @@ static char *exec_query_params(chdb_connection conn,
   return output;
 }
 
-ChdbConnection CreateConnection(const char * path, char ** error_message) {
+ChdbConnection CreateConnection(const char * path, const std::string &configFile, char ** error_message) {
     // Sessions always pass a real path (a temp dir for in-memory sessions), so
     // an empty key here never collides with the default connection's "" key.
     std::string p = (path && path[0]) ? std::string(path) : std::string();
-    return static_cast<ChdbConnection>(acquire_session_conn(p, error_message));
+    return static_cast<ChdbConnection>(acquire_session_conn(p, configFile, error_message));
 }
 
 void CloseConnection(ChdbConnection conn) {
@@ -860,10 +879,29 @@ Napi::Value CreateConnectionWrapper(const Napi::CallbackInfo & info) {
         Napi::TypeError::New(env, "Path string expected").ThrowAsJavaScriptException();
         return env.Null();
     }
+    if (info.Length() > 1 && !info[1].IsString()) {
+        Napi::TypeError::New(env, "Config file path string expected").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    std::string configFile;
+    if (info.Length() > 1) {
+        configFile = info[1].As<Napi::String>().Utf8Value();
+        if (configFile.empty() || configFile.find('\0') != std::string::npos) {
+            Napi::TypeError::New(env, "Config file path must not be empty or contain null bytes").ThrowAsJavaScriptException();
+            return env.Null();
+        }
+        struct stat configStat;
+        if (stat(configFile.c_str(), &configStat) != 0 ||
+            !S_ISREG(configStat.st_mode) || access(configFile.c_str(), R_OK) != 0) {
+            Napi::Error::New(env, "Config file must be an existing readable regular file: " + configFile).ThrowAsJavaScriptException();
+            return env.Null();
+        }
+    }
 
     std::string path = info[0].As<Napi::String>().Utf8Value();
     char *error_message = nullptr;
-    ChdbConnection conn = CreateConnection(path.c_str(), &error_message);
+    ChdbConnection conn = CreateConnection(path.c_str(), configFile, &error_message);
 
     if (!conn) {
         std::string msg = error_message ? error_message : "Failed to create connection";
@@ -1352,6 +1390,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
 
   // Export connection management functions
   exports.Set("CreateConnection", Napi::Function::New(env, CreateConnectionWrapper));
+  exports.Set("supportsSessionConfig", Napi::Boolean::New(env, true));
   exports.Set("CloseConnection", Napi::Function::New(env, CloseConnectionWrapper));
   exports.Set("QueryWithConnection", Napi::Function::New(env, QueryWithConnectionWrapper));
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -49,7 +49,12 @@ ChdbResult:
 class Session(path?='', opts?)
   new Session()        -> temporary in-memory database (temp dir, auto-cleaned)
   new Session("./db")  -> persistent database at ./db
-  opts: { installSignalHandlers?: boolean }  (default false; library does not steal signals)
+  opts: { installSignalHandlers?: boolean, configFile?: string }
+    installSignalHandlers defaults false; the library does not steal signals.
+    configFile selects a readable regular ClickHouse startup configuration file.
+    Relative paths resolve to absolute paths; invalid files and unsupported native
+    bindings fail before opening. The caller retains ownership of the file.
+    Same-path live sessions must use the same resolved configFile (or all omit it).
   Methods:
     .query(sql, format='CSV') -> string                      (sync)
     .queryBind(sql, params, format='CSV') -> string          (sync, bound)

--- a/test/v3/session-config.test.ts
+++ b/test/v3/session-config.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+import { Session, query, drainPending } from '../../index.js'
+
+const tempDir = () => mkdtempSync(join(tmpdir(), 'chdb-session-config-'))
+
+function rejectsConnection(open: () => Session) {
+  let thrown: unknown
+  try {
+    open().close()
+  } catch (error) {
+    thrown = error
+  }
+  expect(thrown).toMatchObject({ name: 'ChdbConnectionError', code: 'CHDB_CONNECTION' })
+}
+
+describe('Session startup configuration', () => {
+  it('rejects invalid files without losing default-connection data', () => {
+    const root = tempDir()
+    const table = 'session_config_default_guard'
+    query(`CREATE TABLE ${table} (value UInt8) ENGINE = Memory`)
+    query(`INSERT INTO ${table} VALUES (42)`)
+    try {
+      for (const configFile of [join(root, 'missing.xml'), root, '', '\0', null, 42]) {
+        rejectsConnection(() => new Session('', { configFile: configFile as string }))
+        expect(query(`SELECT value FROM ${table}`)).toBe('42\n')
+      }
+    } finally {
+      query(`DROP TABLE IF EXISTS ${table}`)
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps same-path sessions usable when a conflicting configuration is refused', async () => {
+    const root = tempDir()
+    const dataPath = join(root, 'data')
+    const firstConfig = join(root, 'first.xml')
+    const secondConfig = join(root, 'second.xml')
+    writeFileSync(firstConfig, '<clickhouse/>')
+    writeFileSync(secondConfig, '<clickhouse/>')
+    const sessions: Session[] = []
+    try {
+      const first = new Session(dataPath, { configFile: firstConfig })
+      sessions.push(first)
+      first.query('CREATE TABLE config_guard (value UInt8) ENGINE = Memory')
+      first.query('INSERT INTO config_guard VALUES (41)')
+      const alongside = new Session(dataPath, { configFile: relative(process.cwd(), firstConfig) })
+      sessions.push(alongside)
+      alongside.query('INSERT INTO config_guard VALUES (1)')
+      rejectsConnection(() => new Session(dataPath, { configFile: secondConfig }))
+      rejectsConnection(() => new Session(dataPath))
+      expect(first.query('SELECT sum(value) FROM config_guard')).toBe('42\n')
+      first.close()
+      rejectsConnection(() => new Session(dataPath, { configFile: secondConfig }))
+      expect(alongside.query('SELECT sum(value) FROM config_guard')).toBe('42\n')
+      alongside.close()
+      await drainPending()
+
+      const changed = new Session(dataPath, { configFile: secondConfig })
+      sessions.push(changed)
+      expect(changed.query('SELECT 43')).toBe('43\n')
+      changed.close()
+      const ordinary = new Session(dataPath)
+      sessions.push(ordinary)
+      rejectsConnection(() => new Session(dataPath, { configFile: firstConfig }))
+      expect(ordinary.query('SELECT 44')).toBe('44\n')
+      ordinary.close()
+      expect(readFileSync(firstConfig, 'utf8')).toBe('<clickhouse/>')
+      expect(readFileSync(secondConfig, 'utf8')).toBe('<clickhouse/>')
+    } finally {
+      for (const session of sessions) session.close()
+      await drainPending()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('signs every loopback S3 request with the configured region, including after reopening', async () => {
+    const root = tempDir()
+    const dataPath = join(root, 'data')
+    const body = Buffer.from('41\n42\n')
+    const requests: { method: string | undefined; url: string | undefined; region: string | undefined }[] = []
+    let expectedRegion = ''
+    const server = createServer((request, response) => {
+      // Keep only the signing region. Do not retain or print authorization headers.
+      const region = /Credential=[^/]+\/\d{8}\/([^/]+)\/s3\/aws4_request/.exec(request.headers.authorization || '')?.[1]
+      requests.push({ method: request.method, url: request.url, region })
+      if (region !== expectedRegion) {
+        request.resume()
+        response.writeHead(403, { 'Content-Type': 'application/xml' })
+        response.end('<Error><Code>SignatureDoesNotMatch</Code><Message>Wrong signing region</Message></Error>')
+        return
+      }
+      if (request.url !== '/session-config/rows.csv' || !['HEAD', 'GET'].includes(request.method || '')) {
+        response.writeHead(404).end()
+        return
+      }
+      response.setHeader('Content-Type', 'text/csv')
+      response.setHeader('Accept-Ranges', 'bytes')
+      response.setHeader('ETag', '"session-config-fixture"')
+      if (request.method === 'HEAD') {
+        response.setHeader('Content-Length', body.length)
+        response.end()
+        return
+      }
+      const range = /^bytes=(\d+)-(\d*)$/.exec(request.headers.range || '')
+      const start = range ? Number(range[1]) : 0
+      const end = range?.[2] ? Math.min(Number(range[2]), body.length - 1) : body.length - 1
+      if (start > end) {
+        response.writeHead(416, { 'Content-Range': `bytes */${body.length}` }).end()
+        return
+      }
+      if (range) {
+        response.statusCode = 206
+        response.setHeader('Content-Range', `bytes ${start}-${end}/${body.length}`)
+      }
+      response.setHeader('Content-Length', end - start + 1)
+      response.end(body.subarray(start, end + 1))
+    })
+    let session: Session | undefined
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', resolve)
+      })
+      const address = server.address()
+      if (!address || typeof address === 'string') throw new Error('The loopback server has no TCP address.')
+      const endpoint = `http://127.0.0.1:${address.port}/session-config/`
+      for (const region of ['eu-west-1', 'ap-southeast-2']) {
+        expectedRegion = region
+        const configFile = join(root, `${region}.xml`)
+        const config = `<clickhouse><s3><session_config><endpoint>${endpoint}</endpoint><region>${region}</region></session_config></s3></clickhouse>`
+        writeFileSync(configFile, config)
+        requests.length = 0
+        session = new Session(dataPath, { configFile: relative(process.cwd(), configFile) })
+        const stream = session.queryStreamBind(
+          "SELECT value FROM s3({url:String}, {key:String}, {secret:String}, 'CSV', 'value UInt8') ORDER BY value",
+          { url: `${endpoint}rows.csv`, key: 'session-config-test', secret: 'session-config-dummy-secret' },
+          { format: 'CSV' },
+        )
+        let result = ''
+        for await (const chunk of stream) result += chunk.text()
+        expect(result).toBe('41\n42\n')
+        expect(requests.some((request) => request.method === 'GET')).toBe(true)
+        expect(requests.map((request) => request.region)).toEqual(requests.map(() => region))
+        expect(requests.map((request) => request.url)).toEqual(requests.map(() => '/session-config/rows.csv'))
+        session.close()
+        await drainPending()
+        expect(existsSync(configFile)).toBe(true)
+        expect(readFileSync(configFile, 'utf8')).toBe(config)
+      }
+    } finally {
+      session?.close()
+      await drainPending()
+      server.closeAllConnections()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      rmSync(root, { recursive: true, force: true })
+    }
+  }, 60_000)
+})


### PR DESCRIPTION
Add `Session(path, { configFile })` and forward `--config-file` to `chdb_connect`. This allows endpoint-specific S3 signing regions and other startup settings without changing the process environment or working directory.

Validate configured files before opening a connection. Reject different configurations on the same active data directory, preserve same-configuration concurrent connections, and clear configuration identity after the last close. Older native binaries reject the option instead of silently ignoring it.

Validation on macOS arm64 with Node 24 and Python 3.11:
- `npm run build` passed.
- `npm run test:all`: 24 legacy tests and 481 v3 tests passed; 11 existing optional cases skipped.
- Region-enforcing loopback S3 tests passed for `eu-west-1` and `ap-southeast-2`, including reopening. Configuration-conflict and invalid-file regressions passed.
- `npm run typecheck` reports 13 diagnostics in untouched `connection/contract.test.ts` and `integrations/agents-tool.test.ts`.

Source dependencies were installed without rewriting the lockfile. `npm ci` rejects the current checked-in lockfile's native-package entries.

Release prerequisite: publish the updated JavaScript package and rebuilt `@chdb/lib-*` platform packages. This contribution does not bump release versions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-session ClickHouse startup configuration to `Session`
> - Adds optional `configFile` to `SessionOptions`; the JS `Session` constructor validates the path (string, non-empty, readable regular file, native binding support) before releasing the default connection.
> - Native `CreateConnection` now accepts a configuration path; `open_raw` appends the startup file to ClickHouse startup arguments, and `acquire_session_conn` records configuration identity in the registry alongside the data path.
> - Live same-path sessions must share the same configuration; a conflicting or missing configuration is refused without opening a new connection.
> - After the last session connection closes, `release_session_conn` clears the configuration registry value so a different configuration can be bound on the next session.
> - Risk: sessions sharing a data directory are refused if their `configFile` differs from the active configuration (see `acquire_session_conn` in [lib/chdb_node.cpp](https://github.com/chdb-io/chdb-node/pull/91/files#diff-6188daea75c8c3ecc463f6d0e51b76e4615f980832225d875806768b121adcc5)); unsupported native bindings fail at construction time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1495d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->