### PR TITLE
Bind the durable ABI in the addon, and ship the default Node engine

### DIFF
--- a/.github/workflows/chdb-node-test.yml
+++ b/.github/workflows/chdb-node-test.yml
@@ -105,6 +105,45 @@ jobs:
           AWS_SECRET_ACCESS_KEY: minioadmin
         run: npm run test:durable:s3
 
+  # The durable control plane over the native addon — the default a Node caller
+  # gets, and the half of the seam the Bun end-to-end suite cannot reach. It is
+  # a job of its own for the reasons in vitest.durable-node.config.ts: it needs
+  # a built addon, and the engine binds one data path per process, so it can
+  # neither ride the engine-free job above nor share a worker with the v3 suite.
+  #
+  # Two platforms, one Node version: what this exercises is the C ABI, which
+  # does not vary by Node version, and the addon build is the slow part.
+  durable-node:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+      - name: Install JS deps (no compile-on-install)
+        run: npm install --ignore-scripts
+      - name: Fetch libchdb
+        run: npm run libchdb
+      - name: Build (addon + dist)
+        run: npm run build
+      - name: Exercise the freshly built addon (not the published prebuilt)
+        # The published @chdb/lib-<platform> carries its own addon and the loader
+        # prefers it. Until one is published from a tree that binds the durable
+        # ABI it exports none of it, so the suite would refuse to start against
+        # a build that is otherwise fine.
+        shell: bash
+        run: rm -rf node_modules/@chdb/lib-*
+      - name: Durable over the addon
+        run: npm run test:durable:node
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/chdb-node-test.yml
+++ b/.github/workflows/chdb-node-test.yml
@@ -136,9 +136,9 @@ jobs:
         run: npm run build
       - name: Exercise the freshly built addon (not the published prebuilt)
         # The published @chdb/lib-<platform> carries its own addon and the loader
-        # prefers it. Until one is published from a tree that binds the durable
-        # ABI it exports none of it, so the suite would refuse to start against
-        # a build that is otherwise fine.
+        # prefers it over the build above. The newest on npm is 26.7.0-stable.1,
+        # from before the durable ABI was bound, so leaving it in place would
+        # have the suite refuse to start against a build that is otherwise fine.
         shell: bash
         run: rm -rf node_modules/@chdb/lib-*
       - name: Durable over the addon

--- a/.github/workflows/engine-release-check.yml
+++ b/.github/workflows/engine-release-check.yml
@@ -89,6 +89,14 @@ jobs:
       - name: Test (v2 mocha + v3 vitest)
         run: npm run test:all
 
