### PR TITLE
Let a Session pass arguments the engine needs at connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,30 @@ it holds for every entry point rather than only the ones that remember to
 check. `chdb/durable`'s engine reaches the addon directly and gets the same
 protection.
 
+### Engine arguments at connect (`connectionArgs`)
+
+Some of what an embedder needs cannot be a `SET`: `--config-file` is not a
+setting, and the arguments deciding how a data directory loads have already
+taken effect before the first query could run.
+
+```js
+const s = new Session("./data", {
+  connectionArgs: [
+    "--async_load_databases=0",         // load databases synchronously
+    "--async_load_system_database=0",   // and the system tables too
+    "--tables_loader_foreground_pool_size=4",
+    "--restore_threads=1",
+    "--output_format_json_quote_64bit_integers=1",
+    "--config-file=/etc/my-chdb.xml",
+  ],
+});
+```
+
+Anything the engine accepts on a `clickhouse local` command line is passed
+through verbatim. Two forms are refused: `--path`, since the data directory is
+the connection registry's key and comes from the first argument, and anything
+containing a NUL byte, which would truncate the argument at the C boundary and
+let the next entry become its value.
 
 **Behaviour change.** Earlier versions did not refuse — they closed the busy
 connection, which usually aborted the engine and on macOS could leave a query