+      - name: Durable over the addon
+        # The durable ABI is four more C entry points and one size-versioned
+        # struct, so it is exactly what a new engine can break without breaking
+        # anything the suite above touches — chdb_query_analysis_v1 growing a
+        # field, or a class moving between MUTATING and MUTATING_GLOBAL, changes
+        # no declaration the addon compiles against.
+        run: npm run test:durable:node
+
   # Green means the engine can be adopted, not that it has been. Adoption is a
   # one-line change to a pinned version and goes through review like any other
   # dependency bump; this only writes the line. LIBCHDB_NPM_VERSION is left

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,10 @@ Need the database to survive losing the machine?     -> chdb/durable   (experime
 ```
 
 The first four sit on the same engine; `chdb/durable` sits *above* it and loads no native
-code of its own — the caller injects the engine. Default to raw SQL for one-off analytics; use the fluent
-builder when an app or LLM assembles queries from parts (it binds every value server-side).
+code of its own — the engine is injected, and `chdb/durable/node` is the one to inject
+(`engineFactory: nodeEngineFactory()`) unless you own your own `dlopen`. Default to raw SQL
+for one-off analytics; use the fluent builder when an app or LLM assembles queries from
+parts (it binds every value server-side).
 
 ## Minimal examples
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ somewhere later.
 | Arrow **scan** (`registerArrowTable`, Arrow input) | ⏳ follow-up |
 | Arrow zero-copy (M2, `{ zeroCopy: true }`) | ⏳ follow-up |
 | chDB ↔ `@clickhouse/client` integration (`chdb/connection`, **experimental**) | ✅ |
-| Durable V1 control plane (`chdb/durable`, **experimental**) | ✅ pure TS; native adapter pending |
+| Durable V1 control plane (`chdb/durable`, **experimental**) | ✅ pure TS, engine injected |
+| Default durable engine over the addon (`chdb/durable/node`) | ✅ |
 | Remote object storage for durable (`chdb/durable/s3`) | ✅ verified on AWS S3 and MinIO; R2 untested |
 
 ### chDB ↔ `@clickhouse/client` integration (`chdb/connection`, experimental)
@@ -165,9 +166,9 @@ and the sync policy with `@clickhouse/client`.
 > **Status**: implements chDB Durable V1 as specified in
 > `CHDB_DURABLE_V1_CONTRACT.md` in the
 > [chdb](https://github.com/chdb-io/chdb) repository, which is the source of
-> truth for the protocol. The pure-TypeScript control plane is complete; a
-> default engine adapter over the native addon is still to come, so today the
-> caller supplies the engine.
+> truth for the protocol. The control plane is pure TypeScript and the engine
+> is injected; Node callers get a default engine over this package's own addon
+> from `chdb/durable/node`.
 >
 > Requires an engine exporting the durable ABI — currently `26.7.2-rc.2`.
 > Compatibility is a floor rather than an equality: an object records
@@ -178,11 +179,19 @@ and the sync policy with `@clickhouse/client`.
 machine: a full checkpoint plus a statement WAL in object storage, with a
 single `head.json` updated by compare-and-swap under a fenced writer lease.
 
-Importing it loads **no native code** — not the addon, not `libchdb`. The
-engine arrives as an `EngineAdapter` the caller provides, which is what lets a
-Bun process that already owns its own `dlopen(libchdb)` reuse the state machine
-without a second engine in the process. The companion `chdb/libchdb` subpath
-resolves where the library *is* without opening it.
+Importing `chdb/durable` loads **no native code** — not the addon, not
+`libchdb`. The engine arrives as an `EngineAdapter`, which is what lets a Bun
+process that already owns its own `dlopen(libchdb)` reuse the state machine
+without a second engine in it. The companion `chdb/libchdb` subpath resolves
+where the library *is* without opening it.
+
+Node callers do not have to write that adapter: `chdb/durable/node` is one over
+this package's addon, and importing *that* is what loads the engine. Backup,
+restore and statement classification run on the libuv pool, so a checkpoint of
+a large database neither freezes the event loop nor starves the lease
+heartbeat. chdb-core binds one data path per process and each object needs a
+private one, so a process holds one open durable object at a time and no
+ordinary `Session` beside it — fan-out goes across worker processes.
 
 Recovery on another machine needs the object to live somewhere neither machine
 owns, so `chdb/durable/s3` provides an S3-compatible backend — AWS S3,
@@ -192,9 +201,12 @@ who only use the local backend never install it.
 
 ```ts
 import { DurableNamespace } from 'chdb/durable'
-import 'chdb/durable/s3'   // registers the s3:// scheme
+import { nodeEngineFactory } from 'chdb/durable/node'   // the engine, on the addon
+import 'chdb/durable/s3'                                // registers the s3:// scheme
 
-const ns = new DurableNamespace('s3://my-bucket/durable?region=eu-west-1', { engineFactory })
+const ns = new DurableNamespace('s3://my-bucket/durable?region=eu-west-1', {
+  engineFactory: nodeEngineFactory(),
+})
 const obj = await ns.open('orders', { database: 'default' })
 
 const ticket = await obj.execute("INSERT INTO events VALUES (1, 'a')")
@@ -230,7 +242,7 @@ out.
 - [Layered API design](docs/design/architecture.md): the Layer 1 / Layer 2 / Layer 3 architecture, package shape, and intended user-facing surfaces.
 - [Layer 1 native binding reviewer guide](docs/design/layer1-native-binding.md): the PR #43 design and implementation map, organized by commit and review feedback.
 - [chDB ↔ `@clickhouse/client` integration (experimental)](docs/design/pluggable-connection.md): the `chdb/connection` surface, the `Connection` interface chdb-node implements, the `.chdb` extension namespace, and the parity-test sync policy.
-- [Durable V1 control plane (experimental)](docs/design/durable-control-plane.md): the `chdb/durable` and `chdb/libchdb` subpaths, the `EngineAdapter` seam, lease/fencing/reconcile behaviour, and the V1 boundary.
+- [Durable V1 control plane (experimental)](docs/design/durable-control-plane.md): the `chdb/durable`, `chdb/durable/node` and `chdb/libchdb` subpaths, the `EngineAdapter` seam, lease/fencing/reconcile behaviour, and the V1 boundary.
 
 ### Runtimes
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Moving between directories works the same way: after `session.close()`, wait wit
 `drainPending()` before opening one at a different path. Opening another session
 at the *same* path needs no wait — those connections coexist by design.
 
+The refusal is enforced in the addon, on a per-connection in-flight count, so
+it holds for every entry point rather than only the ones that remember to
+check. `chdb/durable`'s engine reaches the addon directly and gets the same
+protection.
+
+
 **Behaviour change.** Earlier versions did not refuse — they closed the busy
 connection, which usually aborted the engine and on macOS could leave a query
 whose promise never settled. Code that opened a session without awaiting its
@@ -185,13 +191,16 @@ process that already owns its own `dlopen(libchdb)` reuse the state machine
 without a second engine in it. The companion `chdb/libchdb` subpath resolves
 where the library *is* without opening it.
 
-Node callers do not have to write that adapter: `chdb/durable/node` is one over
-this package's addon, and importing *that* is what loads the engine. Backup,
-restore and statement classification run on the libuv pool, so a checkpoint of
-a large database neither freezes the event loop nor starves the lease
-heartbeat. chdb-core binds one data path per process and each object needs a
-private one, so a process holds one open durable object at a time and no
-ordinary `Session` beside it — fan-out goes across worker processes.
+Node callers do not have to write that adapter: `chdb/durable/node` re-exports
+the control plane plus one over this package's addon. Importing it loads no
+native code either — the addon arrives when `open()` first builds an engine,
+which is also where the ABI is checked, so a stale addon fails there naming
+what is missing. Backup, restore and statement classification run on the libuv
+pool, so a checkpoint of a large database neither freezes the event loop nor
+starves the lease heartbeat. chdb-core binds one data path per process and each
+object needs a private one, so a process holds one open durable object at a
+time and no ordinary `Session` beside it — fan-out goes across worker
+processes.
 
 Recovery on another machine needs the object to live somewhere neither machine
 owns, so `chdb/durable/s3` provides an S3-compatible backend — AWS S3,
@@ -200,9 +209,8 @@ subpath, and `@aws-sdk/client-s3` is an optional peer dependency, so callers
 who only use the local backend never install it.
 
 ```ts
-import { DurableNamespace } from 'chdb/durable'
-import { nodeEngineFactory } from 'chdb/durable/node'   // the engine, on the addon
-import 'chdb/durable/s3'                                // registers the s3:// scheme
+import { DurableNamespace, nodeEngineFactory } from 'chdb/durable/node'
+import 'chdb/durable/s3'   // registers the s3:// scheme
 
 const ns = new DurableNamespace('s3://my-bucket/durable?region=eu-west-1', {
   engineFactory: nodeEngineFactory(),

--- a/docs/design/durable-control-plane.md
+++ b/docs/design/durable-control-plane.md
@@ -626,10 +626,19 @@ Both halves now exist — the addon binds the durable ABI and
 this package:
 
 1. Publish `@chdb/lib-<platform>` packages built from a tree that binds the
-   durable ABI. `optionalDependencies` already pins `26.7.2-rc.2.1`, but a
-   prebuilt from before this work exports none of the four entry points, and
-   the loader prefers it over a local build — so until those are published,
-   using `chdb/durable/node` from an installed package means `npm run build`
-   plus `rm -rf node_modules/@chdb/lib-*`.
+   durable ABI. `optionalDependencies` and `update_libchdb.sh` already name
+   `26.7.2-rc.2.1`, and the release workflow derives the subpackage version
+   from the latter — but nothing has been tagged since, so that version is not
+   on npm at all. The newest published is `26.7.0-stable.1` (main `chdb@3.3.0`
+   pins it), which carries an addon from before this work and exports none of
+   the four entry points.
+
+   Two different failures follow, depending on what is installed. A fresh
+   install resolves no subpackage — an unsatisfiable *optional* dependency is
+   skipped silently — and dies at `require` with "no native binding", before
+   durable is even reached. An older lockfile brings in `26.7.0-stable.1`,
+   which the loader prefers over a local build, and *that* is the case the
+   adapter refuses by name. Until a tag goes out, using `chdb/durable/node`
+   from a checkout means `npm run build` plus `rm -rf node_modules/@chdb/lib-*`.
 2. Add the shared cross-binding fixtures from the chdb repository once they
    exist, and read a Python-written object with them.

--- a/docs/design/durable-control-plane.md
+++ b/docs/design/durable-control-plane.md
@@ -461,7 +461,9 @@ before it arrives (contract §8):
 - Parquet or data WAL
 - garbage collection and destroy — nothing here deletes an object (see below)
 - multiple writers, multiple databases per object, cross-object transactions
-- cross-engine-version restore — V1 pins `chdb_version()` exactly
+- cross-engine-version migration orchestration — V1 already lets later chdb-core
+  releases restore earlier V1 full backups through the `backup_format` and
+  `min_reader` gates, but it does not define an online upgrade/rollback flow
 - multipart upload: a single `PutObject` caps an object at 5 GiB, and a larger
   checkpoint fails with `limit_exceeded` rather than truncating. Note where that
   failure lands — the size is known only after the archive exists, so the backup

--- a/docs/design/durable-control-plane.md
+++ b/docs/design/durable-control-plane.md
@@ -13,13 +13,12 @@ here.
 
 ## What ships
 
-Two subpaths, neither of which loads native code:
-
-| Subpath | What it is |
-| --- | --- |
-| `chdb/durable` | The control plane: object layout, `head.json`, manifest, lease, CAS, fencing, WAL, checkpoint orchestration, error categories, local backend |
-| `chdb/durable/s3` | S3-compatible backend — AWS S3, Cloudflare R2, MinIO. Registers the `s3` scheme on import |
-| `chdb/libchdb` | A path resolver. Says where `libchdb.so` is; does not open it |
+| Subpath | What it is | Loads native code |
+| --- | --- | --- |
+| `chdb/durable` | The control plane: object layout, `head.json`, manifest, lease, CAS, fencing, WAL, checkpoint orchestration, error categories, local backend | no |
+| `chdb/durable/s3` | S3-compatible backend — AWS S3, Cloudflare R2, MinIO. Registers the `s3` scheme on import | no |
+| `chdb/libchdb` | A path resolver. Says where `libchdb.so` is; does not open it | no |
+| `chdb/durable/node` | The default `EngineAdapter`, over this package's addon | **yes** |
 
 The S3 backend sits behind its own subpath so that `chdb/durable` never pulls
 in the AWS SDK. A caller using only the local backend should not have to
@@ -53,6 +52,58 @@ package reaches `libchdb` through its own Bun FFI bindings, and chdb-core binds
 `test/durable/subpath.test.ts` asserts the no-native-load property in a child
 process with `process.dlopen` replaced by a throw, which is the only version of
 that check that cannot pass by accident.
+
+Injected does not have to mean hand-written. `chdb/durable/node` is the adapter
+over this package's addon, so a Node caller writes an engine factory rather
+than an engine:
+
+```ts
+import { DurableNamespace } from 'chdb/durable'
+import { nodeEngineFactory } from 'chdb/durable/node'
+
+const ns = new DurableNamespace('file:///var/lib/chdb-durable', {
+  engineFactory: nodeEngineFactory(),
+})
+```
+
+It sits behind its own subpath rather than in the barrel for the reason above:
+importing it *does* load the addon, and putting it in `chdb/durable` would make
+that subpath's whole guarantee vacuous.
+
+### On the addon
+
+`lib/chdb_node.cpp` binds the four entry points the seam needs —
+`chdb_version`, `chdb_backup_database_n`, `chdb_restore_database_n`,
+`chdb_classify_query_n` — and three of them run on the libuv pool. Backup and
+restore are unbounded (a checkpoint archives a whole database) and
+classification joins them there because the parser reads the entire statement
+text, inline data included. That is also what keeps the two mutexes below
+worth having: heartbeat lands on the head mutex while a checkpoint holds the
+operation mutex, and neither is stuck behind a blocked event loop.
+
+Two things the adapter owns rather than the ABI:
+
+- **Connect-time settings.** `--backups.allowed_path` is server configuration,
+  not a session setting, and `--async_insert=0`, `--wait_for_async_insert=1`,
+  `--mutations_sync=2`, `--alter_sync=2` all mean "the statement has landed
+  before it returns" — without them a statement could reach the WAL while its
+  local effect is not yet in the database the next checkpoint archives. They
+  are connect arguments because `SET` classifies as CONTROL, so nothing can
+  undo them through the public surface later.
+- **Quoting the two statements with no C entry point.** `CREATE DATABASE` and
+  `USE` are built in the adapter, and their quoting has to agree with the
+  quoting core does for `BACKUP`/`RESTORE`. Both escapes matter: doubling
+  backticks alone leaves a backslash as an escape introducer, so a database
+  named `a\b` would be created as `a<backspace>` — under a name the backup
+  call would then not find. The suite round-trips a name carrying both.
+
+`chdb_version` is bound as its own export, taking no connection, because the
+compatibility gate runs before a lease is taken or a scratch directory made.
+
+Beyond that, one constraint is the adapter's to hold rather than the control
+plane's: a native call runs on a libuv thread holding the connection, so
+`close()` waits for anything in flight instead of releasing under it. There is
+no interrupt for a running query, so waiting is the only correct answer.
 
 The five methods that matter map onto the C ABI directly. Two of them are the
 reason the seam exists at all:
@@ -335,6 +386,7 @@ symlink.
 
 ```sh
 npm run test:durable          # protocol + state machine + fault matrix (no engine)
+npm run test:durable:node     # the control plane over this package's addon
 npm run test:durable:s3       # S3-compatible provider conformance (needs a bucket)
 npm run test:durable:e2e      # end-to-end against a real libchdb, under Bun
 npm run test:durable:stack    # the whole stack: Bun + libchdb + real object storage
@@ -384,10 +436,29 @@ Running against a shadowing build fails with a message naming the missing ABI
 rather than a bare `dlopen` TypeError.
 
 `test/durable/libchdb-ffi.ts` is the adapter it uses. It is deliberately not
-shipped: the published package's default adapter belongs on the native addon,
-and a Bun-only module in the dependency graph would be a trap for Node users.
-Downstreams that want this shape should own their copy — it is a symbol table
-and fifty lines of `dlopen`.
+shipped: a Bun-only module in the dependency graph would be a trap for Node
+users, and the shipped default is `chdb/durable/node`. Downstreams that want
+the FFI shape should own their copy — it is a symbol table and fifty lines of
+`dlopen`.
+
+`npm run test:durable:node` covers the other half of the seam, which the Bun
+suite by construction cannot reach: the addon's own bindings, the connect-time
+settings, and the adapter's identifier quoting. It re-runs the load-bearing
+scenarios rather than every scenario twice — version recording, WAL replay
+after losing the machine, checkpoint and restore, the refusal matrix, an
+odd database name — plus the cases that exist only here, like refusing to
+release the connection under a call still on a libuv thread. It needs a built
+addon and no prebuilt shadowing it:
+
+```sh
+npm run build && rm -rf node_modules/@chdb/lib-*
+npm run test:durable:node
+```
+
+That second command is not optional housekeeping. The loader prefers a
+published `@chdb/lib-<platform>` over a local build, and until one is published
+from a tree that binds the durable ABI, the adapter refuses to start against it
+— with a message naming the missing exports rather than a `TypeError`.
 
 ### Conformance status
 
@@ -395,7 +466,7 @@ Against the V1 conformance list, this binding's position:
 
 | Requirement | Status |
 | --- | --- |
-| Core ABI and query-classification matrix | covered by the end-to-end suite |
+| Core ABI and query-classification matrix | covered by the end-to-end suite, and again through the addon |
 | All three `backup_format` / `min_reader` gate outcomes | covered |
 | Format fixtures: empty, checkpoint-only, checkpoint-plus-WAL, quoted database | covered |
 | Missing/corrupt base and WAL, future protocol, unknown feature, incompatible engine | covered |
@@ -550,13 +621,15 @@ Fan-out has to be sequential, or spread across worker processes.
 
 ## Still to do on the chdb-node side
 
-The pure-JS layer is complete; the native side is not:
+Both halves now exist — the addon binds the durable ABI and
+`chdb/durable/node` ships the default adapter over it. What is left is not in
+this package:
 
-1. Bind `chdb_backup_database_n`, `chdb_restore_database_n`,
-   `chdb_classify_query_n` and `chdb_version` in `lib/chdb_node.cpp`.
-2. Ship a default `EngineAdapter` over the addon's async API
-   (`src/durable/adapters/chdb-node.ts`), so `chdb/durable` works out of the box
-   for Node callers who are not bringing their own engine.
-3. Point `optionalDependencies` at `@chdb/lib-*` builds carrying the new ABI.
-4. Add the shared cross-binding fixtures from the chdb repository once they
+1. Publish `@chdb/lib-<platform>` packages built from a tree that binds the
+   durable ABI. `optionalDependencies` already pins `26.7.2-rc.2.1`, but a
+   prebuilt from before this work exports none of the four entry points, and
+   the loader prefers it over a local build — so until those are published,
+   using `chdb/durable/node` from an installed package means `npm run build`
+   plus `rm -rf node_modules/@chdb/lib-*`.
+2. Add the shared cross-binding fixtures from the chdb repository once they
    exist, and read a Python-written object with them.

--- a/docs/design/durable-control-plane.md
+++ b/docs/design/durable-control-plane.md
@@ -13,12 +13,15 @@ here.
 
 ## What ships
 
-| Subpath | What it is | Loads native code |
-| --- | --- | --- |
-| `chdb/durable` | The control plane: object layout, `head.json`, manifest, lease, CAS, fencing, WAL, checkpoint orchestration, error categories, local backend | no |
-| `chdb/durable/s3` | S3-compatible backend — AWS S3, Cloudflare R2, MinIO. Registers the `s3` scheme on import | no |
-| `chdb/libchdb` | A path resolver. Says where `libchdb.so` is; does not open it | no |
-| `chdb/durable/node` | The default `EngineAdapter`, over this package's addon | **yes** |
+No subpath here loads native code at import — including the one that owns the
+engine, which defers the addon to the first `open()`.
+
+| Subpath | What it is |
+| --- | --- |
+| `chdb/durable` | The control plane: object layout, `head.json`, manifest, lease, CAS, fencing, WAL, checkpoint orchestration, error categories, local backend |
+| `chdb/durable/node` | The above, re-exported, plus the default `EngineAdapter` over this package's addon |
+| `chdb/durable/s3` | S3-compatible backend — AWS S3, Cloudflare R2, MinIO. Registers the `s3` scheme on import |
+| `chdb/libchdb` | A path resolver. Says where `libchdb.so` is; does not open it |
 
 The S3 backend sits behind its own subpath so that `chdb/durable` never pulls
 in the AWS SDK. A caller using only the local backend should not have to
@@ -53,22 +56,31 @@ package reaches `libchdb` through its own Bun FFI bindings, and chdb-core binds
 process with `process.dlopen` replaced by a throw, which is the only version of
 that check that cannot pass by accident.
 
-Injected does not have to mean hand-written. `chdb/durable/node` is the adapter
-over this package's addon, so a Node caller writes an engine factory rather
-than an engine:
+Injected does not have to mean hand-written. `chdb/durable/node` re-exports the
+control plane *and* the adapter over this package's addon, so a Node caller
+writes an engine factory rather than an engine, from one import:
 
 ```ts
-import { DurableNamespace } from 'chdb/durable'
-import { nodeEngineFactory } from 'chdb/durable/node'
+import { DurableNamespace, nodeEngineFactory } from 'chdb/durable/node'
 
 const ns = new DurableNamespace('file:///var/lib/chdb-durable', {
   engineFactory: nodeEngineFactory(),
 })
 ```
 
-It sits behind its own subpath rather than in the barrel for the reason above:
-importing it *does* load the addon, and putting it in `chdb/durable` would make
-that subpath's whole guarantee vacuous.
+**Importing that subpath loads no native code either.** The addon arrives when
+an engine is first constructed, inside `open()`; `nodeEngineFactory()` only
+closes over its options. Deferring it that far is what lets the load double as
+the compatibility check — the ABI is verified and the engine version read where
+a caller is actually asking for an engine, so a stale addon fails at `open()`
+naming what is missing instead of at import time.
+
+So the separate subpath is about **layering, not load side effects**.
+`chdb/durable` is the protocol and knows nothing about how an engine is
+reached; `chdb/durable/node` is one answer to that question. A Bun downstream
+owning its own `dlopen` uses the first and never touches the second, which is
+what keeps the engine seam real rather than decorative — and it is why the
+adapter is not folded back into the `chdb/durable` entry point.
 
 ### On the addon
 
@@ -104,6 +116,18 @@ Beyond that, one constraint is the adapter's to hold rather than the control
 plane's: a native call runs on a libuv thread holding the connection, so
 `close()` waits for anything in flight instead of releasing under it. There is
 no interrupt for a running query, so waiting is the only correct answer.
+
+The same hazard from the other direction is the addon's, and building this
+adapter is what exposed it. Opening a data directory closes the shared default
+connection that the stateless `query`/`queryAsync` calls use, and closing one
+mid-operation aborts the engine for the rest of the process. `index.js` had
+guarded that for `new Session()` — but the guard lived *above* the addon, so
+every entry point had to remember it independently, and this adapter, reaching
+`CreateConnection` directly, did not. The count now lives in the addon beside
+the registry whose invariant it protects, incremented by every worker that
+touches a connection off-thread, so the protection applies to callers that
+never heard of it. A guard each caller must re-implement is a guard the next
+caller will miss.
 
 The five methods that matter map onto the C ABI directly. Two of them are the
 reason the seam exists at all:

--- a/lib/chdb_node.cpp
+++ b/lib/chdb_node.cpp
@@ -89,8 +89,23 @@ static std::mutex g_reg_mu;
 // settings, and a durable writer's `SET`-equivalents must not be reachable
 // afterwards (the durable control plane classifies `SET` as CONTROL and
 // refuses it, so a caller cannot undo them through its public surface).
+//
+// Every entry is checked for an embedded NUL first. A JS string may hold one,
+// and `c_str()` hands the engine everything before it — so an argument that
+// looks like "--path\0anything" arrives as a bare "--path", an option that
+// takes the NEXT argv as its value, and the following entry becomes the data
+// directory. Measured: `['--path\0x', '/other']` bound /other while the
+// registry recorded the requested path, which is precisely the mismatch this
+// bookkeeping exists to prevent. CreateConnectionWrapper refuses these with a
+// message; this is the backstop for any future caller that reaches here
+// without going through it.
 static chdb_connection *open_raw(const std::string &path,
                                  const std::vector<std::string> &extraArgs = {}) {
+  if (path.find('\0') != std::string::npos) return nullptr;
+  for (const std::string &a : extraArgs) {
+    if (a.find('\0') != std::string::npos) return nullptr;
+  }
+
   std::vector<std::string> owned;
   owned.reserve(extraArgs.size() + 2);
   owned.emplace_back("clickhouse");
@@ -970,6 +985,15 @@ Napi::Value CreateConnectionWrapper(const Napi::CallbackInfo & info) {
     }
 
     std::string path = info[0].As<Napi::String>().Utf8Value();
+    // An embedded NUL truncates the argument at the C boundary, and a
+    // truncated prefix can be an option that consumes the next argv as its
+    // value — which is how "--path" gets smuggled past the check below. See
+    // open_raw for the measured case.
+    if (path.find('\0') != std::string::npos) {
+        Napi::TypeError::New(env, "Data directory cannot contain a NUL byte")
+            .ThrowAsJavaScriptException();
+        return env.Null();
+    }
     std::vector<std::string> settings;
     if (info.Length() > 1 && !info[1].IsUndefined() && !info[1].IsNull()) {
         if (!info[1].IsArray()) {
@@ -986,6 +1010,16 @@ Napi::Value CreateConnectionWrapper(const Napi::CallbackInfo & info) {
                 return env.Null();
             }
             std::string arg = v.As<Napi::String>().Utf8Value();
+            // Checked before the --path test, not after: an embedded NUL is
+            // exactly how an argument evades that test and still reaches the
+            // engine as "--path".
+            if (arg.find('\0') != std::string::npos) {
+                Napi::TypeError::New(env, "Connection settings cannot contain a NUL byte; it "
+                                          "would truncate the argument and let the next one "
+                                          "become its value")
+                    .ThrowAsJavaScriptException();
+                return env.Null();
+            }
             // The data directory is the registry key, and the registry is what
             // enforces one bound path per process. A setting that moved the
             // path would connect somewhere the registry does not know about,

--- a/lib/chdb_node.cpp
+++ b/lib/chdb_node.cpp
@@ -14,6 +14,9 @@
 
 typedef void * ChdbConnection;
 ChdbConnection CreateConnection(const char * path, char ** error_message);
+ChdbConnection CreateConnectionWithArgs(const char * path,
+                                        const std::vector<std::string> & extraArgs,
+                                        char ** error_message);
 void CloseConnection(ChdbConnection conn);
 char * QueryWithConnection(ChdbConnection conn, const char * query, const char * format, char ** error_message);
 
@@ -80,17 +83,26 @@ struct Registry {
 static Registry g_reg;
 static std::mutex g_reg_mu;
 
-static chdb_connection *open_raw(const std::string &path) {
-  char prog[] = "clickhouse";
-  std::string pathArg;
-  char *args[2] = { prog, nullptr };
-  int argc = 1;
-  if (!path.empty()) {
-    pathArg = "--path=" + path;
-    args[1] = const_cast<char *>(pathArg.c_str());
-    argc = 2;
-  }
-  chdb_connection *conn_ptr = chdb_connect(argc, args);
+// Extra argv entries are the same `--setting=value` forms a `clickhouse local`
+// invocation takes, and they have to be given at connect: `--path` and
+// `--backups.allowed_path` are server configuration rather than session
+// settings, and a durable writer's `SET`-equivalents must not be reachable
+// afterwards (the durable control plane classifies `SET` as CONTROL and
+// refuses it, so a caller cannot undo them through its public surface).
+static chdb_connection *open_raw(const std::string &path,
+                                 const std::vector<std::string> &extraArgs = {}) {
+  std::vector<std::string> owned;
+  owned.reserve(extraArgs.size() + 2);
+  owned.emplace_back("clickhouse");
+  if (!path.empty()) owned.push_back("--path=" + path);
+  for (const std::string &a : extraArgs) owned.push_back(a);
+
+  std::vector<char *> args;
+  args.reserve(owned.size() + 1);
+  for (std::string &a : owned) args.push_back(const_cast<char *>(a.c_str()));
+  args.push_back(nullptr);
+
+  chdb_connection *conn_ptr = chdb_connect(static_cast<int>(owned.size()), args.data());
   return (conn_ptr && *conn_ptr) ? conn_ptr : nullptr;
 }
 
@@ -151,7 +163,9 @@ static chdb_connection *get_default_conn(char **error_message) {
 
 // Session connection: same bound path opens ANOTHER independent connection; a
 // live in-memory default yields; a different data directory is rejected.
-static chdb_connection *acquire_session_conn(const std::string &path, char **error_message) {
+static chdb_connection *acquire_session_conn(const std::string &path,
+                                            const std::vector<std::string> &extraArgs,
+                                            char **error_message) {
   ensure_atexit();
   std::lock_guard<std::mutex> lk(g_reg_mu);
   if (!g_reg.conns.empty()) {
@@ -174,7 +188,7 @@ static chdb_connection *acquire_session_conn(const std::string &path, char **err
     }
     // else boundKey == path: an independent connection to the same server.
   }
-  chdb_connection *c = open_raw(path);
+  chdb_connection *c = open_raw(path, extraArgs);
   if (!c) {
     if (error_message && !*error_message)
       *error_message = strdup((std::string("Failed to create connection for path '") + path + "'").c_str());
@@ -280,10 +294,16 @@ static char *exec_query_params(chdb_connection conn,
 }
 
 ChdbConnection CreateConnection(const char * path, char ** error_message) {
+    return CreateConnectionWithArgs(path, {}, error_message);
+}
+
+ChdbConnection CreateConnectionWithArgs(const char * path,
+                                        const std::vector<std::string> & extraArgs,
+                                        char ** error_message) {
     // Sessions always pass a real path (a temp dir for in-memory sessions), so
     // an empty key here never collides with the default connection's "" key.
     std::string p = (path && path[0]) ? std::string(path) : std::string();
-    return static_cast<ChdbConnection>(acquire_session_conn(p, error_message));
+    return static_cast<ChdbConnection>(acquire_session_conn(p, extraArgs, error_message));
 }
 
 void CloseConnection(ChdbConnection conn) {
@@ -853,6 +873,9 @@ Napi::Value StreamCancelWrapper(const Napi::CallbackInfo &info) {
   return env.Undefined();
 }
 
+// Args: (path, settings[]?) — settings are extra argv entries such as
+// "--backups.allowed_path=/…" or "--async_insert=0". The durable engine
+// adapter is the caller that needs them; every other caller passes none.
 Napi::Value CreateConnectionWrapper(const Napi::CallbackInfo & info) {
     Napi::Env env = info.Env();
 
@@ -862,8 +885,39 @@ Napi::Value CreateConnectionWrapper(const Napi::CallbackInfo & info) {
     }
 
     std::string path = info[0].As<Napi::String>().Utf8Value();
+    std::vector<std::string> settings;
+    if (info.Length() > 1 && !info[1].IsUndefined() && !info[1].IsNull()) {
+        if (!info[1].IsArray()) {
+            Napi::TypeError::New(env, "Connection settings must be an array of strings")
+                .ThrowAsJavaScriptException();
+            return env.Null();
+        }
+        Napi::Array arr = info[1].As<Napi::Array>();
+        for (uint32_t i = 0; i < arr.Length(); i++) {
+            Napi::Value v = arr.Get(i);
+            if (!v.IsString()) {
+                Napi::TypeError::New(env, "Connection settings must be an array of strings")
+                    .ThrowAsJavaScriptException();
+                return env.Null();
+            }
+            std::string arg = v.As<Napi::String>().Utf8Value();
+            // The data directory is the registry key, and the registry is what
+            // enforces one bound path per process. A setting that moved the
+            // path would connect somewhere the registry does not know about,
+            // so the engine and the registry would disagree about what is
+            // bound — refuse it here rather than discover it later.
+            if (arg == "--path" || arg.rfind("--path=", 0) == 0) {
+                Napi::TypeError::New(env, "Connection settings cannot set --path; pass the data "
+                                          "directory as the first argument")
+                    .ThrowAsJavaScriptException();
+                return env.Null();
+            }
+            settings.push_back(std::move(arg));
+        }
+    }
+
     char *error_message = nullptr;
-    ChdbConnection conn = CreateConnection(path.c_str(), &error_message);
+    ChdbConnection conn = CreateConnectionWithArgs(path.c_str(), settings, &error_message);
 
     if (!conn) {
         std::string msg = error_message ? error_message : "Failed to create connection";
@@ -1331,6 +1385,237 @@ Napi::Value ArrowUnregisterWrapper(const Napi::CallbackInfo & info) {
   return env.Undefined();
 }
 
+//===--------------------------------------------------------------------===//
+// Durable V1 engine ABI: chdb_version, chdb_backup_database_n,
+// chdb_restore_database_n, chdb_classify_query_n.
+//
+// These four are everything `chdb/durable`'s EngineAdapter seam needs from the
+// engine (docs/design/durable-control-plane.md), and two contract rules decide
+// their shape rather than taste:
+//
+//   1. The binding never builds management SQL. Backup and restore take an
+//      identifier and a path, and core builds the AST and does the quoting —
+//      so a database name holding a backtick cannot change what runs.
+//   2. The binding never classifies SQL itself. No prefix lists, no regular
+//      expressions: chdb_classify_query_n is ClickHouse's own parser answering
+//      how many executable statements a text holds and whether every
+//      persistent write lands in the database the caller owns. A regex cannot
+//      see through `INSERT ... FORMAT` inline data or resolve an unqualified
+//      table name against the session's current database.
+//
+// All three connection-taking calls run on a libuv thread. Backup and restore
+// are unbounded — a checkpoint archives a whole database — and classification
+// joins them there because the parser runs over the whole statement text,
+// inline data included. None of them touch the connection registry, so the
+// handle has to outlive the call: the JS adapter serializes its operations and
+// refuses to close while one is in flight.
+//
+// Error messages here never echo the SQL. A mutation carrying a credential is
+// refused by the layer above, and a message quoting the statement would put
+// the credential in a log — which is the one thing that refusal exists to
+// prevent.
+//===--------------------------------------------------------------------===//
+
+// BACKUP and RESTORE share everything but which symbol they call and what the
+// failure is called.
+class DurableArchiveWorker : public Napi::AsyncWorker {
+public:
+  enum Op { Backup, Restore };
+
+  DurableArchiveWorker(Napi::Env env, chdb_connection conn, Op op, std::string database,
+                       std::string filePath)
+      : Napi::AsyncWorker(env), deferred_(Napi::Promise::Deferred::New(env)), conn_(conn), op_(op),
+        database_(std::move(database)), filePath_(std::move(filePath)) {}
+
+  Napi::Promise GetPromise() { return deferred_.Promise(); }
+
+  void Execute() override {
+    const char *what = op_ == Backup ? "chdb_backup_database_n" : "chdb_restore_database_n";
+    // V1 checkpoints are always full. The ABI accepts an incremental base, but
+    // an incremental archive records the *path* of that base, and the path does
+    // not exist on the machine that restores it — so no base is ever passed.
+    chdb_result *result =
+        op_ == Backup
+            ? chdb_backup_database_n(conn_, database_.data(), database_.size(), filePath_.data(),
+                                     filePath_.size(), nullptr, 0)
+            : chdb_restore_database_n(conn_, database_.data(), database_.size(), filePath_.data(),
+                                      filePath_.size());
+    if (!result) {
+      SetError(std::string(what) + " returned a null result");
+      return;
+    }
+    const char *error = chdb_result_error(result);
+    if (error) {
+      std::string msg = std::string(what) + " failed: " + error;
+      chdb_destroy_query_result(result);
+      SetError(msg);
+      return;
+    }
+    chdb_destroy_query_result(result);
+  }
+
+  void OnOK() override { deferred_.Resolve(Env().Undefined()); }
+  void OnError(const Napi::Error &e) override { deferred_.Reject(e.Value()); }
+
+private:
+  Napi::Promise::Deferred deferred_;
+  chdb_connection conn_;
+  Op op_;
+  std::string database_, filePath_;
+};
+
+class DurableClassifyWorker : public Napi::AsyncWorker {
+public:
+  DurableClassifyWorker(Napi::Env env, chdb_connection conn, std::string sql, bool hasTarget,
+                        std::string targetDatabase)
+      : Napi::AsyncWorker(env), deferred_(Napi::Promise::Deferred::New(env)), conn_(conn),
+        sql_(std::move(sql)), hasTarget_(hasTarget), target_(std::move(targetDatabase)) {
+    memset(&analysis_, 0, sizeof(analysis_));
+  }
+
+  Napi::Promise GetPromise() { return deferred_.Promise(); }
+
+  void Execute() override {
+    chdb_query_analysis_v1 out;
+    memset(&out, 0, sizeof(out));
+    // Size-versioned struct: a newer engine fills only the fields this build
+    // compiled room for.
+    out.struct_size = sizeof(out);
+    chdb_state state = chdb_classify_query_n(conn_, sql_.data(), sql_.size(),
+                                             hasTarget_ ? target_.data() : nullptr,
+                                             hasTarget_ ? target_.size() : 0, &out);
+    if (state != CHDBSuccess) {
+      // The ABI carries no message for this, and the statement must not become
+      // one. SQL that does not parse is a *successful* UNKNOWN, so a failure
+      // here is about the connection or the struct, never the text.
+      SetError("chdb_classify_query_n reported CHDBError: the connection is closed, or this "
+               "engine wants a larger chdb_query_analysis_v1 than the addon was built against");
+      return;
+    }
+    analysis_ = out;
+  }
+
+  void OnOK() override {
+    Napi::Env env = Env();
+    Napi::HandleScope scope(env);
+    Napi::Object out = Napi::Object::New(env);
+    out.Set("statementCount", Napi::Number::New(env, analysis_.statement_count));
+    out.Set("queryClass", Napi::Number::New(env, analysis_.query_class));
+    // Decoded here rather than in JS so the flag bits are read against the
+    // enum from the header this addon compiled against, in one place.
+    out.Set("hasSecrets",
+            Napi::Boolean::New(env, (analysis_.flags & CHDB_QUERY_HAS_SECRETS) != 0));
+    out.Set("writesOnlyTargetDatabase",
+            Napi::Boolean::New(env,
+                               (analysis_.flags & CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE) != 0));
+    out.Set("changesDatabaseLifecycle",
+            Napi::Boolean::New(env,
+                               (analysis_.flags & CHDB_QUERY_CHANGES_DATABASE_LIFECYCLE) != 0));
+    deferred_.Resolve(out);
+  }
+
+  void OnError(const Napi::Error &e) override { deferred_.Reject(e.Value()); }
+
+private:
+  Napi::Promise::Deferred deferred_;
+  chdb_connection conn_;
+  std::string sql_;
+  bool hasTarget_;
+  std::string target_;
+  chdb_query_analysis_v1 analysis_;
+};
+
+// The connection argument every durable entry point takes, resolved on the main
+// thread (the registry is never touched off-thread).
+static bool durableConn(Napi::Env env, Napi::Value handle, chdb_connection *out) {
+  if (!handle.IsExternal()) {
+    Napi::TypeError::New(env, "Connection handle expected").ThrowAsJavaScriptException();
+    return false;
+  }
+  chdb_connection *inner = static_cast<chdb_connection *>(handle.As<Napi::External<void>>().Data());
+  if (!inner || !*inner) return false;
+  *out = *inner;
+  return true;
+}
+
+// Args: (connection, database, filePath). Full backup, always.
+Napi::Value DurableBackupAsyncWrapper(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 3 || !info[1].IsString() || !info[2].IsString()) {
+    Napi::TypeError::New(env, "Usage: connection, database, filePath").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  chdb_connection conn = nullptr;
+  if (!durableConn(env, info[0], &conn)) {
+    if (env.IsExceptionPending()) return env.Undefined();
+    return rejectedPromise(env, "No active connection available");
+  }
+  auto *worker = new DurableArchiveWorker(env, conn, DurableArchiveWorker::Backup,
+                                          info[1].As<Napi::String>().Utf8Value(),
+                                          info[2].As<Napi::String>().Utf8Value());
+  worker->Queue();
+  return worker->GetPromise();
+}
+
+// Args: (connection, database, filePath).
+Napi::Value DurableRestoreAsyncWrapper(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 3 || !info[1].IsString() || !info[2].IsString()) {
+    Napi::TypeError::New(env, "Usage: connection, database, filePath").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  chdb_connection conn = nullptr;
+  if (!durableConn(env, info[0], &conn)) {
+    if (env.IsExceptionPending()) return env.Undefined();
+    return rejectedPromise(env, "No active connection available");
+  }
+  auto *worker = new DurableArchiveWorker(env, conn, DurableArchiveWorker::Restore,
+                                          info[1].As<Napi::String>().Utf8Value(),
+                                          info[2].As<Napi::String>().Utf8Value());
+  worker->Queue();
+  return worker->GetPromise();
+}
+
+// Args: (connection, sql, targetDatabase|null). A null target skips the
+// writes-only-target-database judgement, and then the flag is never set.
+Napi::Value DurableClassifyAsyncWrapper(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2 || !info[1].IsString()) {
+    Napi::TypeError::New(env, "Usage: connection, sql, [targetDatabase]")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  bool hasTarget = info.Length() > 2 && info[2].IsString();
+  if (info.Length() > 2 && !hasTarget && !info[2].IsUndefined() && !info[2].IsNull()) {
+    Napi::TypeError::New(env, "targetDatabase must be a string, null or undefined")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  chdb_connection conn = nullptr;
+  if (!durableConn(env, info[0], &conn)) {
+    if (env.IsExceptionPending()) return env.Undefined();
+    return rejectedPromise(env, "No active connection available");
+  }
+  auto *worker = new DurableClassifyWorker(
+      env, conn, info[1].As<Napi::String>().Utf8Value(), hasTarget,
+      hasTarget ? info[2].As<Napi::String>().Utf8Value() : std::string());
+  worker->Queue();
+  return worker->GetPromise();
+}
+
+// The loaded library's own version, which needs no connection: the durable
+// compatibility gate runs before a lease is taken or a scratch directory made,
+// so it has to be answerable before any connection exists.
+Napi::Value EngineVersionWrapper(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  const char *version = chdb_version();
+  if (!version) {
+    Napi::Error::New(env, "chdb_version() returned NULL").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  return Napi::String::New(env, version);
+}
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   // Export the functions
   exports.Set("Query", Napi::Function::New(env, QueryWrapper));
@@ -1354,6 +1639,12 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("CreateConnection", Napi::Function::New(env, CreateConnectionWrapper));
   exports.Set("CloseConnection", Napi::Function::New(env, CloseConnectionWrapper));
   exports.Set("QueryWithConnection", Napi::Function::New(env, QueryWithConnectionWrapper));
+
+  // Durable V1 engine ABI (see the section above).
+  exports.Set("EngineVersion", Napi::Function::New(env, EngineVersionWrapper));
+  exports.Set("DurableBackupAsync", Napi::Function::New(env, DurableBackupAsyncWrapper));
+  exports.Set("DurableRestoreAsync", Napi::Function::New(env, DurableRestoreAsyncWrapper));
+  exports.Set("DurableClassifyAsync", Napi::Function::New(env, DurableClassifyAsyncWrapper));
 
   // Arrow C Data Interface bindings.
   exports.Set("ArrowRegisterArray", Napi::Function::New(env, ArrowRegisterArrayWrapper));

--- a/lib/chdb_node.cpp
+++ b/lib/chdb_node.cpp
@@ -106,6 +106,67 @@ static chdb_connection *open_raw(const std::string &path,
   return (conn_ptr && *conn_ptr) ? conn_ptr : nullptr;
 }
 
+//===--------------------------------------------------------------------===//
+// In-flight accounting, so a connection is never closed under a running call.
+//
+// Closing one while a libuv thread is still inside libchdb on it is not
+// survivable: the engine aborts for the rest of the process, and on macOS the
+// worker can stay blocked so its promise never settles — an unexplained hang
+// somewhere later.
+//
+// The JS layer already guarded the one path it owns (index.js refuses
+// `new Session()` while a standalone async op is in flight). But that guard
+// sits ABOVE the addon, so every new entry point has to remember it
+// independently — and `chdb/durable/node`, which reaches CreateConnection
+// directly, did not. A guard that each caller must re-implement is a guard
+// that the next caller will miss.
+//
+// So the count lives here, beside the registry whose invariant it protects,
+// and every entry point gets it whether or not it knows. Each AsyncWorker
+// holds a ConnGuard: its constructor runs on the main thread and the framework
+// deletes the worker on the main thread after OnOK/OnError, so retain and
+// release are both serialized by the event loop and can never straddle
+// Execute().
+//
+// Scope is a worker actively inside libchdb. An *open* stream whose fetch is
+// not running holds no thread, so closing under it fails the stream rather
+// than corrupting the process; index.js's pendingNativeOps covers that case.
+//===--------------------------------------------------------------------===//
+static std::unordered_map<chdb_connection, int> g_inflight;
+
+static void retain_conn(chdb_connection conn) {
+  if (!conn) return;
+  std::lock_guard<std::mutex> lk(g_reg_mu);
+  g_inflight[conn]++;
+}
+
+static void release_conn(chdb_connection conn) {
+  if (!conn) return;
+  std::lock_guard<std::mutex> lk(g_reg_mu);
+  auto it = g_inflight.find(conn);
+  if (it == g_inflight.end()) return;
+  if (--it->second <= 0) g_inflight.erase(it);
+}
+
+// Caller must already hold g_reg_mu: the count is read as part of an eviction
+// decision, and reading it separately would let a worker start in between.
+static int inflight_locked(chdb_connection conn) {
+  auto it = g_inflight.find(conn);
+  return it == g_inflight.end() ? 0 : it->second;
+}
+
+// Held as a member by every worker that touches a connection off-thread.
+class ConnGuard {
+public:
+  explicit ConnGuard(chdb_connection conn) : conn_(conn) { retain_conn(conn_); }
+  ~ConnGuard() { release_conn(conn_); }
+  ConnGuard(const ConnGuard &) = delete;
+  ConnGuard &operator=(const ConnGuard &) = delete;
+
+private:
+  chdb_connection conn_;
+};
+
 // Arrow-table registry cleanup (defined alongside g_live_arrow_tables below).
 // A connection's pinned JS buffers live in that registry keyed by the raw
 // chdb_connection*, so they must be dropped when the connection closes — else
@@ -171,8 +232,25 @@ static chdb_connection *acquire_session_conn(const std::string &path,
   if (!g_reg.conns.empty()) {
     if (g_reg.boundKey.empty()) {
       // Only the in-memory default is up (boundKey ""). It is transient and must
-      // yield so this session can bind a real data directory.
+      // yield so this session can bind a real data directory — but not while a
+      // libuv thread is still inside libchdb on it. This is the check every
+      // entry point used to have to make for itself; making it here is what
+      // makes it apply to all of them.
       if (g_reg.defaultConn) {
+        int busy = inflight_locked(*g_reg.defaultConn);
+        if (busy > 0) {
+          if (error_message && !*error_message)
+            *error_message = strdup(
+                (std::string("chdb: cannot bind '") + path + "' while " + std::to_string(busy) +
+                 (busy == 1 ? " operation is" : " operations are") +
+                 " still running on the default connection. Binding a data directory closes "
+                 "that connection, and closing it mid-operation aborts the engine for the "
+                 "whole process. Await those operations first — or `await drainPending()`, "
+                 "since an aborted or timed-out call rejects straight away while the engine "
+                 "keeps computing, so there may be no promise left to await.")
+                    .c_str());
+          return nullptr;
+        }
         erase_arrow_tables_for_conn(g_reg.defaultConn);
         chdb_close_conn(g_reg.defaultConn);
         g_reg.conns.erase(g_reg.defaultConn);
@@ -213,6 +291,7 @@ static void release_session_conn(chdb_connection *conn) {
   // Last connection out unbinds the EmbeddedServer so a different path may bind.
   if (g_reg.conns.empty()) g_reg.boundKey.clear();
 }
+
 
 static char *exec_query(chdb_connection conn, const char *query,
                         const char *format, char **error_message) {
@@ -460,7 +539,8 @@ public:
       : Napi::AsyncWorker(env),
         deferred_(Napi::Promise::Deferred::New(env)),
         conn_(conn), sql_(std::move(sql)), format_(std::move(format)),
-        hasParams_(hasParams), names_(std::move(names)), values_(std::move(values)) {}
+        hasParams_(hasParams), names_(std::move(names)), values_(std::move(values)),
+        guard_(conn) {}
 
   Napi::Promise GetPromise() { return deferred_.Promise(); }
 
@@ -521,6 +601,7 @@ private:
   std::vector<char> data_;
   double elapsed_ = 0.0;
   uint64_t rowsRead_ = 0, bytesRead_ = 0;
+  ConnGuard guard_;
 };
 
 static Napi::Value rejectedPromise(Napi::Env env, const char *msg) {
@@ -607,7 +688,8 @@ public:
                   Napi::Buffer<char> data, bool countLines)
       : Napi::AsyncWorker(env), deferred_(Napi::Promise::Deferred::New(env)),
         conn_(conn), prefix_(std::move(prefix)),
-        dataPtr_(data.Data()), dataLen_(data.Length()), countLines_(countLines) {
+        dataPtr_(data.Data()), dataLen_(data.Length()), countLines_(countLines),
+        guard_(conn) {
     bufRef_ = Napi::Persistent(data.As<Napi::Object>());
   }
 
@@ -675,6 +757,7 @@ private:
   Napi::ObjectReference bufRef_; // released on the main thread in the worker dtor
   double elapsed_ = 0.0;
   uint64_t rowsWritten_ = 0, bytesWritten_ = 0, linesSent_ = 0;
+  ConnGuard guard_;
 };
 
 // Standalone raw insert (default connection). Args: (prefix, dataBuffer, countLines)
@@ -803,7 +886,8 @@ Napi::Value StreamQueryWrapper(const Napi::CallbackInfo &info) {
 class StreamFetchWorker : public Napi::AsyncWorker {
 public:
   StreamFetchWorker(Napi::Env env, StreamState *st)
-      : Napi::AsyncWorker(env), deferred_(Napi::Promise::Deferred::New(env)), st_(st) {}
+      : Napi::AsyncWorker(env), deferred_(Napi::Promise::Deferred::New(env)), st_(st),
+        guard_(st ? st->conn : nullptr) {}
   Napi::Promise GetPromise() { return deferred_.Promise(); }
 
   void Execute() override {
@@ -852,6 +936,7 @@ private:
   std::vector<char> data_;
   uint64_t numRows_ = 0;
   bool done_ = false;
+  ConnGuard guard_;
 };
 
 // Args: (streamHandle) -> Promise<{ bytes, numRows, done }>
@@ -1425,7 +1510,7 @@ public:
   DurableArchiveWorker(Napi::Env env, chdb_connection conn, Op op, std::string database,
                        std::string filePath)
       : Napi::AsyncWorker(env), deferred_(Napi::Promise::Deferred::New(env)), conn_(conn), op_(op),
-        database_(std::move(database)), filePath_(std::move(filePath)) {}
+        database_(std::move(database)), filePath_(std::move(filePath)), guard_(conn) {}
 
   Napi::Promise GetPromise() { return deferred_.Promise(); }
 
@@ -1462,6 +1547,7 @@ private:
   chdb_connection conn_;
   Op op_;
   std::string database_, filePath_;
+  ConnGuard guard_;
 };
 
 class DurableClassifyWorker : public Napi::AsyncWorker {
@@ -1469,7 +1555,8 @@ public:
   DurableClassifyWorker(Napi::Env env, chdb_connection conn, std::string sql, bool hasTarget,
                         std::string targetDatabase)
       : Napi::AsyncWorker(env), deferred_(Napi::Promise::Deferred::New(env)), conn_(conn),
-        sql_(std::move(sql)), hasTarget_(hasTarget), target_(std::move(targetDatabase)) {
+        sql_(std::move(sql)), hasTarget_(hasTarget), target_(std::move(targetDatabase)),
+        guard_(conn) {
     memset(&analysis_, 0, sizeof(analysis_));
   }
 
@@ -1523,6 +1610,7 @@ private:
   bool hasTarget_;
   std::string target_;
   chdb_query_analysis_v1 analysis_;
+  ConnGuard guard_;
 };
 
 // The connection argument every durable entry point takes, resolved on the main

--- a/lib/chdb_node.cpp
+++ b/lib/chdb_node.cpp
@@ -146,6 +146,17 @@ static chdb_connection *open_raw(const std::string &path,
 // Scope is a worker actively inside libchdb. An *open* stream whose fetch is
 // not running holds no thread, so closing under it fails the stream rather
 // than corrupting the process; index.js's pendingNativeOps covers that case.
+//
+// Scope also stops at eviction. release_session_conn does NOT consult this
+// count, so an explicit CloseConnection on a busy handle is still the
+// caller's problem to avoid — and both callers do: index.js defers teardown
+// while pendingNativeOps is non-empty, and the durable adapter's close()
+// waits out its own in-flight set before releasing. Left that way
+// deliberately: the count would have to defer the close rather than refuse
+// it, since CloseConnection returns void and index.js does not expect it to
+// fail, and neither existing caller can reach the bug. A third caller that
+// closes a busy handle directly would, so this is the line to move if one
+// appears.
 //===--------------------------------------------------------------------===//
 static std::unordered_map<chdb_connection, int> g_inflight;
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "require": "./dist/durable/backends/s3.js",
       "default": "./dist/durable/backends/s3.js"
     },
+    "./durable/node": {
+      "types": "./dist/durable/adapters/chdb-node.d.ts",
+      "require": "./dist/durable/adapters/chdb-node.js",
+      "default": "./dist/durable/adapters/chdb-node.js"
+    },
     "./libchdb": {
       "types": "./dist/libchdb/index.d.ts",
       "require": "./dist/libchdb/index.js",
@@ -69,6 +74,7 @@
     "prepack": "npm run build:ts",
     "install": "node -e \"\"",
     "test:durable": "npm run build:ts && vitest run --config vitest.durable.config.ts",
+    "test:durable:node": "vitest run --config vitest.durable-node.config.ts",
     "test:durable:e2e": "bun test --timeout 120000 test/durable/libchdb-e2e.bun.test.ts",
     "test:durable:s3": "vitest run --config vitest.durable.config.ts test/durable/s3-backend.test.ts",
     "test:durable:stack": "bun test --timeout 300000 test/durable/full-stack.bun.test.ts"

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
       "default": "./dist/durable/backends/s3.js"
     },
     "./durable/node": {
-      "types": "./dist/durable/adapters/chdb-node.d.ts",
-      "require": "./dist/durable/adapters/chdb-node.js",
-      "default": "./dist/durable/adapters/chdb-node.js"
+      "types": "./dist/durable/node.d.ts",
+      "require": "./dist/durable/node.js",
+      "default": "./dist/durable/node.js"
     },
     "./libchdb": {
       "types": "./dist/libchdb/index.d.ts",
@@ -74,7 +74,7 @@
     "prepack": "npm run build:ts",
     "install": "node -e \"\"",
     "test:durable": "npm run build:ts && vitest run --config vitest.durable.config.ts",
-    "test:durable:node": "vitest run --config vitest.durable-node.config.ts",
+    "test:durable:node": "npm run build:ts && vitest run --config vitest.durable-node.config.ts",
     "test:durable:e2e": "bun test --timeout 120000 test/durable/libchdb-e2e.bun.test.ts",
     "test:durable:s3": "vitest run --config vitest.durable.config.ts test/durable/s3-backend.test.ts",
     "test:durable:stack": "bun test --timeout 300000 test/durable/full-stack.bun.test.ts"

--- a/src/durable/adapters/chdb-node.ts
+++ b/src/durable/adapters/chdb-node.ts
@@ -154,6 +154,17 @@ export function assertExtraArgsAllowed(extraArgs: readonly string[]): void {
     if (typeof arg !== 'string') {
       throw new TypeError(`durable: extraArgs must be strings, got ${typeof arg}`)
     }
+    // Before the name check, because an embedded NUL is how an argument gets
+    // past it: the engine sees only the bytes before the NUL, so
+    // `'--path\0x'` reaches it as a bare `--path` and swallows the next entry
+    // as its value. The addon refuses these too — this is the earlier, more
+    // specific error, and it is what keeps the check below honest.
+    if (arg.includes('\0')) {
+      throw new TypeError(
+        `durable: extraArgs cannot contain a NUL byte — it truncates the argument at the C ` +
+          `boundary and lets the next one become its value`,
+      )
+    }
     const name = settingName(arg)
     if (RESERVED_SETTINGS.includes(name)) {
       throw new TypeError(
@@ -245,6 +256,8 @@ export class ChdbNodeEngine implements EngineAdapter {
   private readonly extraArgs: readonly string[]
   private connection: unknown = null
   private closed = false
+  /** The one cleanup every concurrent {@link close} awaits. */
+  private closing?: Promise<void>
   /** Native calls still on a libuv thread, so close can wait them out. */
   private readonly inFlight = new Set<Promise<unknown>>()
 
@@ -368,10 +381,24 @@ export class ChdbNodeEngine implements EngineAdapter {
    * handle, so closing under one would be a use-after-free rather than a
    * cancelled operation. There is no interrupt for a running query, so this
    * waits rather than aborts.
+   *
+   * Concurrent and repeated calls share one cleanup and all resolve only once
+   * the connection is actually gone. Returning early on a `closed` flag would
+   * be a lie to every caller but the first: the first may still be waiting out
+   * a backup, so the handle is still owned by a libuv thread while the others
+   * have been told it is released. Waiting on `inFlight` instead of on the
+   * shared promise would narrow that window without closing it — the count
+   * reaches zero before `CloseConnection` is called.
    */
   async close(): Promise<void> {
-    if (this.closed) return
+    // Set synchronously, so an operation starting between this call and the
+    // first `await` is refused rather than queued behind a closing engine.
     this.closed = true
+    if (!this.closing) this.closing = this.releaseConnection()
+    return this.closing
+  }
+
+  private async releaseConnection(): Promise<void> {
     while (this.inFlight.size > 0) {
       await Promise.allSettled([...this.inFlight])
     }

--- a/src/durable/adapters/chdb-node.ts
+++ b/src/durable/adapters/chdb-node.ts
@@ -2,16 +2,23 @@
  * The default {@link EngineAdapter} for Node: the durable control plane driven
  * by this package's own native addon.
  *
- * `chdb/durable` loads no native code, on purpose — the engine arrives
- * injected, so a Bun `dlopen` or a test fake can drive the same state machine.
- * This module is the injection Node callers should not have to write
- * themselves. It lives behind its own subpath (`chdb/durable/node`) rather
- * than in the barrel, because importing it *does* load the addon and that
- * would make the no-native-load guarantee of `chdb/durable` vacuous.
+ * `chdb/durable` takes an injected engine, on purpose — so a Bun `dlopen` or a
+ * test fake can drive the same state machine. This module is the injection
+ * Node callers should not have to write themselves; import it through the
+ * `chdb/durable/node` barrel, which also re-exports the control plane.
+ *
+ * Importing this module loads no native code. The addon is loaded when an
+ * engine is first *constructed*, inside `namespace.open()` —
+ * {@link nodeEngineFactory} only closes over its options. Deferring it that
+ * far is what lets the load double as the compatibility check: the ABI is
+ * verified and the engine version read at the point a caller is actually
+ * asking for an engine, so a stale addon fails at `open()` naming what is
+ * missing, rather than at import time from a module the caller may not reach.
+ *
+ * The subpath is therefore about **layering, not load side effects**.
  *
  * ```ts
- * import { DurableNamespace } from 'chdb/durable'
- * import { nodeEngineFactory } from 'chdb/durable/node'
+ * import { DurableNamespace, nodeEngineFactory } from 'chdb/durable/node'
  *
  * const ns = new DurableNamespace('s3://bucket/durable?region=us-east-2', {
  *   engineFactory: nodeEngineFactory(),
@@ -97,12 +104,75 @@ const DURABILITY_SETTINGS = [
   '--alter_sync=2',
 ] as const
 
+/**
+ * Argv entries `extraArgs` may not carry, because durable's own guarantees
+ * rest on them.
+ *
+ * ClickHouse takes the *last* value for a repeated argument, so an `extraArgs`
+ * appended after {@link DURABILITY_SETTINGS} could turn `async_insert` back
+ * on — and then `execute()` returns while the rows are still in a buffer, the
+ * statement joins the WAL, and the next checkpoint archives a database that
+ * does not contain them. `BACKUP DATABASE` only captures what has landed, and
+ * a successful checkpoint empties the WAL list, so those rows are gone from
+ * both halves with nothing reported. That is the one failure class this
+ * package exists to rule out, so it is refused rather than documented.
+ *
+ * This list lives here rather than in the addon on purpose. Only durable needs
+ * these pinned; an ordinary `Session` legitimately tunes `mutations_sync` or
+ * loads a config file, and the addon serves both. `path` is the exception —
+ * the addon refuses it for every caller, since it is the connection registry's
+ * key — and it is repeated here so the refusal names durable's own option.
+ */
+export const RESERVED_SETTINGS: readonly string[] = [
+  'path',
+  'backups.allowed_path',
+  'async_insert',
+  'wait_for_async_insert',
+  'mutations_sync',
+  'alter_sync',
+]
+
+/**
+ * The setting name inside an argv entry: leading dashes stripped, cut at the
+ * `=` or the space. Covers `--async_insert=1`, `--async_insert 1` and a bare
+ * `--async_insert`, which ClickHouse reads as three spellings of one argument.
+ */
+function settingName(arg: string): string {
+  const stripped = arg.replace(/^-+/, '')
+  const cut = stripped.search(/[=\s]/)
+  return (cut === -1 ? stripped : stripped.slice(0, cut)).trim()
+}
+
+/**
+ * Refuse reserved settings before anything is connected. A `TypeError`
+ * rather than a durable category, matching how `DurableNamespace` reports a
+ * malformed option: this is a mistake in the calling code, not a state the
+ * object can be in.
+ */
+export function assertExtraArgsAllowed(extraArgs: readonly string[]): void {
+  for (const arg of extraArgs) {
+    if (typeof arg !== 'string') {
+      throw new TypeError(`durable: extraArgs must be strings, got ${typeof arg}`)
+    }
+    const name = settingName(arg)
+    if (RESERVED_SETTINGS.includes(name)) {
+      throw new TypeError(
+        `durable: extraArgs cannot set ${JSON.stringify(name)} — durable pins it, and ` +
+          `ClickHouse takes the last value for a repeated argument, so this would silently ` +
+          `override it. Reserved: ${RESERVED_SETTINGS.join(', ')}`,
+      )
+    }
+  }
+}
+
 export interface ChdbNodeEngineOptions {
   /**
-   * Extra `--setting=value` argv entries appended to the connection. `--path`
-   * is refused by the addon: the data directory is the connection registry's
-   * key, and a setting that moved it would leave the registry describing a
-   * path the engine is not on.
+   * Extra `--setting=value` argv entries for the connection, e.g.
+   * `['--max_threads=8', '--max_memory_usage=8000000000']`.
+   *
+   * Durable's own arguments are appended after these and win, and the settings
+   * durable depends on are refused outright — see {@link RESERVED_SETTINGS}.
+   * Everything else ClickHouse accepts on a command line is fair game.
    */
   extraArgs?: readonly string[]
   /** Use this addon instead of loading one. For tests. */
@@ -179,6 +249,7 @@ export class ChdbNodeEngine implements EngineAdapter {
   private readonly inFlight = new Set<Promise<unknown>>()
 
   constructor(options: ChdbNodeEngineOptions = {}) {
+    assertExtraArgsAllowed(options.extraArgs ?? [])
     this.native = options.native ?? loadDurableNative()
     this.extraArgs = options.extraArgs ?? []
   }
@@ -195,10 +266,13 @@ export class ChdbNodeEngine implements EngineAdapter {
   async start(options: EngineStartOptions): Promise<void> {
     if (this.connection) throw new DurableEngineError('durable: engine is already started')
     if (this.closed) throw new DurableEngineError('durable: engine is closed')
+    // Durable's own arguments go LAST, so that even a reserved setting that
+    // slipped past `assertExtraArgsAllowed` loses — ClickHouse takes the last
+    // value for a repeated argument. The check is the door; this is the lock.
     const settings = [
+      ...this.extraArgs,
       `--backups.allowed_path=${options.backupsAllowedPath}`,
       ...DURABILITY_SETTINGS,
-      ...this.extraArgs,
     ]
     try {
       this.connection = this.native.CreateConnection(options.dataPath, settings)
@@ -316,5 +390,9 @@ export class ChdbNodeEngine implements EngineAdapter {
  * addon is reported at the open that needed it.
  */
 export function nodeEngineFactory(options: ChdbNodeEngineOptions = {}): EngineFactory {
+  // Checked here as well as in the constructor, so a bad `extraArgs` is
+  // reported where it was written rather than at the first `open()`. It is a
+  // string check, so it costs nothing and loads nothing.
+  assertExtraArgsAllowed(options.extraArgs ?? [])
   return () => new ChdbNodeEngine(options)
 }

--- a/src/durable/adapters/chdb-node.ts
+++ b/src/durable/adapters/chdb-node.ts
@@ -263,7 +263,11 @@ export class ChdbNodeEngine implements EngineAdapter {
 
   constructor(options: ChdbNodeEngineOptions = {}) {
     assertExtraArgsAllowed(options.extraArgs ?? [])
-    this.native = options.native ?? loadDurableNative()
+    // An injected addon is checked like a loaded one. Skipping it would make
+    // the injection path the only one that reports a missing export as
+    // `TypeError: EngineVersion is not a function`, instead of the
+    // `DurableEngineError` that names what is absent and how to get it.
+    this.native = options.native ? assertDurableAbi(options.native) : loadDurableNative()
     this.extraArgs = options.extraArgs ?? []
   }
 

--- a/src/durable/adapters/chdb-node.ts
+++ b/src/durable/adapters/chdb-node.ts
@@ -1,0 +1,320 @@
+/**
+ * The default {@link EngineAdapter} for Node: the durable control plane driven
+ * by this package's own native addon.
+ *
+ * `chdb/durable` loads no native code, on purpose — the engine arrives
+ * injected, so a Bun `dlopen` or a test fake can drive the same state machine.
+ * This module is the injection Node callers should not have to write
+ * themselves. It lives behind its own subpath (`chdb/durable/node`) rather
+ * than in the barrel, because importing it *does* load the addon and that
+ * would make the no-native-load guarantee of `chdb/durable` vacuous.
+ *
+ * ```ts
+ * import { DurableNamespace } from 'chdb/durable'
+ * import { nodeEngineFactory } from 'chdb/durable/node'
+ *
+ * const ns = new DurableNamespace('s3://bucket/durable?region=us-east-2', {
+ *   engineFactory: nodeEngineFactory(),
+ * })
+ * ```
+ *
+ * The four ABI calls behind it — `chdb_version`, `chdb_backup_database_n`,
+ * `chdb_restore_database_n`, `chdb_classify_query_n` — are bound in
+ * `lib/chdb_node.cpp`, and the three that take a connection run on the libuv
+ * pool, so a checkpoint of a large database does not freeze the event loop and
+ * heartbeat keeps landing while it runs.
+ *
+ * One process, one engine, one object. chdb-core binds a single data path per
+ * process, and each durable object needs a private one, so a process holds one
+ * open durable object at a time and cannot hold an ordinary `Session`
+ * alongside it. Fan-out goes across worker processes.
+ */
+
+import { loadNative } from '../../loader'
+import type {
+  EngineAdapter,
+  EngineFactory,
+  EngineStartOptions,
+  QueryAnalysis,
+} from '../engine-adapter'
+import { QueryClass } from '../engine-adapter'
+import { DurableEngineError } from '../errors'
+
+/**
+ * The addon surface this adapter uses. Declared structurally rather than
+ * imported, because the addon is a `.node` file with no type information and
+ * this list is exactly the contract between the two halves.
+ */
+export interface ChdbDurableNative {
+  EngineVersion(): string
+  CreateConnection(path: string, settings?: readonly string[]): unknown
+  CloseConnection(connection: unknown): void
+  QueryAsyncConnection(
+    connection: unknown,
+    sql: string,
+    format: string,
+  ): Promise<{ bytes: Buffer }>
+  DurableBackupAsync(connection: unknown, database: string, filePath: string): Promise<void>
+  DurableRestoreAsync(connection: unknown, database: string, filePath: string): Promise<void>
+  DurableClassifyAsync(
+    connection: unknown,
+    sql: string,
+    targetDatabase: string | null,
+  ): Promise<{
+    statementCount: number
+    queryClass: number
+    hasSecrets: boolean
+    writesOnlyTargetDatabase: boolean
+    changesDatabaseLifecycle: boolean
+  }>
+}
+
+/** Everything the durable seam needs; an addon missing any of it is refused. */
+const REQUIRED_EXPORTS = [
+  'EngineVersion',
+  'CreateConnection',
+  'CloseConnection',
+  'QueryAsyncConnection',
+  'DurableBackupAsync',
+  'DurableRestoreAsync',
+  'DurableClassifyAsync',
+] as const
+
+/**
+ * Settings a durable writer cannot leave to chance, applied at connect.
+ *
+ * Asynchronous inserts and non-synchronous mutations both mean "the statement
+ * returned before its effect landed", which would put a statement in the WAL
+ * whose local effect is not yet in the database the next checkpoint archives.
+ * They have to be connect arguments rather than `SET`s: the control plane
+ * classifies `SET` as CONTROL and refuses it, so nothing can undo them through
+ * the public surface later.
+ */
+const DURABILITY_SETTINGS = [
+  '--async_insert=0',
+  '--wait_for_async_insert=1',
+  '--mutations_sync=2',
+  '--alter_sync=2',
+] as const
+
+export interface ChdbNodeEngineOptions {
+  /**
+   * Extra `--setting=value` argv entries appended to the connection. `--path`
+   * is refused by the addon: the data directory is the connection registry's
+   * key, and a setting that moved it would leave the registry describing a
+   * path the engine is not on.
+   */
+  extraArgs?: readonly string[]
+  /** Use this addon instead of loading one. For tests. */
+  native?: ChdbDurableNative
+}
+
+/**
+ * ClickHouse identifier quoting for the one identifier this adapter has to
+ * emit itself.
+ *
+ * `BACKUP`/`RESTORE` take a name and a path and core does the quoting, but
+ * there is no C entry point for `CREATE DATABASE` or `USE`, so these two
+ * statements are built here. Both escapes matter: a backtick would end the
+ * quoted name, and a backslash introduces an escape sequence — leave it alone
+ * and a database called `a\b` is created as `a<backspace>`, under a name the
+ * backup call would then not find.
+ */
+function quoteDatabase(name: string): string {
+  return '`' + name.replace(/\\/g, '\\\\').replace(/`/g, '\\`') + '`'
+}
+
+/**
+ * Refuse an addon that does not carry the durable ABI, naming what is missing.
+ *
+ * Separate from loading so it can be checked against an addon this process did
+ * not load, which is also what the suite does.
+ */
+export function assertDurableAbi(addon: unknown): ChdbDurableNative {
+  const native = (addon ?? {}) as Record<string, unknown>
+  const missing = REQUIRED_EXPORTS.filter((name) => typeof native[name] !== 'function')
+  if (missing.length > 0) {
+    // Far and away the most likely cause is an addon built before the durable
+    // ABI was bound, and the loader prefers a published @chdb/lib-* package
+    // over a local build — so this is the failure a developer working in a
+    // checkout meets first. The message should say what to do about it rather
+    // than what was missing.
+    throw new DurableEngineError(
+      `durable: the loaded chdb addon does not export ${missing.join(', ')}, so it predates the ` +
+        `durable ABI (chdb_version, chdb_backup_database_n, chdb_restore_database_n, ` +
+        `chdb_classify_query_n). Rebuild it with \`npm run build\` in a working copy, or install ` +
+        `a @chdb/lib-* platform package that carries it — note the platform package is resolved ` +
+        `before a local build, so \`rm -rf node_modules/@chdb/lib-*\` is how you override it`,
+    )
+  }
+  return native as unknown as ChdbDurableNative
+}
+
+function loadDurableNative(): ChdbDurableNative {
+  try {
+    return assertDurableAbi(loadNative())
+  } catch (e) {
+    if (e instanceof DurableEngineError) throw e
+    throw new DurableEngineError(
+      `durable: could not load the chdb native addon: ${e instanceof Error ? e.message : String(e)}`,
+      { cause: e },
+    )
+  }
+}
+
+/**
+ * An {@link EngineAdapter} over the chdb-node addon.
+ *
+ * One instance owns one native connection. The control plane serializes its
+ * operations, and this class holds the same line one level down: it will not
+ * release the connection while a native call is still on a libuv thread, since
+ * that thread holds the handle and closing under it would be a use-after-free.
+ */
+export class ChdbNodeEngine implements EngineAdapter {
+  private readonly native: ChdbDurableNative
+  private readonly extraArgs: readonly string[]
+  private connection: unknown = null
+  private closed = false
+  /** Native calls still on a libuv thread, so close can wait them out. */
+  private readonly inFlight = new Set<Promise<unknown>>()
+
+  constructor(options: ChdbNodeEngineOptions = {}) {
+    this.native = options.native ?? loadDurableNative()
+    this.extraArgs = options.extraArgs ?? []
+  }
+
+  /**
+   * `chdb_version()` of the loaded library. Answerable before {@link start},
+   * which the compatibility gate depends on — an incompatible engine is
+   * refused before a lease is taken or a scratch directory made.
+   */
+  async version(): Promise<string> {
+    return this.native.EngineVersion()
+  }
+
+  async start(options: EngineStartOptions): Promise<void> {
+    if (this.connection) throw new DurableEngineError('durable: engine is already started')
+    if (this.closed) throw new DurableEngineError('durable: engine is closed')
+    const settings = [
+      `--backups.allowed_path=${options.backupsAllowedPath}`,
+      ...DURABILITY_SETTINGS,
+      ...this.extraArgs,
+    ]
+    try {
+      this.connection = this.native.CreateConnection(options.dataPath, settings)
+    } catch (e) {
+      // The likeliest failure is not a broken engine but an ordinary
+      // constraint: this process already has a data directory bound, by an
+      // open Session or another durable object.
+      throw new DurableEngineError(
+        `durable: could not start an engine on ${options.dataPath}: ` +
+          `${e instanceof Error ? e.message : String(e)}`,
+        { cause: e },
+      )
+    }
+    if (!this.connection) {
+      throw new DurableEngineError(`durable: could not start an engine on ${options.dataPath}`)
+    }
+  }
+
+  private handle(): unknown {
+    if (this.closed) throw new DurableEngineError('durable: engine is closed')
+    if (!this.connection) throw new DurableEngineError('durable: engine is not started')
+    return this.connection
+  }
+
+  /** Run a native call, keeping it visible to {@link close} until it settles. */
+  private async track<T>(start: () => Promise<T>): Promise<T> {
+    const promise = start()
+    this.inFlight.add(promise)
+    try {
+      return await promise
+    } catch (e) {
+      // Native rejections arrive as plain Errors carrying the engine's own
+      // message. Categorising them as `engine` is what lets a caller tell a
+      // statement that failed from a lease that was lost.
+      throw e instanceof DurableEngineError
+        ? e
+        : new DurableEngineError(`durable: ${e instanceof Error ? e.message : String(e)}`, {
+            cause: e,
+          })
+    } finally {
+      this.inFlight.delete(promise)
+    }
+  }
+
+  async createDatabase(database: string): Promise<void> {
+    await this.run(`CREATE DATABASE IF NOT EXISTS ${quoteDatabase(database)}`)
+  }
+
+  async useDatabase(database: string): Promise<void> {
+    await this.run(`USE ${quoteDatabase(database)}`)
+  }
+
+  async query(sql: string, format: string): Promise<string> {
+    const conn = this.handle()
+    const result = await this.track(() => this.native.QueryAsyncConnection(conn, sql, format))
+    return result.bytes.toString('utf8')
+  }
+
+  async run(sql: string): Promise<void> {
+    const conn = this.handle()
+    await this.track(() => this.native.QueryAsyncConnection(conn, sql, 'CSV'))
+  }
+
+  async analyze(sql: string, targetDatabase: string): Promise<QueryAnalysis> {
+    const conn = this.handle()
+    const out = await this.track(() =>
+      this.native.DurableClassifyAsync(conn, sql, targetDatabase),
+    )
+    return {
+      statementCount: out.statementCount,
+      // A class this build has no name for is not coerced into one: every gate
+      // requires an exact class, so an unrecognised value fails closed.
+      queryClass: out.queryClass as QueryClass,
+      hasSecrets: out.hasSecrets,
+      writesOnlyTargetDatabase: out.writesOnlyTargetDatabase,
+      changesDatabaseLifecycle: out.changesDatabaseLifecycle,
+    }
+  }
+
+  async backupDatabase(database: string, filePath: string): Promise<void> {
+    const conn = this.handle()
+    await this.track(() => this.native.DurableBackupAsync(conn, database, filePath))
+  }
+
+  async restoreDatabase(database: string, filePath: string): Promise<void> {
+    const conn = this.handle()
+    await this.track(() => this.native.DurableRestoreAsync(conn, database, filePath))
+  }
+
+  /**
+   * Release the connection. Safe after a failed {@link start}, safe twice, and
+   * it waits out any native call still running — a libuv thread holds this
+   * handle, so closing under one would be a use-after-free rather than a
+   * cancelled operation. There is no interrupt for a running query, so this
+   * waits rather than aborts.
+   */
+  async close(): Promise<void> {
+    if (this.closed) return
+    this.closed = true
+    while (this.inFlight.size > 0) {
+      await Promise.allSettled([...this.inFlight])
+    }
+    const conn = this.connection
+    this.connection = null
+    if (conn) this.native.CloseConnection(conn)
+  }
+}
+
+/**
+ * An {@link EngineFactory} building {@link ChdbNodeEngine}s — the shape
+ * `DurableNamespace` wants.
+ *
+ * The addon is loaded when the factory is *called*, not when it is built, so
+ * constructing a namespace stays free of native code and a missing or stale
+ * addon is reported at the open that needed it.
+ */
+export function nodeEngineFactory(options: ChdbNodeEngineOptions = {}): EngineFactory {
+  return () => new ChdbNodeEngine(options)
+}

--- a/src/durable/engine-adapter.ts
+++ b/src/durable/engine-adapter.ts
@@ -79,12 +79,15 @@ export interface EngineAdapter {
   start(options: EngineStartOptions): Promise<void>
 
   /**
-   * Exact `chdb_version()`. Recorded in the head and matched on every open.
+   * Exact `chdb_version()` of the loaded engine.
    *
-   * Must be answerable before {@link start}: the open sequence checks engine
-   * compatibility before it takes a lease or creates a scratch directory, so
-   * a mismatch costs nothing. The underlying C symbol takes no connection, so
-   * this is a property of the loaded library rather than of a session.
+   * Recorded in the head as the producer version. It is not an exact-match
+   * gate: compatibility is checked with `backup_format` and `min_reader`, so
+   * later chdb-core releases can restore earlier V1 full backups. The method
+   * must be answerable before {@link start}: an incompatible engine is refused
+   * before the durable object takes a lease or creates a scratch directory.
+   * The underlying C symbol takes no connection, so this is a property of the
+   * loaded library rather than of a session.
    */
   version(): Promise<string>
 

--- a/src/durable/errors.ts
+++ b/src/durable/errors.ts
@@ -84,7 +84,7 @@ export class DurableLeaseFencedError extends DurableError {
   override readonly code = 'CHDB_DURABLE_LEASE_FENCED'
 }
 
-/** The object records an engine version that is not exactly the running one. */
+/** The object requires an engine capability or minimum reader this process does not have. */
 export class DurableEngineIncompatibleError extends DurableError {
   readonly category = 'engine_incompatible'
   override readonly code = 'CHDB_DURABLE_ENGINE_INCOMPATIBLE'

--- a/src/durable/node.ts
+++ b/src/durable/node.ts
@@ -1,0 +1,35 @@
+/**
+ * `chdb/durable/node` — the durable control plane, plus the engine that drives
+ * it on Node.
+ *
+ * One import instead of two:
+ *
+ * ```ts
+ * import { DurableNamespace, nodeEngineFactory } from 'chdb/durable/node'
+ *
+ * const ns = new DurableNamespace('s3://bucket/durable?region=us-east-2', {
+ *   engineFactory: nodeEngineFactory(),
+ * })
+ * ```
+ *
+ * ### This module loads no native code either
+ *
+ * Importing it is as inert as importing `chdb/durable`: the addon is loaded
+ * when an engine is first *constructed*, which happens inside
+ * `namespace.open()`. `nodeEngineFactory()` only closes over its options. So
+ * the load is deferred to the point where it can also be useful — that is
+ * where the ABI is checked and the engine version read, so an addon that
+ * predates the durable ABI fails at `open()` with a message naming what is
+ * missing, rather than at import time from a module the caller may not even
+ * reach.
+ *
+ * The separate subpath is therefore about **layering, not load side effects**.
+ * `chdb/durable` is the protocol and knows nothing about how the engine is
+ * reached; this module is one specific answer to that question, and a Bun
+ * downstream owning its own `dlopen` uses the former without ever touching the
+ * latter. Keeping them apart is what makes the engine seam real rather than
+ * decorative.
+ */
+
+export * from './index'
+export * from './adapters/chdb-node'

--- a/test/durable/node-engine.test.ts
+++ b/test/durable/node-engine.test.ts
@@ -23,9 +23,10 @@
  */
 
 import { afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { mkdtemp, readFile, rm } from 'fs/promises'
+import { execFileSync } from 'child_process'
+import { mkdir, mkdtemp, readFile, rm } from 'fs/promises'
 import { tmpdir } from 'os'
-import { join } from 'path'
+import { join, resolve } from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
 
 import { DurableNamespace } from '../../src/durable/namespace'
@@ -34,6 +35,7 @@ import { isDurableErrorOf } from '../../src/durable/errors'
 import {
   ChdbNodeEngine,
   assertDurableAbi,
+  assertExtraArgsAllowed,
   nodeEngineFactory,
   type ChdbDurableNative,
 } from '../../src/durable/adapters/chdb-node'
@@ -241,6 +243,92 @@ describe('real chdb_classify_query_n gates the public surface', () => {
   })
 })
 
+describe('cross-entry-point connection safety', () => {
+  // Run in a child process: the scenario deliberately leaves a query running
+  // on the shared default connection, and asserting on it from inside this
+  // worker would leave that state behind for whatever runs next.
+  function runNode(source: string): string {
+    return execFileSync(process.execPath, ['-e', source], {
+      encoding: 'utf8',
+      cwd: resolve(__dirname, '..', '..'),
+    }).trim()
+  }
+
+  const scenario = (awaitFirst: boolean): string => `
+    const { queryAsync } = require('./index.js')
+    const { ChdbNodeEngine } = require('./dist/durable/adapters/chdb-node.js')
+    const { mkdtempSync } = require('fs')
+    const { tmpdir } = require('os')
+    const { join } = require('path')
+    ;(async () => {
+      const root = mkdtempSync(join(tmpdir(), 'durable-race-'))
+      const pending = queryAsync('SELECT sum(number) FROM numbers(4000000000)')
+      pending.catch(() => {})
+      ${awaitFirst ? 'await pending' : 'await new Promise(r => setTimeout(r, 200))'}
+      const engine = new ChdbNodeEngine()
+      try {
+        await engine.start({ dataPath: join(root, 'data'), backupsAllowedPath: join(root, 'b') })
+        console.log('STARTED')
+        await engine.close()
+      } catch (e) {
+        console.log('REFUSED: ' + e.message)
+      }
+      ${awaitFirst ? '' : 'await pending.catch(() => {})'}
+      process.exit(0)
+    })().catch(e => { console.error(e); process.exit(1) })
+  `
+
+  it('refuses to bind a data directory under a running standalone query', () => {
+    // index.js guards this for `new Session()`, but that guard sits above the
+    // addon, so every entry point had to remember it — and this one, reaching
+    // CreateConnection directly, did not. Closing the default connection while
+    // a libuv thread is inside libchdb on it aborts the engine for the rest of
+    // the process, or leaves the worker blocked so its promise never settles.
+    const out = runNode(scenario(false))
+    expect(out).toContain('REFUSED')
+    expect(out).toContain('still running on the default connection')
+  })
+
+  it('binds normally once that query has been awaited', () => {
+    // The refusal has to be a wait, not a wall: a released count must let the
+    // next binding through, or the process is stuck for good.
+    expect(runNode(scenario(true))).toBe('STARTED')
+  })
+})
+
+describe('the settings the engine actually ends up with', () => {
+  // A fake native can only prove which strings were passed. What the engine
+  // did with them is a different claim, and it is the one that matters — so it
+  // is read back out of system.settings on a real connection.
+  it('pins the durability settings and still honours a legitimate extraArg', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-node-set-'))
+    roots.push(root)
+    const engine = new ChdbNodeEngine({ extraArgs: ['--max_threads=7'] })
+    try {
+      const data = join(root, 'data')
+      const backups = join(root, 'backups')
+      await mkdir(data, { recursive: true })
+      await mkdir(backups, { recursive: true })
+      await engine.start({ dataPath: data, backupsAllowedPath: backups })
+      const csv = await engine.query(
+        `SELECT name, value FROM system.settings WHERE name IN ` +
+          `('async_insert','wait_for_async_insert','mutations_sync','alter_sync','max_threads') ` +
+          `ORDER BY name`,
+        'CSV',
+      )
+      expect(csv).toBe(
+        '"alter_sync","2"\n' +
+          '"async_insert","0"\n' +
+          '"max_threads","7"\n' +
+          '"mutations_sync","2"\n' +
+          '"wait_for_async_insert","1"\n',
+      )
+    } finally {
+      await engine.close()
+    }
+  })
+})
+
 describe('the adapter around the addon', () => {
   /** A native double: no engine, and every call resolves the way the ABI would. */
   function fakeNative(overrides: Partial<ChdbDurableNative> = {}): ChdbDurableNative & {
@@ -369,11 +457,10 @@ describe('the adapter around the addon', () => {
     await engine.close()
   })
 
-  it('applies the settings a durable writer cannot leave to chance', async () => {
-    // Connect arguments rather than SETs, because the control plane classifies
-    // SET as CONTROL: an async insert or an unsynchronised mutation would
-    // return before its effect landed, putting a statement in the WAL whose
-    // local effect is not yet in the database the next checkpoint archives.
+  it('puts durable\u2019s own arguments last, so nothing can outrank them', async () => {
+    // ClickHouse takes the last value for a repeated argument, so order is the
+    // lock behind the reserved-name check: even a caller that got a reserved
+    // setting past the door loses to the copy appended afterwards.
     let settings: readonly string[] = []
     const native = fakeNative({
       CreateConnection: (_path: string, given?: readonly string[]) => {
@@ -384,14 +471,38 @@ describe('the adapter around the addon', () => {
     const engine = new ChdbNodeEngine({ native, extraArgs: ['--max_threads=2'] })
     await engine.start({ dataPath: '/tmp/x', backupsAllowedPath: '/tmp/x/backups' })
     expect(settings).toEqual([
+      '--max_threads=2',
       '--backups.allowed_path=/tmp/x/backups',
       '--async_insert=0',
       '--wait_for_async_insert=1',
       '--mutations_sync=2',
       '--alter_sync=2',
-      '--max_threads=2',
     ])
     await engine.close()
+  })
+
+  it('refuses every spelling of a reserved setting', () => {
+    // Connect arguments rather than SETs, because the control plane classifies
+    // SET as CONTROL: an async insert or an unsynchronised mutation would
+    // return before its effect landed, putting a statement in the WAL whose
+    // local effect is not yet in the database the next checkpoint archives.
+    // Which is exactly why extraArgs must not be able to hand them back.
+    const reserved = [
+      '--async_insert=1',
+      '--async_insert',
+      '--async_insert 1',
+      '--wait_for_async_insert=0',
+      '--mutations_sync=0',
+      '--alter_sync=0',
+      '--backups.allowed_path=/tmp/elsewhere',
+      '--path=/tmp/elsewhere',
+    ]
+    for (const arg of reserved) {
+      expect(() => assertExtraArgsAllowed([arg]), arg).toThrow(TypeError)
+      // Reported where it was written, not at the first open().
+      expect(() => nodeEngineFactory({ extraArgs: [arg] }), arg).toThrow(/cannot set/)
+    }
+    expect(() => assertExtraArgsAllowed(['--max_threads=8'])).not.toThrow()
   })
 
   it('never passes an incremental base to backup', async () => {

--- a/test/durable/node-engine.test.ts
+++ b/test/durable/node-engine.test.ts
@@ -1,0 +1,414 @@
+/**
+ * The durable control plane over this package's own native addon — the default
+ * a Node caller gets, and the half of the seam the Bun end-to-end suite cannot
+ * reach.
+ *
+ * `libchdb-e2e.bun.test.ts` already proves the control plane against real core
+ * through `bun:ffi`. What is unproven by that is everything *this* path adds:
+ * the four ABI calls bound in `lib/chdb_node.cpp`, the connect-time settings a
+ * durable writer depends on, and the identifier quoting the adapter has to do
+ * itself because the C ABI has no entry point for `CREATE DATABASE`. So this
+ * suite re-runs the load-bearing scenarios over the addon rather than every
+ * scenario twice, and adds the cases that only exist here.
+ *
+ * It needs a built addon and no shadowing prebuilt:
+ *
+ * ```sh
+ * npm run build && rm -rf node_modules/@chdb/lib-*
+ * npm run test:durable:node
+ * ```
+ *
+ * The engine binds one data path per process, so every case opens and closes
+ * its object and nothing here runs in parallel.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { fileURLToPath, pathToFileURL } from 'url'
+
+import { DurableNamespace } from '../../src/durable/namespace'
+import type { DurableObject } from '../../src/durable/object'
+import { isDurableErrorOf } from '../../src/durable/errors'
+import {
+  ChdbNodeEngine,
+  assertDurableAbi,
+  nodeEngineFactory,
+  type ChdbDurableNative,
+} from '../../src/durable/adapters/chdb-node'
+import { loadNative } from '../../src/loader'
+
+const CREATE = 'CREATE TABLE events (id UInt64, note String) ENGINE = MergeTree ORDER BY id'
+
+let engineVersion: string
+const roots: string[] = []
+const openObjects: DurableObject[] = []
+
+beforeAll(async () => {
+  engineVersion = await new ChdbNodeEngine().version()
+})
+
+afterEach(async () => {
+  for (const o of openObjects.splice(0)) await o.close().catch(() => {})
+  for (const r of roots.splice(0)) await rm(r, { recursive: true, force: true })
+})
+
+async function namespace(): Promise<DurableNamespace> {
+  const root = await mkdtemp(join(tmpdir(), 'durable-node-'))
+  roots.push(root)
+  return new DurableNamespace(pathToFileURL(join(root, 'ns')).href, {
+    engineFactory: nodeEngineFactory(),
+    scratchRoot: root,
+    // Long enough that a checkpoint of a test-sized database never races the
+    // lease, short enough that a hung heartbeat still shows up as a failure.
+    tuning: { leaseTtlMs: 60_000, heartbeatIntervalMs: 15_000 },
+  })
+}
+
+async function open(ns: DurableNamespace, id: string, options = {}): Promise<DurableObject> {
+  const o = await ns.open(id, options)
+  openObjects.push(o)
+  return o
+}
+
+/** Close and forget, for a case that then reopens the object. */
+async function release(o: DurableObject): Promise<void> {
+  await o.close()
+  openObjects.splice(openObjects.indexOf(o), 1)
+}
+
+/** First CSV cell of a single-value result. */
+function cell(csv: string): string {
+  return csv.trim().replace(/^"|"$/g, '')
+}
+
+async function caught(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+    return undefined
+  } catch (e) {
+    return e
+  }
+}
+
+describe('durable object over the native addon', () => {
+  it('records the version the addon reports, without a connection to ask on', async () => {
+    // The compatibility gate runs before a lease is taken or a scratch
+    // directory is made, so `chdb_version` has to be answerable with no
+    // connection at all — which is why it is bound as its own export.
+    expect(engineVersion).toMatch(/^\d+\.\d+\.\d+/)
+
+    const ns = await namespace()
+    const o = await open(ns, 'obj', { database: 'default' })
+    await release(o)
+
+    const head = JSON.parse(
+      await readFile(join(fileURLToPath(ns.url), 'obj', 'head.json'), 'utf8'),
+    )
+    expect(head.engine).toEqual({
+      name: 'chdb',
+      version: engineVersion,
+      backup_format: 1,
+      min_reader: engineVersion,
+    })
+  })
+
+  it('survives losing the machine: WAL replay reproduces the rows', async () => {
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database: 'default' })
+    await a.execute(CREATE)
+    await a.execute("INSERT INTO events VALUES (1, 'one'), (2, 'two')")
+    const ticket = await a.execute("INSERT INTO events VALUES (3, 'three')")
+    await a.flushThrough(ticket)
+    await release(a)
+
+    const b = await open(ns, 'obj')
+    expect(await b.query('SELECT id, note FROM events ORDER BY id', { format: 'CSV' })).toBe(
+      '1,"one"\n2,"two"\n3,"three"\n',
+    )
+  })
+
+  it('checkpoints through chdb_backup_database_n and restores from it', async () => {
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database: 'default' })
+    await a.execute(CREATE)
+    await a.execute("INSERT INTO events VALUES (1, 'before')")
+    const base = await a.checkpoint()
+    expect(a.manifest.wal).toEqual([])
+    await a.execute("INSERT INTO events VALUES (2, 'after')")
+    await a.flush()
+    await release(a)
+
+    const b = await open(ns, 'obj')
+    expect(b.manifest.base?.key).toBe(base.key)
+    expect(b.manifest.wal).toHaveLength(1)
+    expect(await b.query('SELECT id, note FROM events ORDER BY id', { format: 'CSV' })).toBe(
+      '1,"before"\n2,"after"\n',
+    )
+  })
+
+  it('quotes a database name that needs both escapes', async () => {
+    // The adapter builds exactly two statements itself — `CREATE DATABASE` and
+    // `USE` — because the C ABI has no entry point for either, while BACKUP and
+    // RESTORE take the name unquoted and core quotes it. So the two quotings
+    // have to agree, and a backslash is where they can silently disagree:
+    // doubling backticks alone leaves `\d` as an escape sequence, which creates
+    // a database under a name the backup call would not find.
+    const database = 'od\\d-db`weird'
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database })
+    await a.execute('CREATE TABLE q (id UInt64) ENGINE = MergeTree ORDER BY id')
+    await a.execute('INSERT INTO q VALUES (7)')
+    expect(cell(await a.query('SELECT currentDatabase()', { format: 'CSV' }))).toBe(database)
+    await a.checkpoint()
+    await release(a)
+
+    const b = await open(ns, 'obj')
+    expect(b.database).toBe(database)
+    expect(cell(await b.query('SELECT id FROM q', { format: 'CSV' }))).toBe('7')
+  })
+
+  it('serves a read-only snapshot without taking the lease', async () => {
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database: 'default' })
+    await a.execute(CREATE)
+    await a.execute("INSERT INTO events VALUES (1, 'x')")
+    await a.flush()
+    await release(a)
+
+    const r = await open(ns, 'obj', { readOnly: true })
+    expect(cell(await r.query('SELECT count() FROM events', { format: 'CSV' }))).toBe('1')
+  })
+
+  it('reports a statement the engine rejected as an engine error, not a refusal', async () => {
+    // The distinction is the caller's next move: a refusal means rewrite the
+    // statement, an engine error means the statement was allowed and failed.
+    const ns = await namespace()
+    const a = await open(ns, 'obj', { database: 'default' })
+    await a.execute(CREATE)
+    await a.flush()
+    const e = await caught(() => a.execute('INSERT INTO events VALUES (1)'))
+    expect(isDurableErrorOf(e, 'engine')).toBe(true)
+    // A failed statement is never buffered, so it is never replayed.
+    expect(a.pendingStatements).toBe(0)
+  })
+})
+
+describe('real chdb_classify_query_n gates the public surface', () => {
+  it('refuses everything the contract says it must, in one object', async () => {
+    // The gate matrix is checked exhaustively against core by the Bun suite;
+    // what is under test here is that the addon's classify binding reports the
+    // same analysis, so one pass over the representative cases is enough.
+    const ns = await namespace()
+    const o = await open(ns, 'obj', { database: 'default' })
+    await o.execute(CREATE)
+    await o.flush()
+
+    const refusals: [string, () => Promise<unknown>][] = [
+      ['a mutation through query()', () => o.query("INSERT INTO events VALUES (1, 'x')")],
+      ['a read through execute()', () => o.execute('SELECT 1')],
+      ['a batch', () => o.execute("INSERT INTO events VALUES (1,'a'); INSERT INTO events VALUES (2,'b')")],
+      ['a write to another database', () => o.execute("INSERT INTO other.events VALUES (1, 'x')")],
+      ['a write leaving the engine', () => o.execute("INSERT INTO FUNCTION file('/tmp/leak.csv') SELECT 1")],
+      ['a database lifecycle change', () => o.execute('CREATE DATABASE sneaky')],
+      ['global state a checkpoint cannot carry', () => o.execute('CREATE FUNCTION addone AS (x) -> x + 1')],
+      ['session control', () => o.execute('USE system')],
+      ['SQL core cannot parse', () => o.execute('this is not sql ((')],
+    ]
+    for (const [what, fn] of refusals) {
+      expect(isDurableErrorOf(await caught(fn), 'classification_refused'), what).toBe(true)
+    }
+
+    // Nothing above reached the WAL, and the current database did not drift.
+    expect(o.pendingStatements).toBe(0)
+    expect(cell(await o.query('SELECT currentDatabase()', { format: 'CSV' }))).toBe('default')
+  })
+
+  it('refuses a mutation carrying a credential without echoing it', async () => {
+    const ns = await namespace()
+    const o = await open(ns, 'obj', { database: 'default' })
+    const e = await caught(() =>
+      o.execute(
+        "CREATE NAMED COLLECTION c AS access_key_id = 'AKIAEXAMPLE', secret_access_key = 'shhh'",
+      ),
+    )
+    expect(
+      isDurableErrorOf(e, 'classification_refused') || isDurableErrorOf(e, 'secret_refused'),
+    ).toBe(true)
+    expect((e as Error).message).not.toContain('AKIAEXAMPLE')
+    expect((e as Error).message).not.toContain('shhh')
+  })
+})
+
+describe('the adapter around the addon', () => {
+  /** A native double: no engine, and every call resolves the way the ABI would. */
+  function fakeNative(overrides: Partial<ChdbDurableNative> = {}): ChdbDurableNative & {
+    closed: number
+  } {
+    const fake = {
+      closed: 0,
+      EngineVersion: () => '26.7.2-rc.2',
+      CreateConnection: () => ({ handle: true }),
+      CloseConnection() {
+        fake.closed++
+      },
+      QueryAsyncConnection: async () => ({ bytes: Buffer.from('') }),
+      DurableBackupAsync: async () => {},
+      DurableRestoreAsync: async () => {},
+      DurableClassifyAsync: async () => ({
+        statementCount: 1,
+        queryClass: 0,
+        hasSecrets: false,
+        writesOnlyTargetDatabase: true,
+        changesDatabaseLifecycle: false,
+      }),
+      ...overrides,
+    }
+    return fake as ChdbDurableNative & { closed: number }
+  }
+
+  it('names every missing export, and what to do about it', () => {
+    // The loader prefers a published @chdb/lib-* prebuilt over a local build,
+    // so an addon predating the durable ABI is the first failure a developer in
+    // a checkout meets. "undefined is not a function" would not help.
+    let message = ''
+    try {
+      assertDurableAbi({ Query: () => '' })
+    } catch (e) {
+      message = (e as Error).message
+    }
+    for (const name of [
+      'EngineVersion',
+      'DurableBackupAsync',
+      'DurableRestoreAsync',
+      'DurableClassifyAsync',
+    ]) {
+      expect(message).toContain(name)
+    }
+    expect(message).toContain('npm run build')
+    expect(message).toContain('@chdb/lib-')
+  })
+
+  it('accepts the addon this process actually loaded', () => {
+    expect(() => assertDurableAbi(loadNative())).not.toThrow()
+  })
+
+  it('refuses a setting that would move the data directory', () => {
+    // The path is the connection registry's key, and the registry is what
+    // enforces one bound directory per process. A setting that moved it would
+    // leave the two describing different places.
+    const native = loadNative() as { CreateConnection: (p: string, s: string[]) => unknown }
+    expect(() => native.CreateConnection('/tmp/should-not-open', ['--path=/tmp/elsewhere'])).toThrow(
+      /--path/,
+    )
+  })
+
+  it('will not release the connection under a call still on a libuv thread', async () => {
+    // The worker holds the handle for the duration, so closing under one is a
+    // use-after-free rather than a cancelled operation.
+    let finish: (() => void) | undefined
+    const native = fakeNative({
+      DurableBackupAsync: () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        }),
+    })
+    const engine = new ChdbNodeEngine({ native })
+    await engine.start({ dataPath: '/tmp/x', backupsAllowedPath: '/tmp/x/backups' })
+
+    const backup = engine.backupDatabase('db', '/tmp/x/backups/a.tar.gz')
+    const closing = engine.close()
+    // Give close every chance to have run past the wait.
+    await new Promise((r) => setTimeout(r, 20))
+    expect(native.closed).toBe(0)
+
+    finish?.()
+    await backup
+    await closing
+    expect(native.closed).toBe(1)
+  })
+
+  it('is safe to close twice, and refuses use afterwards', async () => {
+    const native = fakeNative()
+    const engine = new ChdbNodeEngine({ native })
+    await engine.start({ dataPath: '/tmp/x', backupsAllowedPath: '/tmp/x/backups' })
+    await engine.close()
+    await engine.close()
+    expect(native.closed).toBe(1)
+    expect(isDurableErrorOf(await caught(() => engine.query('SELECT 1', 'CSV')), 'engine')).toBe(
+      true,
+    )
+  })
+
+  it('is safe to close after a failed start', async () => {
+    const native = fakeNative({
+      CreateConnection: () => {
+        throw new Error('only one active data directory per process')
+      },
+    })
+    const engine = new ChdbNodeEngine({ native })
+    const e = await caught(() =>
+      engine.start({ dataPath: '/tmp/x', backupsAllowedPath: '/tmp/x/backups' }),
+    )
+    expect(isDurableErrorOf(e, 'engine')).toBe(true)
+    expect((e as Error).message).toContain('one active data directory')
+    await engine.close()
+    expect(native.closed).toBe(0)
+  })
+
+  it('refuses a second start on the same instance', async () => {
+    const engine = new ChdbNodeEngine({ native: fakeNative() })
+    await engine.start({ dataPath: '/tmp/x', backupsAllowedPath: '/tmp/x/backups' })
+    expect(
+      isDurableErrorOf(
+        await caught(() => engine.start({ dataPath: '/tmp/y', backupsAllowedPath: '/tmp/y/b' })),
+        'engine',
+      ),
+    ).toBe(true)
+    await engine.close()
+  })
+
+  it('applies the settings a durable writer cannot leave to chance', async () => {
+    // Connect arguments rather than SETs, because the control plane classifies
+    // SET as CONTROL: an async insert or an unsynchronised mutation would
+    // return before its effect landed, putting a statement in the WAL whose
+    // local effect is not yet in the database the next checkpoint archives.
+    let settings: readonly string[] = []
+    const native = fakeNative({
+      CreateConnection: (_path: string, given?: readonly string[]) => {
+        settings = given ?? []
+        return { handle: true }
+      },
+    })
+    const engine = new ChdbNodeEngine({ native, extraArgs: ['--max_threads=2'] })
+    await engine.start({ dataPath: '/tmp/x', backupsAllowedPath: '/tmp/x/backups' })
+    expect(settings).toEqual([
+      '--backups.allowed_path=/tmp/x/backups',
+      '--async_insert=0',
+      '--wait_for_async_insert=1',
+      '--mutations_sync=2',
+      '--alter_sync=2',
+      '--max_threads=2',
+    ])
+    await engine.close()
+  })
+
+  it('never passes an incremental base to backup', async () => {
+    // V1 checkpoints are always full: an incremental archive records the
+    // absolute path of its base, and that path does not exist on the machine
+    // doing the restore. The adapter has no parameter for one, and the addon
+    // passes NULL — so the only place this could regress is the arity here.
+    const calls: unknown[][] = []
+    const native = fakeNative({
+      DurableBackupAsync: async (...args: unknown[]) => {
+        calls.push(args)
+      },
+    })
+    const engine = new ChdbNodeEngine({ native })
+    await engine.start({ dataPath: '/tmp/x', backupsAllowedPath: '/tmp/x/backups' })
+    await engine.backupDatabase('db', '/tmp/x/backups/a.tar.gz')
+    expect(calls[0]).toHaveLength(3)
+    await engine.close()
+  })
+})

--- a/test/durable/node-engine.test.ts
+++ b/test/durable/node-engine.test.ts
@@ -417,6 +417,64 @@ describe('the adapter around the addon', () => {
     expect(native.closed).toBe(1)
   })
 
+  it('refuses an argument carrying a NUL byte, at both layers', () => {
+    // Built rather than written literally, so this file holds no control
+    // character. A JS string may carry a NUL and `c_str()` hands the engine
+    // only what precedes it — so '--path<NUL>x' arrives as a bare '--path',
+    // an option that takes the NEXT argv as its value, and the entry after it
+    // becomes the data directory. Measured before the fix: ['--path<NUL>x',
+    // '/other'] bound /other while the registry recorded the requested path.
+    // That is the exact mismatch the registry exists to prevent, and it
+    // walked straight through the '--path' check, which compares strings.
+    const nul = String.fromCharCode(0)
+    for (const arg of [`--path${nul}x`, `--async_insert${nul}x`, `--max_threads${nul}x`]) {
+      expect(() => assertExtraArgsAllowed([arg]), arg).toThrow(/NUL/)
+      expect(() => nodeEngineFactory({ extraArgs: [arg] }), arg).toThrow(/NUL/)
+    }
+    // And the addon refuses them independently, which is what protects the
+    // callers that never pass through the adapter.
+    const native = loadNative() as { CreateConnection: (p: string, s?: string[]) => unknown }
+    expect(() => native.CreateConnection('/tmp/should-not-open', [`--path${nul}x`, '/tmp/other'])).toThrow(
+      /NUL/,
+    )
+    expect(() => native.CreateConnection(`/tmp/should${nul}-not-open`)).toThrow(/NUL/)
+  })
+
+  it('makes every concurrent close wait for the connection to actually go', async () => {
+    // Returning early on a `closed` flag would tell the second caller the
+    // handle is released while the first is still waiting out a backup that
+    // owns it.
+    let finish: (() => void) | undefined
+    const native = fakeNative({
+      DurableBackupAsync: () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        }),
+    })
+    const engine = new ChdbNodeEngine({ native })
+    await engine.start({ dataPath: '/tmp/x', backupsAllowedPath: '/tmp/x/backups' })
+
+    const backup = engine.backupDatabase('db', '/tmp/x/backups/a.tar.gz')
+    const first = engine.close()
+    const second = engine.close()
+
+    let secondSettled = false
+    void second.then(() => {
+      secondSettled = true
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(secondSettled).toBe(false)
+    expect(native.closed).toBe(0)
+
+    finish?.()
+    await backup
+    await Promise.all([first, second])
+    expect(native.closed).toBe(1)
+    // A third, long after the fact, still resolves and still closes once.
+    await engine.close()
+    expect(native.closed).toBe(1)
+  })
+
   it('is safe to close twice, and refuses use afterwards', async () => {
     const native = fakeNative()
     const engine = new ChdbNodeEngine({ native })

--- a/test/durable/node-engine.test.ts
+++ b/test/durable/node-engine.test.ts
@@ -378,6 +378,22 @@ describe('the adapter around the addon', () => {
     expect(message).toContain('@chdb/lib-')
   })
 
+  it('checks an injected addon the same way as a loaded one', () => {
+    // Otherwise the injection path is the only one that reports a missing
+    // export as `TypeError: EngineVersion is not a function`, which says
+    // nothing about what to install.
+    const partial = { CreateConnection: () => ({}), CloseConnection: () => {} }
+    let thrown: unknown
+    try {
+      new ChdbNodeEngine({ native: partial as unknown as ChdbDurableNative })
+    } catch (e) {
+      thrown = e
+    }
+    expect(isDurableErrorOf(thrown, 'engine')).toBe(true)
+    expect((thrown as Error).message).toContain('EngineVersion')
+    expect((thrown as Error).message).toContain('DurableClassifyAsync')
+  })
+
   it('accepts the addon this process actually loaded', () => {
     expect(() => assertDurableAbi(loadNative())).not.toThrow()
   })

--- a/test/durable/subpath.test.ts
+++ b/test/durable/subpath.test.ts
@@ -53,6 +53,37 @@ describe.skipIf(!built)('subpath imports', () => {
     expect(out).toBe('clean')
   })
 
+  it('loads chdb/durable/node without loading any native addon', () => {
+    // The subpath that owns the engine still must not load it at import: the
+    // addon arrives when open() first builds one. Calling the factory is part
+    // of the check, since it is the step a caller performs before any open and
+    // the one most likely to acquire the addon by accident.
+    const out = runNode(`
+      process.dlopen = () => { throw new Error('durable/node subpath loaded native code') }
+      const m = require('./dist/durable/node.js')
+      if (typeof m.DurableNamespace !== 'function') throw new Error('missing DurableNamespace')
+      if (typeof m.nodeEngineFactory !== 'function') throw new Error('missing nodeEngineFactory')
+      m.nodeEngineFactory({ extraArgs: ['--max_threads=2'] })
+      const native = Object.keys(require.cache).filter(p => p.endsWith('.node'))
+      if (native.length) throw new Error('native modules loaded: ' + native.join(','))
+      console.log('clean')
+    `)
+    expect(out).toBe('clean')
+  })
+
+  it('loads chdb/durable/node without native code under ESM too', () => {
+    const out = runNode(`
+      process.dlopen = () => { throw new Error('durable/node subpath loaded native code') }
+      import('./dist/durable/node.js').then(m => {
+        if (typeof m.DurableNamespace !== 'function') throw new Error('no DurableNamespace')
+        if (typeof m.nodeEngineFactory !== 'function') throw new Error('no nodeEngineFactory')
+        m.nodeEngineFactory()
+        console.log('clean')
+      }).catch(e => { console.error(e); process.exit(1) })
+    `)
+    expect(out).toBe('clean')
+  })
+
   it('exposes named exports to ESM importers', () => {
     const out = runNode(`
       import('./dist/durable/index.js').then(m => {

--- a/test/durable/subpath.test.ts
+++ b/test/durable/subpath.test.ts
@@ -1,5 +1,5 @@
 /**
- * Packaging guarantees for the two new subpaths.
+ * Packaging guarantees for the durable subpaths.
  *
  * The assertion that matters is the first one: importing `chdb/durable` must
  * not load native code. It is checked in a child process with `process.dlopen`
@@ -100,11 +100,26 @@ describe.skipIf(!built)('subpath imports', () => {
     expect(out).toContain("chdb/durable/s3")
   })
 
-  it('declares both subpaths in package.json exports', () => {
+  it('declares every durable subpath in package.json exports', () => {
     const pkg = require('../../package.json') as { exports: Record<string, unknown> }
     expect(pkg.exports['./durable']).toBeDefined()
     expect(pkg.exports['./libchdb']).toBeDefined()
     expect(pkg.exports['./durable/s3']).toBeDefined()
+    expect(pkg.exports['./durable/node']).toBeDefined()
+  })
+
+  it('points each of them at a file the build produced', () => {
+    // The addon adapter's subpath name and its file name deliberately differ
+    // (`./durable/node` -> `dist/durable/adapters/chdb-node.js`), so a typo
+    // here would only surface as a caller's failed import.
+    const pkg = require('../../package.json') as {
+      exports: Record<string, { require?: string }>
+    }
+    for (const sub of ['./durable', './durable/s3', './durable/node', './libchdb']) {
+      const target = pkg.exports[sub]?.require
+      expect(target, sub).toBeDefined()
+      expect(existsSync(resolve(__dirname, '..', '..', target as string)), target).toBe(true)
+    }
   })
 })
 

--- a/vitest.durable-node.config.ts
+++ b/vitest.durable-node.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config'
+
+// The durable control plane driven by this package's own native addon, which is
+// the default a Node caller gets. It needs a config of its own because it is the
+// one durable suite that loads native code:
+//
+//  1. `vitest.durable.config.ts` deliberately runs without an engine, and one of
+//     its assertions is that importing `chdb/durable` loads nothing native.
+//  2. The engine binds ONE data path per process and every durable object needs
+//     a private one, so this cannot share a worker with the v3 suite (which owns
+//     the process-wide session registry) and cannot run in parallel with itself.
+//
+// It also needs a built addon: `npm run build`, then `rm -rf node_modules/@chdb/lib-*`
+// so the loader prefers it over a published prebuilt that may predate the durable ABI.
+export default defineConfig({
+  test: {
+    include: ['test/durable/node-engine.test.ts'],
+    environment: 'node',
+    // A checkpoint is a whole-database backup plus an upload; the default five
+    // seconds is a local-fake budget, not an engine one.
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    fileParallelism: false,
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+  },
+})

--- a/vitest.durable.config.ts
+++ b/vitest.durable.config.ts
@@ -10,12 +10,14 @@ import { defineConfig } from 'vitest/config'
 //     chdb/durable loads nothing native" assertion vacuous — the addon would
 //     already be in the process.
 //
-// The Bun end-to-end suite (*.bun.ts) is excluded: it runs under `bun test`
-// because it reaches libchdb through bun:ffi.
+// Two suites are excluded because they would break both properties. The Bun
+// end-to-end suite (*.bun.test.ts) runs under `bun test`, since it reaches
+// libchdb through bun:ffi; the addon suite (node-engine.test.ts) loads the
+// native addon, and has its own config for the same reason.
 export default defineConfig({
   test: {
     include: ['test/durable/**/*.test.ts'],
-    exclude: ['test/durable/**/*.bun.test.ts'],
+    exclude: ['test/durable/**/*.bun.test.ts', 'test/durable/node-engine.test.ts'],
     environment: 'node',
     testTimeout: 20_000,
   },


### PR DESCRIPTION
Follow-on to #90, which shipped the pure-TypeScript Durable V1 control plane
and left the native half open. This is that half: the addon binds the durable
ABI, and Node callers get a default engine instead of having to write one.

`docs/design/durable-control-plane.md` listed four things still to do on the
chdb-node side. The first two are done here; the third turned out to be a
statement about npm rather than about this tree, and the fourth is still
waiting on the chdb repository.

## The addon binds four entry points

| addon export | C symbol |
| --- | --- |
| `EngineVersion()` | `chdb_version` — takes no connection |
| `DurableBackupAsync(conn, db, path)` | `chdb_backup_database_n`, base always `NULL` |
| `DurableRestoreAsync(conn, db, path)` | `chdb_restore_database_n` |
| `DurableClassifyAsync(conn, sql, db\|null)` | `chdb_classify_query_n` |

The three that take a connection run on the libuv pool. A checkpoint archives
a whole database and classification reads the entire statement text, inline
data included, so neither belongs on the event loop — and keeping them off it
is what lets heartbeat land on the head mutex while a checkpoint holds the
operation mutex.

Backup never passes an incremental base even though the ABI accepts one: an
incremental archive records the *path* of its base, and that path does not
exist on the machine that restores it. `chdb_version` is its own export taking
no connection, because the compatibility gate runs before a lease is taken or
a scratch directory made.

`CreateConnection` grows an optional settings array. A durable writer needs
argv entries a session cannot express — `--backups.allowed_path` is server
configuration, not a setting — and the arguments that make a statement land
before it returns have to be unreachable afterwards, since `SET` classifies as
CONTROL. It refuses `--path`: the data directory is the connection registry's
key, and a setting that moved it would leave the registry and the engine
describing different places.

## `chdb/durable/node`

The control plane still takes an injected `EngineAdapter` — that is what lets a
Bun downstream with its own `dlopen` drive the same state machine — but
injected no longer means hand-written:

```ts
import { DurableNamespace, nodeEngineFactory } from 'chdb/durable/node'

const ns = new DurableNamespace('s3://bucket/durable?region=us-east-2', {
  engineFactory: nodeEngineFactory(),
})
```

Importing that subpath loads no native code. The addon arrives when `open()`
first constructs an engine, which is also where the ABI is verified and the
version read, so a stale addon fails there naming what is missing rather than
at import time. The separate subpath is about layering, not load side effects,
and the child-process no-dlopen assertion the other subpaths had now covers
this one too, under CJS and ESM.

Two things the adapter owns rather than the ABI. Connect-time settings, above.
And identifier quoting for `CREATE DATABASE` and `USE`, which have no C entry
point — that quoting has to agree with what core does for BACKUP and RESTORE,
and a backslash is where it can silently disagree: doubling backticks alone
leaves `\d` an escape sequence, so a database named ``od\d-db`weird`` would be
created under a name the backup call could not find. The suite round-trips
that name through create → backup → restore.

## Two hazards closed, one of which predates this PR

**`extraArgs` could override the settings durable rests on.** ClickHouse takes
the last value for a repeated argument, so `extraArgs: ['--async_insert=1']`
won — verified against `system.settings`. That is not a tuning choice:
`execute()` would return while rows sat in a buffer, the statement would join
the WAL, and the next checkpoint would archive a database without them while
emptying the WAL list. Both halves lose the rows and nothing reports it. Six
names are now refused, matched on the setting name so every spelling is
caught, and durable's own arguments go last — the check is the door, the order
is the lock.

**A connection could be closed under a running call.** This one is not
specific to durable and is worth a close look. Binding a data directory closes
the shared default connection used by stateless `query`/`queryAsync`, and
closing one mid-operation aborts the engine for the rest of the process — or
leaves the worker blocked inside libchdb so its promise never settles.
`index.js` guarded that for `new Session()`, but the guard sat *above* the
addon, so every entry point had to remember it independently. This adapter
reaches `CreateConnection` directly and did not. Reproduced: a standalone
`queryAsync` in flight, and `engine.start()` closed the connection under it
while `new Session()` at the same moment was correctly refused.

The count now lives in the addon beside the registry whose invariant it
protects. Every worker touching a connection off-thread holds a `ConnGuard`,
retained and released on the main thread so it cannot straddle `Execute()`,
and eviction of the default connection reads it under the registry lock. A
guard each caller must re-implement is a guard the next caller will miss.

## Not here: `SessionOptions.connectionArgs`

The same review asked for it, and the settings array above is what unblocks
it, but it is an ordinary-`Session` capability with nothing to do with
durable — so it follows separately rather than padding this diff. It has to
follow rather than land alongside, since it depends on the `CreateConnection`
change here.

## Tests

| Suite | Result |
| --- | --- |
| `npm run test:durable:node` (new) | 21 pass |
| `npm run test:durable` | 136 pass |
| `npm run test:v3` | 482 pass, no regressions |
| `npm run test:durable:e2e` (Bun FFI) | 19 pass |

The new suite re-runs the load-bearing scenarios over the addon rather than
every scenario twice — the Bun suite already proves the state machine against
real core through a different seam. It adds what only exists here: the
connect-time settings read back out of `system.settings` on a real connection,
the odd database name, the reserved-setting refusals, the cross-entry-point
race in a child process, and refusing to release a connection under a call
still on a libuv thread.

CI runs it on two platforms, and the engine release check runs it too — four C
entry points and a size-versioned struct are exactly what a new core can break
without breaking any declaration the addon compiles against.

`npm run typecheck` reports 13 pre-existing errors under `test/v3/**`,
unchanged by this PR. `npm test` (mocha) cannot run on Node 26 here at all, as
`yargs` fails to load; unchanged too.

## Two things to know

**No `@chdb/lib-*` on npm carries this yet.** `optionalDependencies` and
`update_libchdb.sh` name `26.7.2-rc.2.1`, and the release workflow derives the
subpackage version from the latter, but nothing has been tagged since — the
newest published is `26.7.0-stable.1`, which `chdb@3.3.0` pins and which
predates this ABI. So reviewing this locally needs:

```sh
npm run build && rm -rf node_modules/@chdb/lib-*
npm run test:durable:node
```

Both new CI jobs do exactly that. A tag will publish both halves in one run:
`subpackages` builds and publishes the four platform packages, then `main`
publishes `chdb` with `dist/durable/**`.

**Core classifies a `SETTINGS` clause inconsistently.** Not introduced here and
not worked around here, but it limits the advice this PR gives. `SET` is
CONTROL and therefore refused, and the correct alternative is a per-statement
`SETTINGS` clause — which stays MUTATING on `INSERT` and READ_ONLY on
`SELECT`, but flips `ALTER`, `OPTIMIZE` and `DELETE` from MUTATING to CONTROL:

```
MUTATING  -> CONTROL   OPTIMIZE TABLE t FINAL [SETTINGS mutations_sync=2]
MUTATING  -> CONTROL   ALTER TABLE t UPDATE b='z' WHERE a=1 [SETTINGS ...]
MUTATING  -> CONTROL   DELETE FROM t WHERE a=1 [SETTINGS ...]
MUTATING  -> MUTATING  TRUNCATE TABLE t [SETTINGS max_threads=2]
```

`chdb.h` lists all of those as MUTATING. The direction is safe — durable fails
closed, refusing a statement it could have accepted — and the binding must not
special-case it, since classifying SQL itself is precisely what the contract
forbids. It needs fixing in chdb-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add default Node durable engine adapter and bind durable ABI in native addon
> - Adds `ChdbNodeEngine` in [chdb-node.ts](https://github.com/chdb-io/chdb-node/pull/92/files#diff-3c6f1e37b27b2eb3b2d5541586a8632dbe6b6460b0848749eac7105f17813785) implementing the durable control-plane `EngineAdapter` over the native addon, with connection ownership, in-flight call tracking, and idempotent concurrent-safe close that waits for outstanding native calls before releasing the connection
> - Binds the durable ABI in [chdb_node.cpp](https://github.com/chdb-io/chdb-node/pull/92/files#diff-6188daea75c8c3ecc463f6d0e51b76e4615f980832225d875806768b121adcc5): `CreateConnectionWithArgs`, `DurableBackupAsync`, `DurableRestoreAsync`, `DurableClassifyAsync`, and `EngineVersion`, plus `ConnGuard` RAII guards on all async workers so the connection stays marked in-flight for the worker lifetime
> - Validates loaded and injected addons against the required durable export list via `assertDurableAbi`, reporting missing exports as `DurableEngineError` with rebuild/install guidance; native loading and validation happen at engine construction time
> - Rejects reserved connection settings (path, backup path, durability sync settings) and embedded NUL bytes in caller-supplied `extraArgs` before native connection creation; binds a data directory only when the default connection has zero in-flight operations, returning an error otherwise instead of closing a busy connection
> - Ships `./durable/node` package export re-exporting the control plane and `nodeEngineFactory()`, with a dedicated Vitest config and CI job on Ubuntu/macOS with Node 22
> - Risk: `acquire_session_conn` in [chdb_node.cpp](https://github.com/chdb-io/chdb-node/pull/92/files#diff-6188daea75c8c3ecc463f6d0e51b76e4615f980832225d875806768b121adcc5) now refuses data-directory binding while the default connection is busy — callers that previously relied on silently closing an in-use default connection will receive an error; `ChdbNodeEngine.start` appends durable-pinned sync settings after caller extras, so callers cannot override `--async_insert`, `--mutations_sync`, or `--alter_sync` through `extraArgs`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9888bd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->