--- a/index.d.ts
+++ b/index.d.ts
@@ -250,6 +250,45 @@ export interface SessionOptions {
    * never call `process.exit`; the app decides how to terminate.
    */
   installSignalHandlers?: boolean;
+  /**
+   * Extra argv entries for the engine, in `clickhouse local` command-line
+   * form:
+   *
+   * ```js
+   * new Session('./db', {
+   *   connectionArgs: [
+   *     '--async_load_databases=0',              // load databases synchronously
+   *     '--async_load_system_database=0',        // and the system tables too
+   *     '--tables_loader_foreground_pool_size=4',
+   *     '--restore_threads=1',
+   *     '--output_format_json_quote_64bit_integers=1',
+   *     '--config-file=/etc/my-chdb.xml',
+   *   ],
+   * })
+   * ```
+   *
+   * These have to be given at connect rather than as `SET` statements. Some
+   * are server configuration and not settings at all (`--config-file`), and
+   * the ones governing how the data directory loads have already taken effect
+   * before a query could run — so there is no later moment at which setting
+   * them would mean anything.
+   *
+   * Two forms are refused, both by the addon, so both throw here:
+   *
+   * - `--path`, in any spelling. The data directory is the connection
+   *   registry's key and comes from the first constructor argument; a setting
+   *   that moved it would leave the registry and the engine describing
+   *   different places.
+   * - anything containing a NUL byte. It truncates the argument at the C
+   *   boundary, and a truncated prefix can be an option that takes the next
+   *   entry as its value — which is how `--path` gets smuggled past the check
+   *   above.
+   *
+   * Everything else the engine accepts on a command line is passed through
+   * verbatim, unvalidated: a name this build does not know, or a malformed
+   * value, is the engine's to reject.
+   */
+  connectionArgs?: readonly string[];
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -641,10 +641,27 @@ class Session {
     // while one is live is still rejected. The registry key is normalized to an
     // absolute path so e.g. "./data" and its absolute form bind the same server;
     // this.path is left as the caller passed it (public surface).
+    // Extra argv entries for the engine, e.g. --async_load_databases=0 or
+    // --config-file=... . They have to be given here rather than as SET
+    // statements later: some are server configuration and not settings at all
+    // (--config-file, --backups.allowed_path), and the ones that decide how
+    // the data directory is loaded have already taken effect by the time a
+    // query could run. The addon refuses --path, since the data directory is
+    // the connection registry's key and comes from the first argument.
+    let connectionArgs;
+    if (opts && opts.connectionArgs != null) {
+      if (!Array.isArray(opts.connectionArgs) ||
+          opts.connectionArgs.some((a) => typeof a !== "string")) {
+        throw new TypeError("Session: connectionArgs must be an array of strings");
+      }
+      connectionArgs = opts.connectionArgs;
+    }
     try {
       const key = this.path ? resolvePath(this.path) : this.path;
       this._key = key; // normalized directory, for the deferred-teardown bookkeeping
-      this.connection = chdbNode.CreateConnection(key);
+      this.connection = connectionArgs
+        ? chdbNode.CreateConnection(key, connectionArgs)
+        : chdbNode.CreateConnection(key);
     } catch (e) {
       if (this.isTemp) { try { this.#removeTempDir(); } catch (_) {} }
       throw asConnectionError(e);

--- a/test/v3/connection-args.test.ts
+++ b/test/v3/connection-args.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `new Session(path, { connectionArgs })`.
+ *
+ * Some of what an embedder needs cannot be a `SET`. `--config-file` is not a
+ * setting at all, and the arguments governing how a data directory loads
+ * (`--async_load_databases`, `--restore_threads`) have already taken effect
+ * before the first query could run. Downstreams moving off their own FFI
+ * bindings depend on these, so the option exists to keep their semantics
+ * unchanged.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const { Session } = require('../../index.js')
+
+const open: any[] = []
+
+function session(args?: readonly string[]): any {
+  const s = new Session(mkdtempSync(join(tmpdir(), 'chdb-args-')), args ? { connectionArgs: args } : {})
+  open.push(s)
+  return s
+}
+
+function cell(csv: string): string {
+  return csv.trim().replace(/^"|"$/g, '')
+}
+
+afterEach(() => {
+  for (const s of open.splice(0)) {
+    try {
+      s.close()
+    } catch {
+      /* a test may have closed it already */
+    }
+  }
+})
+
+describe('Session connectionArgs', () => {
+  it('applies settings that have to be given at connect', () => {
+    const s = session([
+      '--session_timezone=UTC',
+      '--max_query_size=67108864',
+      '--async_load_databases=0',
+    ])
+    expect(cell(s.query("SELECT getSetting('session_timezone')", 'CSV'))).toBe('UTC')
+    expect(cell(s.query("SELECT getSetting('max_query_size')", 'CSV'))).toBe('67108864')
+  })
+
+  it('leaves a session without the option exactly as it was', () => {
+    // The option is additive: absent, the addon is called with one argument,
+    // the way every existing caller calls it.
+    const s = session()
+    expect(cell(s.query('SELECT 1', 'CSV'))).toBe('1')
+    expect(cell(s.query("SELECT getSetting('session_timezone')", 'CSV'))).toBe('')
+  })
+
+  it('refuses to let a setting move the data directory', () => {
+    // The path is the connection registry's key, and the registry is what
+    // enforces one bound directory per process. A setting that moved it would
+    // leave the registry and the engine describing different places.
+    expect(() => session(['--path=/tmp/elsewhere'])).toThrow(/--path/)
+  })
+
+  it('applies the arguments a data directory has to be loaded with', () => {
+    // The reason the option exists. These decide how the directory loads, so
+    // by the time a query could run they have already taken effect — there is
+    // no later moment at which setting them would mean anything.
+    const s = session([
+      '--async_load_databases=0',
+      '--async_load_system_database=0',
+      '--tables_loader_foreground_pool_size=4',
+      '--restore_threads=1',
+    ])
+    expect(
+      s.query(
+        `SELECT name, value FROM system.server_settings WHERE name IN ` +
+          `('async_load_databases','async_load_system_database',` +
+          `'tables_loader_foreground_pool_size','restore_threads') ORDER BY name`,
+        'CSV',
+      ),
+    ).toBe('"async_load_databases","0"\n"async_load_system_database","0"\n"restore_threads","1"\n"tables_loader_foreground_pool_size","4"\n')
+  })
+
+  it('honours a config file, which is not a setting at all', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chdb-conf-'))
+    writeFileSync(
+      join(dir, 'conf.xml'),
+      '<clickhouse><restore_threads>7</restore_threads></clickhouse>',
+    )
+    const s = session([`--config-file=${join(dir, 'conf.xml')}`])
+    expect(cell(s.query("SELECT value FROM system.server_settings WHERE name = 'restore_threads'", 'CSV'))).toBe('7')
+  })
+
+  it('quotes 64-bit integers in JSON when asked at connect', () => {
+    // The value survives the round trip exactly, which is the point: past
+    // 2^53 a JSON number does not.
+    const s = session(['--output_format_json_quote_64bit_integers=1'])
+    expect(s.query('SELECT toInt64(9007199254740993) AS big', 'JSONEachRow').trim()).toBe(
+      '{"big":"9007199254740993"}',
+    )
+  })
+
+  it('refuses an argument carrying a NUL byte', () => {
+    // Built rather than written literally so this file holds no control
+    // character. A NUL truncates the argument at the C boundary, and the
+    // truncated prefix can be an option that takes the next entry as its
+    // value — which is how '--path' evades the check above.
+    const nul = String.fromCharCode(0)
+    expect(() => session([`--path${nul}x`, '/tmp/elsewhere'])).toThrow(/NUL/)
+    expect(() => session([`--max_threads${nul}x`])).toThrow(/NUL/)
+  })
+
+  it('refuses anything that is not an array of strings', () => {
+    expect(() => new Session('', { connectionArgs: 'nope' as any })).toThrow(TypeError)
+    expect(() => new Session('', { connectionArgs: [1] as any })).toThrow(TypeError)
+  })
+})


### PR DESCRIPTION
Follow-on to #92. That change gave the addon an optional settings array and
stopped there, because it was about durable and this is not — it is the half a
caller can actually reach.

```js
new Session('./data', {
  connectionArgs: [
    '--async_load_databases=0',              // load databases synchronously
    '--async_load_system_database=0',        // and the system tables too
    '--tables_loader_foreground_pool_size=4',
    '--restore_threads=1',
    '--output_format_json_quote_64bit_integers=1',
    '--config-file=/etc/my-chdb.xml',
  ],
})
```

## Why these cannot be `SET`s

`--config-file` is not a setting at all. And the arguments deciding how a data
directory loads — `async_load_databases`, `async_load_system_database`,
`tables_loader_foreground_pool_size`, `restore_threads` — have already taken
effect by the time a query could run, so there is no later moment at which
setting them would mean anything. A downstream moving off its own FFI bindings
depends on all four, plus `output_format_json_quote_64bit_integers`, which is
what keeps a value past 2^53 intact through JSON.

Checked against engine `26.7.2-rc.2`: all six take effect through connect
arguments, `changed = 1` on each, and a config file's values are read.

## The tests assert what the engine ended up with

Not the argv that went in. The addon can only prove which strings it passed,
and the claim is about what the engine did with them — so each case reads back
out of `system.server_settings` or `system.settings`:

```
"async_load_databases","0"
"async_load_system_database","0"
"restore_threads","1"
"tables_loader_foreground_pool_size","4"
```

The config-file case writes a real XML and checks the value came from it. The
64-bit case asserts the round trip, `{"big":"9007199254740993"}`, since past
2^53 a JSON number would not survive it.

## Two forms are refused

Both already by the addon, from #92, so both surface here:

- **`--path`**, in any spelling. The data directory is the connection
  registry's key and comes from the first constructor argument; a setting that
  moved it would leave the registry and the engine describing different places,
  and the registry is what enforces one bound directory per process.
- **anything containing a NUL byte.** It truncates the argument at the C
  boundary, and a truncated prefix can be an option that takes the next entry
  as its value — which is how `--path` gets smuggled past the check above. That
  was measured on #92: `['--path\0x', '/other']` bound `/other` while the
  registry recorded the requested path.

Nothing else is validated. An unknown setting name or a malformed value is the
engine's to reject, not this layer's to guess at.

## Tests

| Suite | Result |
| --- | --- |
| `test/v3/connection-args.test.ts` (new) | 8 pass |
| `npm run test:v3` | 486 pass |
| `npm run test:durable` | 136 pass |
| `npm run test:durable:node` | 24 pass |

`npm run typecheck` reports the same 13 pre-existing errors under `test/v3/**`
as on main. `npm test` (mocha) cannot run on Node 26 locally — `yargs` fails to
load — which is unchanged and unrelated.

The option is additive: absent, the addon is called with one argument, exactly
as every existing caller calls it, and a test pins that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `connectionArgs` option to `Session` for engine startup arguments
> - Adds an optional `connectionArgs` string array to `SessionOptions` so engine command-line settings can be supplied at connect time, before the first query.
> - The `Session` constructor validates that the option is an array of strings (throwing `TypeError` otherwise) and forwards it to native connection creation as a second argument; when absent, the existing one-argument call is unchanged.
> - The native addon rejects arguments that change the data directory or contain NUL bytes, surfacing errors through the existing connection-error handling.
> - Adds a test module covering supported settings (timezone, query-size, async loading, config files, JSON integer quoting), rejection of path-changing and NUL-containing arguments, and validation of invalid option types.
> - Risk: non-string or non-array values for `connectionArgs` now throw synchronously during construction in [index.js](https://github.com/chdb-io/chdb-node/pull/93/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346); callers passing malformed values will see a `TypeError` rather than a silent ignore.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 42bc08f. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>index.js — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 654](https://github.com/chdb-io/chdb-node/blob/42bc08f9168b038e210e0934354a815fb3067043/index.js#L654): `connectionArgs.some(...)` skips holes in a sparse array, so `new Session(path, { connectionArgs: ['--flag', , '--other'] })` passes this validation even though the hole is not a string. The native wrapper subsequently reads that index as `undefined` and throws, but the surrounding `try` converts its `TypeError` into `ChdbConnectionError`; this violates the new API's promised synchronous `TypeError` validation for non-string entries and gives callers the wrong error category. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->